### PR TITLE
Add multi Quartz scheduler functionality

### DIFF
--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
@@ -9,6 +9,7 @@ import com.box.l10n.mojito.cli.utils.PollableTaskJobMatcher;
 import com.box.l10n.mojito.cli.utils.TestingJobListener;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.quartz.QuartzSchedulerManager;
 import com.box.l10n.mojito.rest.thirdparty.ThirdPartySyncAction;
 import com.box.l10n.mojito.service.thirdparty.ThirdPartySyncJob;
 import com.box.l10n.mojito.service.thirdparty.ThirdPartySyncJobInput;
@@ -19,7 +20,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.quartz.JobKey;
 import org.quartz.Matcher;
-import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -30,7 +30,7 @@ public class ThirdPartySyncCommandTest extends CLITestBase {
   @Qualifier("fail_on_unknown_properties_false")
   ObjectMapper objectMapper;
 
-  @Autowired Scheduler scheduler;
+  @Autowired QuartzSchedulerManager schedulerManager;
 
   Matcher<JobKey> jobMatcher;
   TestingJobListener testingJobListener;
@@ -39,13 +39,20 @@ public class ThirdPartySyncCommandTest extends CLITestBase {
   public void setUp() throws SchedulerException {
     testingJobListener = new TestingJobListener(objectMapper);
     jobMatcher = new PollableTaskJobMatcher<>(ThirdPartySyncJob.class);
-    scheduler.getListenerManager().addJobListener(testingJobListener, jobMatcher);
+    schedulerManager
+        .getScheduler(QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME)
+        .getListenerManager()
+        .addJobListener(testingJobListener, jobMatcher);
   }
 
   @After
   public void tearDown() throws SchedulerException {
-    scheduler.getListenerManager().removeJobListener(testingJobListener.getName());
-    scheduler
+    schedulerManager
+        .getScheduler(QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME)
+        .getListenerManager()
+        .removeJobListener(testingJobListener.getName());
+    schedulerManager
+        .getScheduler(QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME)
         .getListenerManager()
         .removeJobListenerMatcher(testingJobListener.getName(), jobMatcher);
   }

--- a/docker/docker-compose-api-worker.yml
+++ b/docker/docker-compose-api-worker.yml
@@ -19,61 +19,6 @@ services:
       - --collation-server=utf8mb4_bin
       - --max-connections=1000
       - --log_error_verbosity=2
-  worker:
-    deploy:
-      mode: replicated
-      replicas: 2
-      endpoint_mode: vip
-      resources:
-        limits:
-          cpus: '2'
-          memory: 1G
-        reservations:
-          cpus: '1'
-          memory: 200M
-    healthcheck:
-      test: [ "CMD", "curl", "localhost:8080/" ]
-      interval: 5s
-      timeout: 10s
-      retries: 20
-    depends_on:
-      db:
-        condition: service_healthy
-      api:
-        condition: service_healthy
-    build:
-      dockerfile: docker/Dockerfile-bk8
-      context: ../
-    links:
-      - db
-    restart: always
-    environment:
-      SPRING_APPLICATION_JSON: '{
-        "spring.flyway.enabled": "true",
-        "l10n.flyway.clean" : "false",
-        "spring.jpa.database-platform" : "org.hibernate.dialect.MySQLDialect",
-        "spring.jpa.hibernate.ddl-auto" : "none",
-        "spring.datasource.url" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
-        "spring.datasource.username" : "mojito",
-        "spring.datasource.password" : "ChangeMe",
-        "spring.datasource.driverClassName" : "com.mysql.cj.jdbc.Driver",
-        "spring.jpa.defer-datasource-initialization" : "false",
-        "l10n.org.quartz.scheduler.enabled" : "true",
-        "l10n.org.quartz.jobStore.useProperties" : "true",
-        "l10n.org.quartz.scheduler.instanceId" : "AUTO",
-        "l10n.org.quartz.jobStore.isClustered" : "true",
-        "l10n.org.quartz.threadPool.threadCount" : "10",
-        "l10n.org.quartz.jobStore.class" : "org.quartz.impl.jdbcjobstore.JobStoreTX",
-        "l10n.org.quartz.jobStore.driverDelegateClass" : "org.quartz.impl.jdbcjobstore.StdJDBCDelegate",
-        "l10n.org.quartz.jobStore.dataSource" : "myDS",
-        "l10n.org.quartz.dataSource.myDS.provider" : "hikaricp",
-        "l10n.org.quartz.dataSource.myDS.driver" : "com.mysql.jdbc.Driver",
-        "l10n.org.quartz.dataSource.myDS.URL" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
-        "l10n.org.quartz.dataSource.myDS.user" : "mojito",
-        "l10n.org.quartz.dataSource.myDS.password" : "ChangeMe",
-        "l10n.org.quartz.dataSource.myDS.maxConnections" : "12",
-        "l10n.org.quartz.dataSource.myDS.validationQuery" : "select 1"
-        }'
   api:
     deploy:
       mode: replicated
@@ -97,6 +42,8 @@ services:
     build:
       dockerfile: docker/Dockerfile-bk8
       context: ../
+    image: mojito:latest
+    pull_policy: never
     links:
       - db
     ports:
@@ -114,18 +61,108 @@ services:
       "spring.datasource.driverClassName" : "com.mysql.cj.jdbc.Driver",
       "spring.jpa.defer-datasource-initialization" : "false",
       "l10n.org.quartz.scheduler.enabled" : "false",
-      "l10n.org.quartz.jobStore.useProperties" : "true",
-      "l10n.org.quartz.scheduler.instanceId" : "AUTO",
-      "l10n.org.quartz.jobStore.isClustered" : "true",
-      "l10n.org.quartz.threadPool.threadCount" : "10",
-      "l10n.org.quartz.jobStore.class" : "org.quartz.impl.jdbcjobstore.JobStoreTX",
-      "l10n.org.quartz.jobStore.driverDelegateClass" : "org.quartz.impl.jdbcjobstore.StdJDBCDelegate",
-      "l10n.org.quartz.jobStore.dataSource" : "myDS",
-      "l10n.org.quartz.dataSource.myDS.provider" : "hikaricp",
-      "l10n.org.quartz.dataSource.myDS.driver" : "com.mysql.jdbc.Driver",
-      "l10n.org.quartz.dataSource.myDS.URL" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
-      "l10n.org.quartz.dataSource.myDS.user" : "mojito",
-      "l10n.org.quartz.dataSource.myDS.password" : "ChangeMe",
-      "l10n.org.quartz.dataSource.myDS.maxConnections" : "12",
-      "l10n.org.quartz.dataSource.myDS.validationQuery" : "select 1"
+      "l10n.org.multi-quartz.enabled" : "true",
+      "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.useProperties" : "true",
+      "l10n.org.multi-quartz.schedulers.default.quartz.scheduler.instanceId" : "AUTO",
+      "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.isClustered" : "true",
+      "l10n.org.multi-quartz.schedulers.default.quartz.threadPool.threadCount" : 10,
+      "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.class" : "org.quartz.impl.jdbcjobstore.JobStoreTX",
+      "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.driverDelegateClass" : "org.quartz.impl.jdbcjobstore.StdJDBCDelegate",
+      "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.dataSource" : "myDS",
+      "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.provider" : "hikaricp",
+      "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.driver" : "com.mysql.jdbc.Driver",
+      "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.URL" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
+      "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.user" : "mojito",
+      "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.password" : "ChangeMe",
+      "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.maxConnections" : 12,
+      "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.validationQuery" : "select 1",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.useProperties" : "true",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.scheduler.instanceId" : "AUTO",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.isClustered" : "true",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.threadPool.threadCount" : 5,
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.class" : "org.quartz.impl.jdbcjobstore.JobStoreTX",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.driverDelegateClass" : "org.quartz.impl.jdbcjobstore.StdJDBCDelegate",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.dataSource" : "myDS",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.provider" : "hikaricp",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.driver" : "com.mysql.jdbc.Driver",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.URL" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.user" : "mojito",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.password" : "ChangeMe",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.maxConnections" : 12,
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.validationQuery" : "select 1",
+      "l10n.assetExtraction.quartz.schedulerName" : "lowPriority",
+      "logging.level.com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler" : "DEBUG",
+      "logging.level.com.box.l10n.mojito.service.repository.statistics.RepositoryStatisticsJob" : "DEBUG"
       }'
