### PR TITLE
Added config value to enable/disable Quartz scheduler on a server

### DIFF
--- a/docker/docker-compose-api-worker.yml
+++ b/docker/docker-compose-api-worker.yml
@@ -1,0 +1,130 @@
+version: '2.4'
+name: mojito
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      interval: 5s
+      timeout: 30s
+      retries: 20
+    environment:
+      MYSQL_ROOT_PASSWORD: ChangeMe
+      MYSQL_DATABASE: mojito
+      MYSQL_USER: mojito
+      MYSQL_PASSWORD: ChangeMe
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_bin
+      - --max-connections=1000
+  worker:
+    deploy:
+      mode: replicated
+      replicas: 1
+      endpoint_mode: vip
+#      resources:
+#        limits:
+#          cpus: '0.50'
+#          memory: 500M
+#        reservations:
+#          cpus: '0.25'
+#          memory: 20M
+    healthcheck:
+      test: [ "CMD", "curl", "localhost:8080/" ]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    depends_on:
+      db:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+    build:
+      dockerfile: docker/Dockerfile-bk8
+      context: ../
+    links:
+      - db
+    restart: always
+    environment:
+      SPRING_APPLICATION_JSON: '{
+        "spring.flyway.enabled": "true",
+        "l10n.flyway.clean" : "false",
+        "spring.jpa.database-platform" : "org.hibernate.dialect.MySQLDialect",
+        "spring.jpa.hibernate.ddl-auto" : "none",
+        "spring.datasource.url" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
+        "spring.datasource.username" : "mojito",
+        "spring.datasource.password" : "ChangeMe",
+        "spring.datasource.driverClassName" : "com.mysql.cj.jdbc.Driver",
+        "spring.jpa.defer-datasource-initialization" : "false",
+        "l10n.org.quartz.scheduler.enabled" : "true",
+        "l10n.org.quartz.jobStore.useProperties" : "true",
+        "l10n.org.quartz.scheduler.instanceId" : "AUTO",
+        "l10n.org.quartz.jobStore.isClustered" : "true",
+        "l10n.org.quartz.threadPool.threadCount" : "10",
+        "l10n.org.quartz.jobStore.class" : "org.quartz.impl.jdbcjobstore.JobStoreTX",
+        "l10n.org.quartz.jobStore.driverDelegateClass" : "org.quartz.impl.jdbcjobstore.StdJDBCDelegate",
+        "l10n.org.quartz.jobStore.dataSource" : "myDS",
+        "l10n.org.quartz.dataSource.myDS.provider" : "hikaricp",
+        "l10n.org.quartz.dataSource.myDS.driver" : "com.mysql.jdbc.Driver",
+        "l10n.org.quartz.dataSource.myDS.URL" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
+        "l10n.org.quartz.dataSource.myDS.user" : "mojito",
+        "l10n.org.quartz.dataSource.myDS.password" : "ChangeMe",
+        "l10n.org.quartz.dataSource.myDS.maxConnections" : "12",
+        "l10n.org.quartz.dataSource.myDS.validationQuery" : "select 1"
+        }'
+  api:
+    deploy:
+      mode: replicated
+      replicas: 1
+      endpoint_mode: vip
+#      resources:
+#        limits:
+#          cpus: '0.50'
+#          memory: 500M
+#        reservations:
+#          cpus: '0.25'
+#          memory: 20M
+    healthcheck:
+      test: [ "CMD", "curl", "localhost:8080/" ]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    depends_on:
+      db:
+        condition: service_healthy
+    build:
+      dockerfile: docker/Dockerfile-bk8
+      context: ../
+    links:
+      - db
+    ports:
+      - "8080:8080"
+    restart: always
+    environment:
+      SPRING_APPLICATION_JSON: '{
+      "spring.flyway.enabled": "true",
+      "l10n.flyway.clean" : "false",
+      "spring.jpa.database-platform" : "org.hibernate.dialect.MySQLDialect",
+      "spring.jpa.hibernate.ddl-auto" : "none",
+      "spring.datasource.url" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
+      "spring.datasource.username" : "mojito",
+      "spring.datasource.password" : "ChangeMe",
+      "spring.datasource.driverClassName" : "com.mysql.cj.jdbc.Driver",
+      "spring.jpa.defer-datasource-initialization" : "false",
+      "l10n.org.quartz.scheduler.enabled" : "false",
+      "l10n.org.quartz.jobStore.useProperties" : "true",
+      "l10n.org.quartz.scheduler.instanceId" : "AUTO",
+      "l10n.org.quartz.jobStore.isClustered" : "true",
+      "l10n.org.quartz.threadPool.threadCount" : "10",
+      "l10n.org.quartz.jobStore.class" : "org.quartz.impl.jdbcjobstore.JobStoreTX",
+      "l10n.org.quartz.jobStore.driverDelegateClass" : "org.quartz.impl.jdbcjobstore.StdJDBCDelegate",
+      "l10n.org.quartz.jobStore.dataSource" : "myDS",
+      "l10n.org.quartz.dataSource.myDS.provider" : "hikaricp",
+      "l10n.org.quartz.dataSource.myDS.driver" : "com.mysql.jdbc.Driver",
+      "l10n.org.quartz.dataSource.myDS.URL" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
+      "l10n.org.quartz.dataSource.myDS.user" : "mojito",
+      "l10n.org.quartz.dataSource.myDS.password" : "ChangeMe",
+      "l10n.org.quartz.dataSource.myDS.maxConnections" : "12",
+      "l10n.org.quartz.dataSource.myDS.validationQuery" : "select 1"
+      }'

