### PR TITLE
ICU4J Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <plugin.version.google-java-format>1.7</plugin.version.google-java-format>
         <jjwt.version>0.10.5</jjwt.version>
         <github.api.version>1.313</github.api.version>
+        <icu4j.version>64.2</icu4j.version>
     </properties>
 
     <dependencies>
@@ -71,6 +72,11 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>${icu4j.version}</version>
+        </dependency>
     </dependencies>
 
     <!-- SCM setup to push changes to the Github repo on release -->

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
-            <version>64.2</version>
+            <version>${icu4j.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Defining icu4j inside parent pom.xml. Icu4j was being pulled from okapi.
Bumped acu4j from v62.1 (which comes with okapi v0.36) to v64.2 which is the same version defined in webapp

The reasons for these changes are:

- To be able to use the same icu4j version across the entire project;
- To have more flexibility when updating okapi library, without relying on acu4j being updated;