+  worker:
+    deploy:
+      mode: replicated
+      replicas: 2
+      endpoint_mode: vip
+      resources:
+        limits:
+          cpus: '2'
+          memory: 1G
+        reservations:
+          cpus: '1'
+          memory: 200M
+    healthcheck:
+      test: [ "CMD", "curl", "localhost:8080/" ]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    depends_on:
+      db:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+    image: mojito:latest
+    pull_policy: never
+    links:
+      - db
+    restart: always
+    environment:
+      SPRING_APPLICATION_JSON: '{
+        "spring.flyway.enabled": "true",
+        "l10n.flyway.clean" : "false",
+        "spring.jpa.database-platform" : "org.hibernate.dialect.MySQLDialect",
+        "spring.jpa.hibernate.ddl-auto" : "none",
+        "spring.datasource.url" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
+        "spring.datasource.username" : "mojito",
+        "spring.datasource.password" : "ChangeMe",
+        "spring.datasource.driverClassName" : "com.mysql.cj.jdbc.Driver",
+        "spring.jpa.defer-datasource-initialization" : "false",
+        "l10n.org.quartz.scheduler.enabled" : "true",
+        "l10n.org.multi-quartz.enabled" : "true",
+        "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.useProperties" : "true",
+        "l10n.org.multi-quartz.schedulers.default.quartz.scheduler.instanceId" : "AUTO",
+        "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.isClustered" : "true",
+        "l10n.org.multi-quartz.schedulers.default.quartz.threadPool.threadCount" : 10,
+        "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.class" : "org.quartz.impl.jdbcjobstore.JobStoreTX",
+        "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.driverDelegateClass" : "org.quartz.impl.jdbcjobstore.StdJDBCDelegate",
+        "l10n.org.multi-quartz.schedulers.default.quartz.jobStore.dataSource" : "myDS",
+        "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.provider" : "hikaricp",
+        "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.driver" : "com.mysql.jdbc.Driver",
+        "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.URL" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
+        "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.user" : "mojito",
+        "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.password" : "ChangeMe",
+        "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.maxConnections" : 12,
+        "l10n.org.multi-quartz.schedulers.default.quartz.dataSource.myDS.validationQuery" : "select 1",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.useProperties" : "true",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.scheduler.instanceId" : "AUTO",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.isClustered" : "true",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.threadPool.threadCount" : 5,
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.class" : "org.quartz.impl.jdbcjobstore.JobStoreTX",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.driverDelegateClass" : "org.quartz.impl.jdbcjobstore.StdJDBCDelegate",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.jobStore.dataSource" : "myDS",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.provider" : "hikaricp",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.driver" : "com.mysql.jdbc.Driver",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.URL" : "jdbc:mysql://db:3306/mojito?characterEncoding=UTF-8&useUnicode=true",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.user" : "mojito",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.password" : "ChangeMe",
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.maxConnections" : 12,
+        "l10n.org.multi-quartz.schedulers.lowPriority.quartz.dataSource.myDS.validationQuery" : "select 1",
+        "l10n.assetExtraction.quartz.schedulerName" : "lowPriority",
+        "logging.level.com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler" : "DEBUG",
+        "logging.level.com.box.l10n.mojito.service.repository.statistics.RepositoryStatisticsJob" : "DEBUG"
+        }'

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
         <jjwt.version>0.10.5</jjwt.version>
         <github.api.version>1.313</github.api.version>
         <icu4j.version>64.2</icu4j.version>
