### PR TITLE
Rebuild corrupted cache from database

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/textunitdtocache/TextUnitDTOsCacheService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/textunitdtocache/TextUnitDTOsCacheService.java
@@ -67,10 +67,21 @@ public class TextUnitDTOsCacheService {
       StatusFilter statusFilter,
       boolean isRootLocale,
       UpdateType updateType) {
+
+    ImmutableMap<String, TextUnitDTO> filteredWithStatus;
     ImmutableList<TextUnitDTO> textUnitDTOsForAssetAndLocale =
         getTextUnitDTOsForAssetAndLocale(assetId, localeId, isRootLocale, updateType);
-    ImmutableMap<String, TextUnitDTO> filteredWithStatus =
-        filterWithStatusAndMap(statusFilter, textUnitDTOsForAssetAndLocale);
+    try {
+      filteredWithStatus = filterWithStatusAndMap(statusFilter, textUnitDTOsForAssetAndLocale);
+    } catch (IllegalArgumentException illegalArgumentException) {
+      logger.warn(
+          "Can't filterWithStatusAndMap, consider the cache corrupted and refetch text unit from the database");
+      final ImmutableList<TextUnitDTO> textUnitDTOS =
+          updateTextUnitDTOsWithDeltaFromDatabase(
+              ImmutableList.of(), assetId, localeId, isRootLocale);
+      filteredWithStatus = filterWithStatusAndMap(statusFilter, textUnitDTOS);
+    }
+
     return filteredWithStatus;
   }
 


### PR DESCRIPTION
If the text unit dto cache contains text units with the same md5 then the map creation will fail on duplicated keys.

The cache is now considered as corrupted and a valid list of text units is fetched from the database and presited in the cache.

This is an edge case, but the duplicate md5s can happen when restoring a database snapshot from prod to dev environment where the text unit id have diverged.