### PR TITLE
Set scheduler in quartz job info

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
@@ -40,7 +40,11 @@ public class QuartzPollableTaskScheduler {
   public <I, O> PollableFuture<O> scheduleJob(
       Class<? extends QuartzPollableJob<I, O>> clazz, I input, String schedulerName) {
     QuartzJobInfo<I, O> quartzJobInfo =
-        QuartzJobInfo.newBuilder(clazz).withInput(input).withMessage(clazz.getSimpleName()).build();
+        QuartzJobInfo.newBuilder(clazz)
+            .withInput(input)
+            .withMessage(clazz.getSimpleName())
+            .withScheduler(schedulerName)
+            .build();
     return scheduleJob(quartzJobInfo);
   }
 
@@ -53,6 +57,7 @@ public class QuartzPollableTaskScheduler {
         QuartzJobInfo.newBuilder(clazz)
             .withInput(input)
             .withTimeout(timeoutInSeconds)
+            .withScheduler(schedulerName)
             .withMessage(clazz.getSimpleName())
             .build();
 


### PR DESCRIPTION
Set the scheduler name in quartz job info, missing from https://github.com/pinterest/mojito/pull/24