+        <docker.compose.detached.mode>true</docker.compose.detached.mode>
+        <docker.compose.remove.volumes>true</docker.compose.remove.volumes>
     </properties>
 
     <dependencies>
@@ -149,6 +151,34 @@
                         <version>${plugin.version.google-java-format}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>com.dkanejs.maven.plugins</groupId>
+                <artifactId>docker-compose-maven-plugin</artifactId>
+                <version>4.0.0</version>
+                <configuration>
+                    <composeFiles>
+                        <composeFile>./docker/docker-compose-api-worker.yml</composeFile>
+                    </composeFiles>
+                    <ignorePullFailures>true</ignorePullFailures>
+                    <detachedMode>${docker.compose.detached.mode}</detachedMode>
+                    <removeVolumes>${docker.compose.remove.volumes}</removeVolumes>
+                    <build>true</build>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>api-worker-cluster-up</id>
+                        <goals>
+                            <goal>up</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>api-worker-cluster-down</id>
+                        <goals>
+                            <goal>down</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzJobInfo.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzJobInfo.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.quartz;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
+
 import java.util.Date;
 import org.quartz.JobBuilder;
 
@@ -14,6 +16,7 @@ public class QuartzJobInfo<I, O> {
   boolean inlineInput;
   long timeout;
   boolean requestRecovery;
+  String scheduler;
 
   private QuartzJobInfo(Builder<I, O> builder) {
     clazz = builder.clazz;
@@ -26,6 +29,7 @@ public class QuartzJobInfo<I, O> {
     inlineInput = builder.inlineInput;
     timeout = builder.timeout;
     requestRecovery = builder.requestRecovery;
+    scheduler = builder.scheduler;
   }
 
   public Class<? extends QuartzPollableJob<I, O>> getClazz() {
@@ -68,6 +72,10 @@ public class QuartzJobInfo<I, O> {
     return requestRecovery;
   }
 
+  public String getScheduler() {
+    return scheduler;
+  }
+
   public static <I, O> Builder<I, O> newBuilder(Class<? extends QuartzPollableJob<I, O>> clazz) {
     Builder<I, O> builder = new Builder<I, O>();
     builder.clazz = clazz;
@@ -85,6 +93,7 @@ public class QuartzJobInfo<I, O> {
     private boolean inlineInput = true;
     private long timeout = 3600;
     private boolean requestRecovery = false;
+    private String scheduler = DEFAULT_SCHEDULER_NAME;
 
     private Builder() {}
 
@@ -125,6 +134,11 @@ public class QuartzJobInfo<I, O> {
 
     public Builder<I, O> withTimeout(long val) {
       timeout = val;
+      return this;
+    }
+
+    public Builder<I, O> withScheduler(String val) {
+      scheduler = val;
       return this;
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
@@ -29,7 +29,7 @@ public class QuartzPollableTaskScheduler {
   /** logger */
   static Logger logger = LoggerFactory.getLogger(QuartzPollableTaskScheduler.class);
 
-  @Autowired Scheduler scheduler;
+  @Autowired QuartzSchedulerManager schedulerManager;
 
   @Autowired PollableTaskService pollableTaskService;
 
@@ -41,7 +41,6 @@ public class QuartzPollableTaskScheduler {
       Class<? extends QuartzPollableJob<I, O>> clazz, I input) {
     QuartzJobInfo<I, O> quartzJobInfo =
         QuartzJobInfo.newBuilder(clazz).withInput(input).withMessage(clazz.getSimpleName()).build();
-
     return scheduleJob(quartzJobInfo);
   }
 
@@ -76,6 +75,10 @@ public class QuartzPollableTaskScheduler {
    * @return
    */
   public <I, O> PollableFuture<O> scheduleJob(QuartzJobInfo<I, O> quartzJobInfo) {
+
+    logger.debug("Scheduling job on queue: {}", quartzJobInfo.getScheduler());
+
+    Scheduler scheduler = schedulerManager.getScheduler(quartzJobInfo.getScheduler());
 
     String pollableTaskName = getPollableTaskName(quartzJobInfo.getClazz());
 

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPropertiesConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPropertiesConfig.java
@@ -5,12 +5,17 @@ import java.util.Map;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationProperties("l10n.org")
+@ConditionalOnProperty(
+    name = "l10n.org.multi-quartz.enabled",
+    havingValue = "false",
+    matchIfMissing = true)
 public class QuartzPropertiesConfig {
 
   static Logger logger = LoggerFactory.getLogger(QuartzPropertiesConfig.class);
@@ -30,6 +35,9 @@ public class QuartzPropertiesConfig {
       properties.put("org.quartz." + entry.getKey(), entry.getValue());
       logger.debug("org.quartz.{}={}", entry.getKey(), entry.getValue());
     }
+
+    properties.put(
+        "org.quartz.scheduler.instanceName", QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME);
 
     return properties;
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzQueueException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzQueueException.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.quartz;
+
+public class QuartzQueueException extends RuntimeException {
+
+  public QuartzQueueException(String message) {
+    super(message);
+  }
+
+  public QuartzQueueException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzSchedulerConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzSchedulerConfig.java
@@ -10,6 +10,7 @@ import org.quartz.Trigger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +19,10 @@ import org.springframework.scheduling.quartz.SpringBeanJobFactory;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
+@ConditionalOnProperty(
+    name = "l10n.org.multi-quartz.enabled",
+    havingValue = "false",
+    matchIfMissing = true)
 public class QuartzSchedulerConfig {
 
   /** logger */
@@ -67,6 +72,7 @@ public class QuartzSchedulerConfig {
     schedulerFactory.setOverwriteExistingJobs(true);
     schedulerFactory.setTriggers(triggers.toArray(new Trigger[] {}));
     schedulerFactory.setAutoStartup(false);
+    schedulerFactory.setBeanName(QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME);
 
     if (quartzMetricsReportingJobListener != null) {
       schedulerFactory.setGlobalJobListeners(quartzMetricsReportingJobListener);

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzSchedulerManager.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzSchedulerManager.java
@@ -1,0 +1,13 @@
+package com.box.l10n.mojito.quartz;
+
+import java.util.List;
+import org.quartz.Scheduler;
+
+public interface QuartzSchedulerManager {
+
+  String DEFAULT_SCHEDULER_NAME = "default";
+
+  Scheduler getScheduler(String schedulerName);
+
+  List<Scheduler> getSchedulers();
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzService.java
@@ -21,14 +21,20 @@ public class QuartzService {
   /** logger */
   static Logger logger = getLogger(QuartzService.class);
 
-  @Autowired Scheduler scheduler;
+  @Autowired QuartzSchedulerManager schedulerManager;
 
+  // TODO(mallen): Handle for other schedulers other than 'default'???
   public List<String> getDynamicJobs() throws SchedulerException {
-    Set<JobKey> jobKeys = scheduler.getJobKeys(GroupMatcher.jobGroupEquals(DYNAMIC_GROUP_NAME));
+    Set<JobKey> jobKeys =
+        schedulerManager
+            .getScheduler(QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME)
+            .getJobKeys(GroupMatcher.jobGroupEquals(DYNAMIC_GROUP_NAME));
     return jobKeys.stream().map(jobKey -> jobKey.getName()).collect(Collectors.toList());
   }
 
   public void deleteAllDynamicJobs() throws SchedulerException {
+    Scheduler scheduler =
+        schedulerManager.getScheduler(QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME);
     Set<JobKey> jobKeys = scheduler.getJobKeys(GroupMatcher.jobGroupEquals(DYNAMIC_GROUP_NAME));
     scheduler.deleteJobs(new ArrayList<>(jobKeys));
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzSingleSchedulerManager.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzSingleSchedulerManager.java
@@ -1,0 +1,28 @@
+package com.box.l10n.mojito.quartz;
+
+import java.util.Collections;
+import java.util.List;
+import org.quartz.Scheduler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(
+    name = "l10n.org.multi-quartz.enabled",
+    havingValue = "false",
+    matchIfMissing = true)
+public class QuartzSingleSchedulerManager implements QuartzSchedulerManager {
+
+  @Autowired Scheduler scheduler;
+
+  @Override
+  public Scheduler getScheduler(String schedulerName) {
+    return scheduler;
+  }
+
+  @Override
+  public List<Scheduler> getSchedulers() {
+    return Collections.singletonList(scheduler);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerConfig.java
@@ -1,0 +1,90 @@
+package com.box.l10n.mojito.quartz.multi;
+
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
+
+import com.box.l10n.mojito.monitoring.QuartzMetricsReportingJobListener;
+import com.box.l10n.mojito.quartz.AutoWiringSpringBeanJobFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import javax.annotation.PostConstruct;
+import org.quartz.Trigger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.scheduling.quartz.SpringBeanJobFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "l10n.org.multi-quartz.enabled", havingValue = "true")
+public class QuartzMultiSchedulerConfig {
+
+  Logger logger = LoggerFactory.getLogger(QuartzMultiSchedulerConfig.class);
+
+  @Autowired ApplicationContext applicationContext;
+
+  @Autowired
+  QuartzMultiSchedulerConfigurationProperties quartzMultiSchedulerConfigurationProperties;
+
+  @Autowired(required = false)
+  QuartzMetricsReportingJobListener quartzMetricsReportingJobListener;
+
+  @Autowired(required = false)
+  List<Trigger> triggers = new ArrayList<>();
+
+  @PostConstruct
+  public void createSchedulers() {
+
+    for (Map.Entry<String, SchedulerConfigurationProperties> entry :
+        quartzMultiSchedulerConfigurationProperties.getSchedulers().entrySet()) {
+      Map<String, String> quartzProps = entry.getValue().getQuartz();
+      Properties properties = new Properties();
+
+      for (Map.Entry<String, String> quartzEntry : quartzProps.entrySet()) {
+        properties.put("org.quartz." + quartzEntry.getKey(), quartzEntry.getValue());
+        logger.debug("org.quartz.{}={}", quartzEntry.getKey(), quartzEntry.getValue());
+      }
+      SchedulerFactoryBean schedulerFactory = new SchedulerFactoryBean();
+      applySchedulerFactoryProperties(schedulerFactory, properties);
+
+      if (entry.getKey().equalsIgnoreCase(DEFAULT_SCHEDULER_NAME)) {
+        schedulerFactory.setTriggers(triggers.toArray(new Trigger[] {}));
+      }
+
+      schedulerFactory.setBeanName(entry.getKey());
+
+      ConfigurableApplicationContext configurableApplicationContext =
+          (ConfigurableApplicationContext) applicationContext;
+      configurableApplicationContext
+          .getBeanFactory()
+          .initializeBean(schedulerFactory, entry.getKey());
+      configurableApplicationContext.getBeanFactory().autowireBean(schedulerFactory);
+      configurableApplicationContext
+          .getBeanFactory()
+          .registerSingleton(entry.getKey(), schedulerFactory);
+    }
+  }
+
+  public void applySchedulerFactoryProperties(
+      SchedulerFactoryBean schedulerFactory, Properties quartzProperties) {
+    schedulerFactory.setQuartzProperties(quartzProperties);
+    schedulerFactory.setJobFactory(createSpringBeanJobFactory());
+    schedulerFactory.setOverwriteExistingJobs(true);
+    schedulerFactory.setAutoStartup(false);
+
+    if (quartzMetricsReportingJobListener != null) {
+      schedulerFactory.setGlobalJobListeners(quartzMetricsReportingJobListener);
+    }
+  }
+
+  public SpringBeanJobFactory createSpringBeanJobFactory() {
+    AutoWiringSpringBeanJobFactory jobFactory = new AutoWiringSpringBeanJobFactory();
+    jobFactory.setApplicationContext(applicationContext);
+    return jobFactory;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerConfigurationProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerConfigurationProperties.java
@@ -1,0 +1,40 @@
+package com.box.l10n.mojito.quartz.multi;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("l10n.org.multi-quartz")
+@ConditionalOnProperty(name = "l10n.org.multi-quartz.enabled", havingValue = "true")
+public class QuartzMultiSchedulerConfigurationProperties {
+
+  Map<String, SchedulerConfigurationProperties> schedulers;
+
+  List<SchedulerConfigurationProperties> schedulerConfigurationProperties = new ArrayList<>();
+
+  public Map<String, SchedulerConfigurationProperties> getSchedulers() {
+    return schedulers;
+  }
+
+  public void setSchedulers(Map<String, SchedulerConfigurationProperties> schedulers) {
+    this.schedulers = schedulers;
+  }
+}
+
+class SchedulerConfigurationProperties {
+
+  private Map<String, String> quartz = new HashMap<>();
+
+  public Map<String, String> getQuartz() {
+    return quartz;
+  }
+
+  public void setQuartz(Map<String, String> quartz) {
+    this.quartz = quartz;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerException.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.quartz.multi;
+
+public class QuartzMultiSchedulerException extends RuntimeException {
+
+  public QuartzMultiSchedulerException(String message) {
+    super(message);
+  }
+
+  public QuartzMultiSchedulerException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerManager.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerManager.java
@@ -1,0 +1,64 @@
+package com.box.l10n.mojito.quartz.multi;
+
+import com.box.l10n.mojito.quartz.QuartzSchedulerManager;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "l10n.org.multi-quartz.enabled", havingValue = "true")
+@DependsOn("quartzMultiSchedulerConfig")
+public class QuartzMultiSchedulerManager implements QuartzSchedulerManager {
+
+  Logger logger = LoggerFactory.getLogger(QuartzMultiSchedulerManager.class);
+
+  @Autowired List<Scheduler> schedulers;
+
+  Map<String, Scheduler> schedulerByName = new HashMap<>();
+
+  @PostConstruct
+  public void init() throws SchedulerException {
+    for (Scheduler scheduler : schedulers) {
+      if (schedulerByName.containsKey(scheduler.getSchedulerName())) {
+        throw new QuartzMultiSchedulerException(
+            "Scheduler with name '"
+                + scheduler.getSchedulerName()
+                + "' already exists. Please configure a unique name for each scheduler");
+      }
+      schedulerByName.put(scheduler.getSchedulerName(), scheduler);
+    }
+
+    if (!schedulerByName.containsKey(DEFAULT_SCHEDULER_NAME)) {
+      throw new QuartzMultiSchedulerException(
+          "No default scheduler found. Please configure a scheduler with name '"
+              + DEFAULT_SCHEDULER_NAME
+              + "'");
+    }
+  }
+
+  @Override
+  public Scheduler getScheduler(String schedulerName) {
+
+    if (!schedulerByName.containsKey(schedulerName)) {
+      logger.warn(
+          "Scheduler with name '{}' not found, scheduling job on default scheduler", schedulerName);
+      schedulerName = DEFAULT_SCHEDULER_NAME;
+    }
+
+    return schedulerByName.get(schedulerName);
+  }
+
+  @Override
+  public List<Scheduler> getSchedulers() {
+    return schedulers;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.rest.asset;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
+
 import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.Locale;
 import com.box.l10n.mojito.entity.PollableTask;
@@ -35,6 +37,7 @@ import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -70,6 +73,9 @@ public class AssetWS {
   @Autowired QuartzPollableTaskScheduler quartzPollableTaskScheduler;
 
   @Autowired MeterRegistry meterRegistry;
+
+  @Value("${l10n.assetWS.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
 
   /**
    * Gets the list of {@link Asset} for a given {@link Repository} and other optional filters
@@ -230,6 +236,7 @@ public class AssetWS {
         QuartzJobInfo.newBuilder(GenerateLocalizedAssetJob.class)
             .withInlineInput(false)
             .withInput(localizedAssetBody)
+            .withScheduler(schedulerName)
             .build();
     PollableFuture<LocalizedAssetBody> localizedAssetBodyPollableFuture =
         quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/MachineTranslationWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/MachineTranslationWS.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.rest.machinetranslation;
 
 import static com.box.l10n.mojito.CacheType.Names.MACHINE_TRANSLATION;
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 
 import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.quartz.QuartzJobInfo;
@@ -14,6 +15,7 @@ import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,6 +42,9 @@ public class MachineTranslationWS {
 
   @Autowired RepositoryMachineTranslationService repositoryMachineTranslationService;
 
+  @Value("${l10n.machineTranslation.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
+
   @RequestMapping(method = RequestMethod.POST, value = "/api/machine-translation-batch")
   @ResponseStatus(HttpStatus.OK)
   @Cacheable(MACHINE_TRANSLATION)
@@ -48,6 +53,7 @@ public class MachineTranslationWS {
         QuartzJobInfo.newBuilder(BatchMachineTranslationJob.class)
             .withInlineInput(false)
             .withInput(translationRequest)
+            .withScheduler(schedulerName)
             .build();
     PollableFuture<TranslationsResponseDTO> localizedAssetBodyPollableFuture =
         quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetService.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.asset;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static com.box.l10n.mojito.rest.asset.AssetSpecification.branchId;
 import static com.box.l10n.mojito.rest.asset.AssetSpecification.deletedEquals;
 import static com.box.l10n.mojito.rest.asset.AssetSpecification.pathEquals;
@@ -47,6 +48,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -88,6 +90,9 @@ public class AssetService {
   @Autowired FilterOptionsMd5Builder filterOptionsMd5Builder;
 
   @Autowired QuartzPollableTaskScheduler quartzPollableTaskScheduler;
+
+  @Value("${l10n.assetService.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
 
   /**
    * Adds an {@link Asset} to a {@link Repository}.
@@ -386,6 +391,7 @@ public class AssetService {
         QuartzJobInfo.newBuilder(DeleteAssetsOfBranchJob.class)
             .withInput(deleteAssetsOfBranchJobInput)
             .withMessage(pollableMessage)
+            .withScheduler(schedulerName)
             .build();
     return quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionService.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.assetExtraction;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static com.box.l10n.mojito.service.assetExtraction.LocalBranchToEntityBranchConverter.NULL_BRANCH_TEXT_PLACEHOLDER;
 import static java.util.function.Function.identity;
 
@@ -83,6 +84,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.annotation.Retryable;
@@ -161,6 +163,9 @@ public class AssetExtractionService {
   @Autowired EntityManager entityManager;
 
   @Autowired LocalBranchToEntityBranchConverter localBranchToEntityBranchConverter;
+
+  @Value("${l10n.assetExtraction.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String quartzSchedulerName;
 
   /**
    * If the asset type is supported, starts the text units extraction for the given asset.
@@ -1156,6 +1161,7 @@ public class AssetExtractionService {
             .withMessage(pollableMessage)
             .withParentId(parentTaskId)
             .withExpectedSubTaskNumber(5)
+            .withScheduler(quartzSchedulerName)
             .build();
 
     return quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchService.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.branch;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.box.l10n.mojito.entity.Branch;
@@ -12,6 +13,7 @@ import java.text.MessageFormat;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
@@ -30,6 +32,9 @@ public class BranchService {
   @Autowired BranchRepository branchRepository;
 
   @Autowired QuartzPollableTaskScheduler quartzPollableTaskScheduler;
+
+  @Value("${l10n.branchService.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
 
   public Branch createBranch(
       Repository repository, String branchName, User createdByUser, Set<String> branchNotifierIds) {
@@ -78,6 +83,7 @@ public class BranchService {
         QuartzJobInfo.newBuilder(DeleteBranchJob.class)
             .withInput(deleteBranchJobInput)
             .withMessage(pollableMessage)
+            .withScheduler(schedulerName)
             .build();
     return quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticService.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.branch;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static com.box.l10n.mojito.service.assetExtraction.AssetExtractionService.PRIMARY_BRANCH;
 import static com.box.l10n.mojito.service.tm.search.StatusFilter.FOR_TRANSLATION;
 import static com.box.l10n.mojito.utils.Predicates.not;
@@ -43,6 +44,7 @@ import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -76,6 +78,9 @@ public class BranchStatisticService {
   @Autowired TextUnitDTOsCacheService textUnitDTOsCacheService;
 
   @Autowired EntityManager entityManager;
+
+  @Value("${l10n.branchStatistic.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
 
   /**
    * Compute statistics for all branches that are not deleted in a given repository.
@@ -411,6 +416,7 @@ public class BranchStatisticService {
         QuartzJobInfo.newBuilder(BranchNotificationJob.class)
             .withUniqueId(String.valueOf(branch.getId()))
             .withInput(branchNotificationJobInput)
+            .withScheduler(schedulerName)
             .build();
     quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.branch.notification;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.box.l10n.mojito.entity.Branch;
@@ -27,6 +28,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -52,6 +54,9 @@ public class BranchNotificationService {
   @Autowired QuartzPollableTaskScheduler quartzPollableTaskScheduler;
 
   @Autowired BranchNotificationServiceLegacy branchNotificationServiceLegacy;
+
+  @Value("${l10n.branchNotification.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
 
   /**
    * When the state of branch changes, notifications must be sent (new, updated, translated). This
@@ -180,6 +185,7 @@ public class BranchNotificationService {
             .withInput(branchNotificationMissingScreenshotsJobInput)
             .withTriggerStartDate(date)
             .withUniqueId(notifierId + "_" + branch.getId())
+            .withScheduler(schedulerName)
             .build();
     quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notificationlegacy/BranchNotificationServiceLegacy.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notificationlegacy/BranchNotificationServiceLegacy.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.branch.notificationlegacy;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.box.l10n.mojito.entity.Branch;
@@ -28,6 +29,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -45,6 +47,9 @@ public class BranchNotificationServiceLegacy {
   @Autowired BranchStatisticRepository branchStatisticRepository;
 
   @Autowired BranchTextUnitStatisticRepository branchTextUnitStatisticRepository;
+
+  @Value("${l10n.branchNotificationsLegacy.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
 
   /**
    * 'required = false' needed here to allow a successful Spring Boot startup as if no {@link
@@ -161,6 +166,7 @@ public class BranchNotificationServiceLegacy {
             .withInput(branchNotificationMissingScreenshotsJobInput)
             .withTriggerStartDate(date)
             .withUniqueId(senderType + "_" + branch.getId())
+            .withScheduler(schedulerName)
             .build();
     quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsJobScheduler.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsJobScheduler.java
@@ -1,15 +1,21 @@
 package com.box.l10n.mojito.service.repository.statistics;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
+
 import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.google.common.base.Preconditions;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RepositoryStatisticsJobScheduler {
 
   @Autowired QuartzPollableTaskScheduler quartzPollableTaskScheduler;
+
+  @Value("${l10n.repositoryStatistics.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String quartzSchedulerName;
 
   public void schedule(Long repositoryId) {
     Preconditions.checkNotNull(repositoryId);
@@ -20,6 +26,7 @@ public class RepositoryStatisticsJobScheduler {
     QuartzJobInfo.Builder<RepositoryStatisticsJobInput, Void> quartzInfo =
         QuartzJobInfo.newBuilder(RepositoryStatisticsJob.class)
             .withUniqueId(String.valueOf(repositoryId))
+            .withScheduler(quartzSchedulerName)
             .withInput(repositoryStatisticsJobInput);
 
     quartzPollableTaskScheduler.scheduleJob(quartzInfo.build());

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.service.tm;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
+
 import com.box.l10n.mojito.common.StreamUtil;
 import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.Locale;
@@ -80,6 +82,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -140,6 +143,9 @@ public class TMService {
   @Autowired PullRunService pullRunService;
 
   @Autowired PullRunAssetService pullRunAssetService;
+
+  @Value("${l10n.tmService.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
 
   /**
    * Adds a {@link TMTextUnit} in a {@link TM}.
@@ -1194,6 +1200,7 @@ public class TMService {
         QuartzJobInfo.newBuilder(ImportLocalizedAssetJob.class)
             .withInlineInput(false)
             .withInput(importLocalizedAssetJobInput)
+            .withScheduler(schedulerName)
             .build();
 
     return quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);

--- a/webapp/src/test/java/com/box/l10n/mojito/monitoring/QuartzPendingJobsReportingTaskTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/monitoring/QuartzPendingJobsReportingTaskTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.quartz.JobBuilder.newJob;
 
+import com.box.l10n.mojito.quartz.QuartzSchedulerManager;
 import com.box.l10n.mojito.service.DBUtils;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import com.box.l10n.mojito.test.TestIdWatcher;
@@ -40,7 +41,7 @@ public class QuartzPendingJobsReportingTaskTest extends ServiceTestBase {
 
   @Autowired DataSource dataSource;
 
-  @Autowired Scheduler scheduler;
+  @Autowired QuartzSchedulerManager schedulerManager;
 
   @Autowired DBUtils dbUtils;
 
@@ -48,6 +49,8 @@ public class QuartzPendingJobsReportingTaskTest extends ServiceTestBase {
   Boolean monitoringEnabled;
 
   QuartzPendingJobsReportingTask task;
+
+  Scheduler scheduler;
 
   /*
    * This sets up the condition we'll use for await() later on. Given jobs can take some time
@@ -66,6 +69,7 @@ public class QuartzPendingJobsReportingTaskTest extends ServiceTestBase {
 
     Assume.assumeTrue(dbUtils.isMysql() && monitoringEnabled);
     task = new QuartzPendingJobsReportingTask(dataSource, meterRegistry);
+    scheduler = schedulerManager.getScheduler(QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME);
 
     scheduler.clear();
   }

--- a/webapp/src/test/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerConfigurationPropertiesTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerConfigurationPropertiesTest.java
@@ -1,0 +1,46 @@
+package com.box.l10n.mojito.quartz.multi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(
+    classes = {
+      QuartzMultiSchedulerConfigurationProperties.class,
+      QuartzMultiSchedulerConfigurationPropertiesTest.class
+    },
+    properties = {
+      "l10n.org.multi-quartz.enabled=true",
+      "l10n.org.multi-quartz.schedulers.default.quartz.threadPool.threadCount=10",
+      "l10n.org.multi-quartz.schedulers.lowPriority.quartz.threadPool.threadCount=5"
+    })
+@EnableConfigurationProperties(QuartzMultiSchedulerConfigurationProperties.class)
+public class QuartzMultiSchedulerConfigurationPropertiesTest {
+
+  @Autowired
+  QuartzMultiSchedulerConfigurationProperties quartzMultiSchedulerConfigurationProperties;
+
+  @Test
+  public void testSchedulersConfig() {
+    Map<String, SchedulerConfigurationProperties> schedulerConfigurationProperties =
+        quartzMultiSchedulerConfigurationProperties.getSchedulers();
+
+    assertThat(schedulerConfigurationProperties).containsOnlyKeys("default", "lowPriority");
+    SchedulerConfigurationProperties defaultSchedulerConfigurationProperties =
+        schedulerConfigurationProperties.get("default");
+    SchedulerConfigurationProperties lowPrioritySchedulerConfigurationProperties =
+        schedulerConfigurationProperties.get("lowPriority");
+    assertThat(defaultSchedulerConfigurationProperties.getQuartz().get("threadPool.threadCount"))
+        .isEqualTo("10");
+    assertThat(
+            lowPrioritySchedulerConfigurationProperties.getQuartz().get("threadPool.threadCount"))
+        .isEqualTo("5");
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerManagerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/quartz/multi/QuartzMultiSchedulerManagerTest.java
@@ -1,0 +1,131 @@
+package com.box.l10n.mojito.quartz.multi;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.box.l10n.mojito.quartz.QuartzConfig;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(
+    classes = {
+      QuartzMultiSchedulerConfigurationProperties.class,
+      QuartzMultiSchedulerConfig.class,
+      QuartzMultiSchedulerManager.class,
+      QuartzConfig.class,
+      QuartzMultiSchedulerManagerTest.class
+    },
+    properties = {
+      "l10n.org.multi-quartz.enabled=true",
+      "l10n.org.multi-quartz.schedulers.default.quartz.threadPool.threadCount=10",
+      "l10n.org.multi-quartz.schedulers.scheduler2.quartz.threadPool.threadCount=5"
+    })
+@EnableConfigurationProperties(QuartzMultiSchedulerConfigurationProperties.class)
+public class QuartzMultiSchedulerManagerTest {
+
+  @Autowired QuartzMultiSchedulerManager quartzMultiSchedulerManager;
+
+  @Test
+  public void testSchedulerGeneratedFromProperties() throws SchedulerException {
+    Scheduler defaultScheduler = quartzMultiSchedulerManager.getScheduler("default");
+    Scheduler scheduler2 = quartzMultiSchedulerManager.getScheduler("scheduler2");
+
+    assertEquals("default", defaultScheduler.getSchedulerName());
+    assertEquals(10, defaultScheduler.getMetaData().getThreadPoolSize());
+    assertEquals("scheduler2", scheduler2.getSchedulerName());
+    assertEquals(5, scheduler2.getMetaData().getThreadPoolSize());
+    await()
+        .atMost(Duration.of(10, ChronoUnit.SECONDS))
+        .until(() -> defaultScheduler.isStarted() && scheduler2.isStarted());
+  }
+
+  @Test(expected = QuartzMultiSchedulerException.class)
+  public void testExceptionThrownIfNoDefaultSchedulerConfigured() throws SchedulerException {
+    List<Scheduler> schedulers = new ArrayList<>();
+    Scheduler schedulerMock = mock(Scheduler.class);
+    when(schedulerMock.getSchedulerName()).thenReturn("scheduler1");
+    schedulers.add(schedulerMock);
+
+    QuartzMultiSchedulerManager quartzMultiSchedulerManager = new QuartzMultiSchedulerManager();
+    quartzMultiSchedulerManager.schedulers = schedulers;
+    quartzMultiSchedulerManager.init();
+  }
+
+  @Test(expected = QuartzMultiSchedulerException.class)
+  public void testExceptionThrownIfDuplicateSchedulerConfigured() throws SchedulerException {
+    List<Scheduler> schedulers = new ArrayList<>();
+    Scheduler schedulerMock = mock(Scheduler.class);
+    Scheduler schedulerMock2 = mock(Scheduler.class);
+    when(schedulerMock.getSchedulerName()).thenReturn("scheduler1");
+    when(schedulerMock2.getSchedulerName()).thenReturn("scheduler1");
+    schedulers.add(schedulerMock);
+    schedulers.add(schedulerMock2);
+
+    QuartzMultiSchedulerManager quartzMultiSchedulerManager = new QuartzMultiSchedulerManager();
+    quartzMultiSchedulerManager.schedulers = schedulers;
+    quartzMultiSchedulerManager.init();
+  }
+
+  @Test
+  public void testDefaultSchedulerReturnedIfRequestedDoesntExist() throws SchedulerException {
+    assertEquals(
+        "default",
+        quartzMultiSchedulerManager.getScheduler("schedulerNotExist").getSchedulerName());
+  }
+
+  @Test
+  public void testScheduleJobOnSeparateSchedulers() throws SchedulerException {
+    Scheduler defaultScheduler = quartzMultiSchedulerManager.getScheduler("default");
+    Scheduler scheduler2 = quartzMultiSchedulerManager.getScheduler("scheduler2");
+
+    await()
+        .atMost(Duration.of(10, ChronoUnit.SECONDS))
+        .until(() -> defaultScheduler.isStarted() && scheduler2.isStarted());
+
+    JobDetail jobDetail = JobBuilder.newJob(TestJob.class).withIdentity("job1", "DYNAMIC").build();
+    Trigger trigger =
+        TriggerBuilder.newTrigger().withIdentity("trigger1", "DYNAMIC").startNow().build();
+    defaultScheduler.scheduleJob(jobDetail, trigger);
+
+    assertTrue(defaultScheduler.checkExists(jobDetail.getKey()));
+
+    assertFalse(scheduler2.checkExists(jobDetail.getKey()));
+
+    await()
+        .atMost(Duration.of(10, ChronoUnit.SECONDS))
+        .until(() -> jobDetail.getJobDataMap() != null);
+    assertEquals("default", TestJob.getExecutingScheduler());
+
+    JobDetail jobDetail2 = JobBuilder.newJob(TestJob.class).withIdentity("job2", "DYNAMIC").build();
+    Trigger trigger2 =
+        TriggerBuilder.newTrigger().withIdentity("trigger2", "DYNAMIC").startNow().build();
+    scheduler2.scheduleJob(jobDetail2, trigger2);
+
+    assertTrue(scheduler2.checkExists(jobDetail2.getKey()));
+    assertFalse(defaultScheduler.checkExists(jobDetail2.getKey()));
+
+    await()
+        .atMost(Duration.of(10, ChronoUnit.SECONDS))
+        .until(() -> jobDetail2.getJobDataMap() != null);
+    assertEquals("scheduler2", TestJob.getExecutingScheduler());
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/quartz/multi/TestJob.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/quartz/multi/TestJob.java
@@ -1,0 +1,28 @@
+package com.box.l10n.mojito.quartz.multi;
+
+import org.quartz.Job;
+import org.quartz.SchedulerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestJob implements Job {
+
+  private static volatile String executingScheduler;
+
+  Logger logger = LoggerFactory.getLogger(TestJob.class);
+
+  @Override
+  public void execute(org.quartz.JobExecutionContext context)
+      throws org.quartz.JobExecutionException {
+    logger.info("Executing test job");
+    try {
+      executingScheduler = context.getScheduler().getSchedulerName();
+    } catch (SchedulerException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static String getExecutingScheduler() {
+    return executingScheduler;
+  }
+}


### PR DESCRIPTION
This PR adds functionality to allow the configuration of multiple Quartz schedulers and introduces configuration properties to allow jobs to be scheduled to a specified Quartz scheduler.

Updates the docker-compose file `docker-compose-api-worker.yml` to spin up a single db & mojito api container alongside two mojito worker containers used to execute the Quartz jobs which can be utilised for testing.