### PR TITLE
Added schedulerName config to services not directly using QuartzJobInfo

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
@@ -38,14 +38,17 @@ public class QuartzPollableTaskScheduler {
   @Autowired ObjectMapper objectMapper;
 
   public <I, O> PollableFuture<O> scheduleJob(
-      Class<? extends QuartzPollableJob<I, O>> clazz, I input) {
+      Class<? extends QuartzPollableJob<I, O>> clazz, I input, String schedulerName) {
     QuartzJobInfo<I, O> quartzJobInfo =
         QuartzJobInfo.newBuilder(clazz).withInput(input).withMessage(clazz.getSimpleName()).build();
     return scheduleJob(quartzJobInfo);
   }
 
   public <I, O> PollableFuture<O> scheduleJobWithCustomTimeout(
-      Class<? extends QuartzPollableJob<I, O>> clazz, I input, long timeoutInSeconds) {
+      Class<? extends QuartzPollableJob<I, O>> clazz,
+      I input,
+      String schedulerName,
+      long timeoutInSeconds) {
     QuartzJobInfo<I, O> quartzJobInfo =
         QuartzJobInfo.newBuilder(clazz)
             .withInput(input)

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetService.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.service.asset;
 
 import static com.box.l10n.mojito.entity.TMTextUnitVariant.Status.APPROVED;
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.box.l10n.mojito.entity.Asset;
@@ -52,6 +53,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -101,6 +103,9 @@ public class VirtualAssetService {
   @Autowired EntityManager em;
 
   @Autowired PluralFormService pluralFormService;
+
+  @Value("${l10n.virtualAssetService.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
 
   @Transactional
   public VirtualAsset createOrUpdateVirtualAsset(VirtualAsset virtualAsset)
@@ -308,7 +313,7 @@ public class VirtualAssetService {
     importVirtualAssetJobInput.setVirtualAssetTextUnits(virtualAssetTextUnits);
     importVirtualAssetJobInput.setReplace(b);
     return quartzPollableTaskScheduler.scheduleJob(
-        VirtualTextUnitBatchUpdateJob.class, importVirtualAssetJobInput);
+        VirtualTextUnitBatchUpdateJob.class, importVirtualAssetJobInput, schedulerName);
   }
 
   public PollableFuture<Void> importLocalizedTextUnits(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.thirdparty;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
@@ -34,6 +35,7 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /** @author jeanaurambault */
@@ -70,6 +72,9 @@ public class ThirdPartyService {
 
   @Autowired ThirdPartyTMS thirdPartyTMS;
 
+  @Value("${l10n.thirdPartyService.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
+
   public void removeImage(String projectId, String imageId) {
     logger.debug(
         "remove image (screenshot) from Smartling, project id: {}, imageId: {}",
@@ -95,7 +100,10 @@ public class ThirdPartyService {
     thirdPartySyncJobInput.setOptions(thirdPartySync.getOptions());
 
     return quartzPollableTaskScheduler.scheduleJobWithCustomTimeout(
-        ThirdPartySyncJob.class, thirdPartySyncJobInput, thirdPartySync.getTimeout());
+        ThirdPartySyncJob.class,
+        thirdPartySyncJobInput,
+        schedulerName,
+        thirdPartySync.getTimeout());
   }
 
   void syncMojitoWithThirdPartyTMS(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.service.tm.importer;
 
 import static com.box.l10n.mojito.entity.TMTextUnitVariant.Status.APPROVED;
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static com.box.l10n.mojito.utils.Predicates.logIfFalse;
 
 import com.box.l10n.mojito.entity.Asset;
@@ -51,6 +52,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,6 +89,9 @@ public class TextUnitBatchImporterService {
 
   @Autowired MeterRegistry meterRegistry;
 
+  @Value("${l10n.textUnitBatchImporterService.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
+  String schedulerName;
+
   /**
    * Imports a batch of text units.
    *
@@ -116,7 +121,8 @@ public class TextUnitBatchImporterService {
     importTextUnitJobInput.setIntegrityCheckKeepStatusIfFailedAndSameTarget(
         integrityCheckKeepStatusIfFailedAndSameTarget);
 
-    return quartzPollableTaskScheduler.scheduleJob(ImportTextUnitJob.class, importTextUnitJobInput);
+    return quartzPollableTaskScheduler.scheduleJob(
+        ImportTextUnitJob.class, importTextUnitJobInput, schedulerName);
   }
 
   public PollableFuture<Void> importTextUnits(

--- a/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableTaskSchedulerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableTaskSchedulerTest.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.quartz;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -20,12 +21,14 @@ public class QuartzPollableTaskSchedulerTest extends ServiceTestBase {
   @Test
   public void test() throws ExecutionException, InterruptedException {
     PollableFuture<AQuartzPollableJobOutput> pollableFuture =
-        quartzPollableTaskScheduler.scheduleJob(AQuartzPollableJob.class, 10L);
+        quartzPollableTaskScheduler.scheduleJob(
+            AQuartzPollableJob.class, 10L, DEFAULT_SCHEDULER_NAME);
     AQuartzPollableJobOutput s = pollableFuture.get();
     assertEquals("output: 10", s.getOutput());
 
     PollableFuture<AQuartzPollableJobOutput> stringPollableFuture2 =
-        quartzPollableTaskScheduler.scheduleJob(AQuartzPollableJob.class, 10L);
+        quartzPollableTaskScheduler.scheduleJob(
+            AQuartzPollableJob.class, 10L, DEFAULT_SCHEDULER_NAME);
     AQuartzPollableJobOutput s2 = stringPollableFuture2.get();
     assertEquals("output: 10", s2.getOutput());
   }
@@ -33,7 +36,8 @@ public class QuartzPollableTaskSchedulerTest extends ServiceTestBase {
   @Test
   public void testVoid() throws ExecutionException, InterruptedException {
     PollableFuture<Void> pollableFuture =
-        quartzPollableTaskScheduler.scheduleJob(VoidQuartzPollableJob.class, 10L);
+        quartzPollableTaskScheduler.scheduleJob(
+            VoidQuartzPollableJob.class, 10L, DEFAULT_SCHEDULER_NAME);
     Void aVoid = pollableFuture.get();
     assertEquals(null, aVoid);
     try {


### PR DESCRIPTION
Added missing schedulerName configuration option to services that don't call `scheduleJob(QuartzJobInfo info)` directly