--- a/docker/docker-compose-api-worker.yml
+++ b/docker/docker-compose-api-worker.yml
@@ -18,6 +18,7 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_bin
       - --max-connections=1000
+      - --log_error_verbosity=2
   worker:
     deploy:
       mode: replicated
@@ -76,7 +77,7 @@ services:
   api:
     deploy:
       mode: replicated
-      replicas: 2
+      replicas: 1
       endpoint_mode: vip
       resources:
         limits:
@@ -99,7 +100,7 @@ services:
     links:
       - db
     ports:
-      - "8080-8081:8080"
+      - "8080:8080"
     restart: always
     environment:
       SPRING_APPLICATION_JSON: '{

--- a/docker/docker-compose-api-worker.yml
+++ b/docker/docker-compose-api-worker.yml
@@ -21,15 +21,15 @@ services:
   worker:
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 2
       endpoint_mode: vip
-#      resources:
-#        limits:
-#          cpus: '0.50'
-#          memory: 500M
-#        reservations:
-#          cpus: '0.25'
-#          memory: 20M
+      resources:
+        limits:
+          cpus: '2'
+          memory: 1G
+        reservations:
+          cpus: '1'
+          memory: 200M
     healthcheck:
       test: [ "CMD", "curl", "localhost:8080/" ]
       interval: 5s
@@ -76,15 +76,15 @@ services:
   api:
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 2
       endpoint_mode: vip
-#      resources:
-#        limits:
-#          cpus: '0.50'
-#          memory: 500M
-#        reservations:
-#          cpus: '0.25'
-#          memory: 20M
+      resources:
+        limits:
+          cpus: '2'
+          memory: 1G
+        reservations:
+          cpus: '1'
+          memory: 200M
     healthcheck:
       test: [ "CMD", "curl", "localhost:8080/" ]
       interval: 5s
@@ -99,7 +99,7 @@ services:
     links:
       - db
     ports:
-      - "8080:8080"
+      - "8080-8081:8080"
     restart: always
     environment:
       SPRING_APPLICATION_JSON: '{

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzConfig.java
@@ -15,6 +15,7 @@ import org.quartz.impl.matchers.GroupMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -32,6 +33,9 @@ public class QuartzConfig {
   @Autowired(required = false)
   List<JobDetail> jobDetails = new ArrayList<>();
 
+  @Value("${l10n.org.quartz.scheduler.enabled:true}")
+  boolean startScheduler;
+
   /**
    * Starts the scheduler after having removed outdated trigger/jobs
    *
@@ -40,7 +44,10 @@ public class QuartzConfig {
   @PostConstruct
   void startScheduler() throws SchedulerException {
     removeOutdatedJobs();
-    scheduler.startDelayed(2);
+    if (startScheduler) {
+      logger.info("Starting scheduler");
+      scheduler.startDelayed(2);
+    }
   }
 
   void removeOutdatedJobs() throws SchedulerException {

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzConfig.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.quartz;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import javax.annotation.PostConstruct;
 import org.quartz.JobDetail;
@@ -15,7 +16,6 @@ import org.quartz.impl.matchers.GroupMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,8 +33,7 @@ public class QuartzConfig {
   @Autowired(required = false)
   List<JobDetail> jobDetails = new ArrayList<>();
 
-  @Value("${l10n.org.quartz.scheduler.enabled:true}")
-  boolean startScheduler;
+  @Autowired QuartzPropertiesConfig quartzPropertiesConfig;
 
   /**
    * Starts the scheduler after having removed outdated trigger/jobs
@@ -43,8 +42,9 @@ public class QuartzConfig {
    */
   @PostConstruct
   void startScheduler() throws SchedulerException {
+    Properties quartzProps = quartzPropertiesConfig.getQuartzProperties();
     removeOutdatedJobs();
-    if (startScheduler) {
+    if (Boolean.parseBoolean(quartzProps.getProperty("org.quartz.scheduler.enabled", "true"))) {
       logger.info("Starting scheduler");
       scheduler.startDelayed(2);
     }


### PR DESCRIPTION
New configuration value allows the Quartz scheduler to be disabled on a node via an application.properties value. This will be utilised in the cluster separation to distinguish worker nodes and api nodes.

Added docker compose cluster that contains a single mysql DB alongside a mojito-api and mojito-worker service that can be used for testing the multi cluster configuration. Successfully sent a command via mojito-cli to an api node which created a pollable task that was picked up and executed by a worker.

`mojito-api` server handling a demo create request, creating the pollable task for asset extraction which is then handled by the `mojito-worker` container
![Screenshot 2023-08-15 at 17 53 38](https://github.com/pinterest/mojito/assets/3417310/346aa687-30ea-47e5-ae10-488442001695)
