### PR TITLE
Split third party pull into Quartz child jobs

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/locale/LocaleRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/locale/LocaleRepository.java
@@ -8,4 +8,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 /** @author jaurambault */
 @RepositoryRestResource(exported = false)
 public interface LocaleRepository
-    extends JpaRepository<Locale, Long>, JpaSpecificationExecutor<Locale> {}
+    extends JpaRepository<Locale, Long>, JpaSpecificationExecutor<Locale> {
+
+  Locale findByBcp47Tag(String bcp47Tag);
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
@@ -53,7 +53,7 @@ public class RepositoryStatisticsUpdatedReactor {
    *
    * @param repositoryId
    */
-  public void generateEvent(Long repositoryId) {
+  public synchronized void generateEvent(Long repositoryId) {
     replayProcessor.onNext(repositoryId);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -168,6 +168,7 @@ public class ThirdPartyService {
           skipAssetsWithPathPattern,
           options,
           repository,
+          schedulerName,
           currentTask);
     }
     if (actions.contains(ThirdPartySyncAction.MAP_TEXTUNIT)) {
@@ -219,7 +220,7 @@ public class ThirdPartyService {
         options);
   }
 
-  @Pollable(message = "Pull translations from third party service.")
+  @Pollable(message = "Trigger translations pull from third party service.")
   private void pull(
       String thirdPartyProjectId,
       String pluralSeparator,
@@ -228,6 +229,7 @@ public class ThirdPartyService {
       String skipAssetsWithPathPattern,
       List<String> options,
       Repository repository,
+      String schedulerName,
       @ParentTask PollableTask currentTask) {
     thirdPartyTMS.pull(
         repository,
@@ -236,7 +238,9 @@ public class ThirdPartyService {
         parseLocaleMapping(localeMapping),
         skipTextUnitsWithPattern,
         skipAssetsWithPathPattern,
-        options);
+        options,
+        schedulerName,
+        currentTask);
   }
 
   @Pollable(message = "Pull source text units from third party service.")

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMS.java
@@ -1,6 +1,8 @@
 package com.box.l10n.mojito.service.thirdparty;
 
+import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import java.util.List;
 import java.util.Map;
 
@@ -68,14 +70,16 @@ interface ThirdPartyTMS {
       String skipAssetsWithPathPattern,
       List<String> options);
 
-  void pull(
+  PollableFuture<Void> pull(
       Repository repository,
       String projectId,
       String pluralSeparator,
       Map<String, String> localeMapping,
       String skipTextUnitsWithPattern,
       String skipAssetsWithPathPattern,
-      List<String> optionList);
+      List<String> optionList,
+      String schedulerName,
+      PollableTask currentTask);
 
   void pushTranslations(
       Repository repository,

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
@@ -1,6 +1,8 @@
 package com.box.l10n.mojito.service.thirdparty;
 
+import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,14 +87,18 @@ public class ThirdPartyTMSInMemory implements ThirdPartyTMS {
       List<String> options) {}
 
   @Override
-  public void pull(
+  public PollableFuture<Void> pull(
       Repository repository,
       String projectId,
       String pluralSeparator,
       Map<String, String> localeMapping,
       String skipTextUnitsWithPattern,
       String skipAssetsWithPathPattern,
-      List<String> optionList) {}
+      List<String> optionList,
+      String schedulerName,
+      PollableTask currentTask) {
+    return null;
+  }
 
   @Override
   public void pushTranslations(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJob.java
@@ -1,0 +1,94 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.quartz;
+
+import static com.box.l10n.mojito.service.thirdparty.smartling.SmartlingFileUtils.getOutputSourceFile;
+
+import com.box.l10n.mojito.LocaleMappingHelper;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.quartz.QuartzJobInfo;
+import com.box.l10n.mojito.quartz.QuartzPollableJob;
+import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
+import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import com.box.l10n.mojito.service.repository.RepositoryService;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class SmartlingPullBatchFileJob
+    extends QuartzPollableJob<SmartlingPullBatchFileJobInput, Void> {
+
+  static Logger logger = LoggerFactory.getLogger(SmartlingPullBatchFileJob.class);
+
+  @Autowired QuartzPollableTaskScheduler quartzPollableTaskScheduler;
+
+  @Autowired MeterRegistry meterRegistry;
+
+  @Autowired RepositoryRepository repositoryRepository;
+
+  @Autowired LocaleMappingHelper localeMappingHelper;
+
+  @Autowired RepositoryService repositoryService;
+
+  @Override
+  public Void call(SmartlingPullBatchFileJobInput input) throws Exception {
+
+    Repository repository = repositoryRepository.findByName(input.getRepositoryName());
+
+    for (RepositoryLocale locale :
+        repositoryService.getRepositoryLocalesWithoutRootLocale(repository)) {
+      logger.debug("Pulling locale file for locale: {}", locale.getLocale().getBcp47Tag());
+      scheduleLocaleFileJob(input, repository, locale);
+    }
+
+    return null;
+  }
+
+  private void scheduleLocaleFileJob(
+      SmartlingPullBatchFileJobInput input, Repository repository, RepositoryLocale locale) {
+    SmartlingPullLocaleFileJobInput smartlingPullLocaleFileJobInput =
+        new SmartlingPullLocaleFileJobInput();
+    String fileName =
+        getOutputSourceFile(input.getBatchNumber(), repository.getName(), input.getFilePrefix());
+    smartlingPullLocaleFileJobInput.setRepositoryName(input.getRepositoryName());
+    smartlingPullLocaleFileJobInput.setLocaleId(locale.getId());
+    smartlingPullLocaleFileJobInput.setSmartlingFilePrefix(input.getFilePrefix());
+    smartlingPullLocaleFileJobInput.setFileName(fileName);
+    smartlingPullLocaleFileJobInput.setPluralSeparator(input.getPluralSeparator());
+    smartlingPullLocaleFileJobInput.setSmartlingLocale(
+        parseLocaleMapping(input.getLocaleMapping())
+            .getOrDefault(locale.getLocale().getBcp47Tag(), locale.getLocale().getBcp47Tag()));
+    smartlingPullLocaleFileJobInput.setDeltaPull(input.isDeltaPull());
+    smartlingPullLocaleFileJobInput.setPluralFixForLocale(
+        Optional.ofNullable(input.getPluralFixForLocale())
+            .orElse("")
+            .contains(locale.getLocale().getBcp47Tag()));
+    smartlingPullLocaleFileJobInput.setDryRun(input.isDryRun());
+    smartlingPullLocaleFileJobInput.setSmartlingProjectId(input.getProjectId());
+    smartlingPullLocaleFileJobInput.setLocaleBcp47Tag(locale.getLocale().getBcp47Tag());
+    QuartzJobInfo<SmartlingPullLocaleFileJobInput, Void> quartzJobInfo =
+        QuartzJobInfo.newBuilder(SmartlingPullLocaleFileJob.class)
+            .withInput(smartlingPullLocaleFileJobInput)
+            .withInlineInput(false)
+            .withScheduler(input.getSchedulerName())
+            .withParentId(getParentId())
+            .withMessage(
+                String.format(
+                    "Pulling file '%s' for locale %s", fileName, locale.getLocale().getBcp47Tag()))
+            .build();
+
+    quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
+  }
+
+  private Map<String, String> parseLocaleMapping(String input) {
+    return Optional.ofNullable(localeMappingHelper.getLocaleMapping(input))
+        .orElseGet(Collections::emptyMap);
+  }
+
+  protected long getParentId() {
+    return getCurrentPollableTask().getId();
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJobInput.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJobInput.java
@@ -1,0 +1,99 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.quartz;
+
+public class SmartlingPullBatchFileJobInput {
+
+  Long batchNumber;
+  String pluralSeparator;
+  String repositoryName;
+
+  String projectId;
+  boolean isDeltaPull;
+  String localeMapping;
+  String filePrefix;
+
+  String pluralFixForLocale;
+
+  String schedulerName;
+
+  boolean isDryRun;
+
+  public Long getBatchNumber() {
+    return batchNumber;
+  }
+
+  public void setBatchNumber(Long batchNumber) {
+    this.batchNumber = batchNumber;
+  }
+
+  public String getPluralSeparator() {
+    return pluralSeparator;
+  }
+
+  public void setPluralSeparator(String pluralSeparator) {
+    this.pluralSeparator = pluralSeparator;
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public void setProjectId(String projectId) {
+    this.projectId = projectId;
+  }
+
+  public String getRepositoryName() {
+    return repositoryName;
+  }
+
+  public void setRepositoryName(String repositoryName) {
+    this.repositoryName = repositoryName;
+  }
+
+  public boolean isDeltaPull() {
+    return isDeltaPull;
+  }
+
+  public void setDeltaPull(boolean deltaPull) {
+    isDeltaPull = deltaPull;
+  }
+
+  public String getLocaleMapping() {
+    return localeMapping;
+  }
+
+  public void setLocaleMapping(String localeMapping) {
+    this.localeMapping = localeMapping;
+  }
+
+  public String getFilePrefix() {
+    return filePrefix;
+  }
+
+  public void setFilePrefix(String filePrefix) {
+    this.filePrefix = filePrefix;
+  }
+
+  public String getPluralFixForLocale() {
+    return pluralFixForLocale;
+  }
+
+  public void setPluralFixForLocale(String pluralFixForLocale) {
+    this.pluralFixForLocale = pluralFixForLocale;
+  }
+
+  public boolean isDryRun() {
+    return isDryRun;
+  }
+
+  public void setDryRun(boolean dryRun) {
+    isDryRun = dryRun;
+  }
+
+  public String getSchedulerName() {
+    return schedulerName;
+  }
+
+  public void setSchedulerName(String schedulerName) {
+    this.schedulerName = schedulerName;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullLocaleFileJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullLocaleFileJob.java
@@ -1,0 +1,153 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.quartz;
+
+import static com.box.l10n.mojito.service.thirdparty.ThirdPartyTMSUtils.isFileEqualToPreviousRun;
+
+import com.box.l10n.mojito.LocaleMappingHelper;
+import com.box.l10n.mojito.android.strings.AndroidStringDocumentMapper;
+import com.box.l10n.mojito.android.strings.AndroidStringDocumentReader;
+import com.box.l10n.mojito.quartz.QuartzPollableJob;
+import com.box.l10n.mojito.service.locale.LocaleRepository;
+import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import com.box.l10n.mojito.service.thirdparty.ThirdPartyFileChecksumRepository;
+import com.box.l10n.mojito.service.thirdparty.smartling.SmartlingPluralFix;
+import com.box.l10n.mojito.service.tm.importer.TextUnitBatchImporterService;
+import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.box.l10n.mojito.smartling.SmartlingClient;
+import com.box.l10n.mojito.smartling.SmartlingClientException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import java.io.IOException;
+import java.util.List;
+import javax.xml.parsers.ParserConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.xml.sax.SAXException;
+import reactor.core.publisher.Mono;
+
+public class SmartlingPullLocaleFileJob
+    extends QuartzPollableJob<SmartlingPullLocaleFileJobInput, Void> {
+
+  static Logger logger = LoggerFactory.getLogger(SmartlingPullLocaleFileJob.class);
+
+  @Autowired MeterRegistry meterRegistry;
+
+  @Autowired ThirdPartyFileChecksumRepository thirdPartyFileChecksumRepository;
+
+  @Autowired TextUnitBatchImporterService textUnitBatchImporterService;
+
+  @Autowired RepositoryRepository repositoryRepository;
+
+  @Autowired LocaleRepository localeRepository;
+
+  @Autowired SmartlingClient smartlingClient;
+
+  @Autowired LocaleMappingHelper localeMappingHelper;
+
+  @Override
+  public Void call(SmartlingPullLocaleFileJobInput input) throws Exception {
+
+    meterRegistry
+        .timer(
+            "SmartlingSync.processPullBatch",
+            Tags.of(
+                "repository",
+                input.getRepositoryName(),
+                "locale",
+                input.getLocaleBcp47Tag(),
+                "deltaPull",
+                Boolean.toString(input.isDeltaPull())))
+        .record(
+            () -> {
+              String localeTag = input.getLocaleBcp47Tag();
+              String smartlingLocale = input.getSmartlingLocale();
+              String fileName = input.getFileName();
+              AndroidStringDocumentMapper mapper =
+                  new AndroidStringDocumentMapper(
+                      input.getPluralSeparator(), null, localeTag, input.getRepositoryName());
+
+              logger.debug(
+                  "Download localized file from Smartling for file: {}, Mojito locale: {} and Smartling locale: {}",
+                  fileName,
+                  localeTag,
+                  smartlingLocale);
+
+              String fileContent =
+                  Mono.fromCallable(
+                          () ->
+                              smartlingClient.downloadPublishedFile(
+                                  input.getSmartlingProjectId(), smartlingLocale, fileName, false))
+                      .retryWhen(
+                          smartlingClient
+                              .getRetryConfiguration()
+                              .doBeforeRetry(
+                                  e ->
+                                      logger.info(
+                                          String.format(
+                                              "Retrying after failure to download file %s",
+                                              fileName),
+                                          e.failure())))
+                      .doOnError(
+                          e -> {
+                            String msg =
+                                String.format(
+                                    "Error downloading file %s: %s", fileName, e.getMessage());
+                            logger.error(msg, e);
+                            throw new SmartlingClientException(msg, e);
+                          })
+                      .blockOptional()
+                      .orElseThrow(
+                          () ->
+                              new SmartlingClientException(
+                                  "Error with download from Smartling, file content string is not present."));
+
+              if (input.isDeltaPull()
+                  && matchesChecksumFromPreviousSync(input, localeTag, fileName, fileContent)) {
+                logger.info(
+                    "Checksum match for "
+                        + fileName
+                        + " in locale "
+                        + localeTag
+                        + ", skipping text unit import.");
+                return;
+              }
+
+              List<TextUnitDTO> textUnits;
+
+              try {
+                textUnits =
+                    mapper.mapToTextUnits(AndroidStringDocumentReader.fromText(fileContent));
+              } catch (ParserConfigurationException | IOException | SAXException e) {
+                String msg = "An error ocurred when processing a pull batch";
+                logger.error(msg, e);
+                throw new RuntimeException(msg, e);
+              }
+
+              if (!textUnits.isEmpty()
+                  && input.getSmartlingFilePrefix().equalsIgnoreCase("plural")
+                  && input.isPluralFixForLocale()) {
+                textUnits = SmartlingPluralFix.fixTextUnits(textUnits);
+              }
+
+              if (!input.isDryRun()) {
+                logger.debug("Importing text units for locale: {}", smartlingLocale);
+                textUnitBatchImporterService.importTextUnits(textUnits, false, true);
+              }
+            });
+    return null;
+  }
+
+  public boolean matchesChecksumFromPreviousSync(
+      SmartlingPullLocaleFileJobInput input,
+      String localeTag,
+      String fileName,
+      String fileContent) {
+    return isFileEqualToPreviousRun(
+        thirdPartyFileChecksumRepository,
+        repositoryRepository.findByName(input.getRepositoryName()),
+        localeRepository.findByBcp47Tag(localeTag),
+        fileName,
+        fileContent,
+        meterRegistry);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullLocaleFileJobInput.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullLocaleFileJobInput.java
@@ -1,0 +1,122 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.quartz;
+
+public class SmartlingPullLocaleFileJobInput {
+
+  String repositoryName;
+
+  long localeId;
+
+  String localeBcp47Tag;
+  String fileName;
+  String pluralSeparator;
+
+  String smartlingLocale;
+
+  String smartlingProjectId;
+
+  String smartlingFilePrefix;
+
+  boolean isDeltaPull;
+
+  boolean isPluralFixForLocale;
+
+  boolean isDryRun;
+
+  String schedulerName;
+
+  public String getSmartlingProjectId() {
+    return smartlingProjectId;
+  }
+
+  public void setSmartlingProjectId(String smartlingProjectId) {
+    this.smartlingProjectId = smartlingProjectId;
+  }
+
+  public String getSmartlingLocale() {
+    return smartlingLocale;
+  }
+
+  public void setSmartlingLocale(String smartlingLocale) {
+    this.smartlingLocale = smartlingLocale;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public void setFileName(String fileName) {
+    this.fileName = fileName;
+  }
+
+  public String getPluralSeparator() {
+    return pluralSeparator;
+  }
+
+  public void setPluralSeparator(String pluralSeparator) {
+    this.pluralSeparator = pluralSeparator;
+  }
+
+  public String getSmartlingFilePrefix() {
+    return smartlingFilePrefix;
+  }
+
+  public void setSmartlingFilePrefix(String smartlingFilePrefix) {
+    this.smartlingFilePrefix = smartlingFilePrefix;
+  }
+
+  public boolean isDeltaPull() {
+    return isDeltaPull;
+  }
+
+  public void setDeltaPull(boolean deltaPull) {
+    isDeltaPull = deltaPull;
+  }
+
+  public boolean isPluralFixForLocale() {
+    return isPluralFixForLocale;
+  }
+
+  public void setPluralFixForLocale(boolean pluralFixForLocale) {
+    isPluralFixForLocale = pluralFixForLocale;
+  }
+
+  public boolean isDryRun() {
+    return isDryRun;
+  }
+
+  public void setDryRun(boolean dryRun) {
+    isDryRun = dryRun;
+  }
+
+  public long getLocaleId() {
+    return localeId;
+  }
+
+  public void setLocaleId(long localeId) {
+    this.localeId = localeId;
+  }
+
+  public String getLocaleBcp47Tag() {
+    return localeBcp47Tag;
+  }
+
+  public void setLocaleBcp47Tag(String localeBcp47Tag) {
+    this.localeBcp47Tag = localeBcp47Tag;
+  }
+
+  public String getRepositoryName() {
+    return repositoryName;
+  }
+
+  public void setRepositoryName(String repositoryName) {
+    this.repositoryName = repositoryName;
+  }
+
+  public String getSchedulerName() {
+    return schedulerName;
+  }
+
+  public void setSchedulerName(String schedulerName) {
+    this.schedulerName = schedulerName;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullTranslationsJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullTranslationsJob.java
@@ -1,0 +1,66 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.quartz;
+
+import com.box.l10n.mojito.quartz.QuartzJobInfo;
+import com.box.l10n.mojito.quartz.QuartzPollableJob;
+import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
+import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import java.util.stream.LongStream;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class SmartlingPullTranslationsJob
+    extends QuartzPollableJob<SmartlingPullTranslationsJobInput, Void> {
+
+  @Autowired QuartzPollableTaskScheduler quartzPollableTaskScheduler;
+
+  @Autowired RepositoryRepository repositoryRepository;
+
+  @Override
+  public Void call(SmartlingPullTranslationsJobInput input) throws Exception {
+
+    LongStream.range(0, batchesFor(input.getSingularCount(), input.getBatchSize()))
+        .forEach(num -> schedulePullBatchFileJob(input, num, "singular"));
+
+    LongStream.range(0, batchesFor(input.getPluralCount(), input.getBatchSize()))
+        .forEach(num -> schedulePullBatchFileJob(input, num, "plural"));
+
+    return null;
+  }
+
+  private void schedulePullBatchFileJob(
+      SmartlingPullTranslationsJobInput input, long num, String filePrefix) {
+    QuartzJobInfo<SmartlingPullBatchFileJobInput, Void> quartzJobInfo =
+        QuartzJobInfo.newBuilder(SmartlingPullBatchFileJob.class)
+            .withInput(createPullBatchFileJobInput(num, filePrefix, input))
+            .withInlineInput(false)
+            .withScheduler(input.getSchedulerName())
+            .withParentId(getParentId())
+            .build();
+    quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
+  }
+
+  protected long getParentId() {
+    return getCurrentPollableTask().getId();
+  }
+
+  private SmartlingPullBatchFileJobInput createPullBatchFileJobInput(
+      long batchNumber, String filePrefix, SmartlingPullTranslationsJobInput input) {
+    SmartlingPullBatchFileJobInput smartlingPullBatchFileJobInput =
+        new SmartlingPullBatchFileJobInput();
+    smartlingPullBatchFileJobInput.setBatchNumber(batchNumber);
+    smartlingPullBatchFileJobInput.setFilePrefix(filePrefix);
+    smartlingPullBatchFileJobInput.setRepositoryName(input.getRepositoryName());
+    smartlingPullBatchFileJobInput.setPluralSeparator(input.getPluralSeparator());
+    smartlingPullBatchFileJobInput.setLocaleMapping(input.getLocaleMapping());
+    smartlingPullBatchFileJobInput.setDeltaPull(input.isDeltaPull());
+    smartlingPullBatchFileJobInput.setProjectId(input.getProjectId());
+    smartlingPullBatchFileJobInput.setPluralFixForLocale(input.getPluralFixForLocale());
+    smartlingPullBatchFileJobInput.setDryRun(input.isDryRun());
+    smartlingPullBatchFileJobInput.setSchedulerName(input.getSchedulerName());
+
+    return smartlingPullBatchFileJobInput;
+  }
+
+  private long batchesFor(long totalUnits, int batchSize) {
+    return totalUnits / batchSize + ((totalUnits % batchSize == 0) ? 0 : 1);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullTranslationsJobInput.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullTranslationsJobInput.java
@@ -1,0 +1,134 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.quartz;
+
+public class SmartlingPullTranslationsJobInput {
+
+  long singularCount;
+
+  long pluralCount;
+
+  String repositoryName;
+
+  String projectId;
+
+  boolean isDeltaPull;
+
+  String pluralFixForLocale;
+
+  boolean isDryRun;
+
+  String pluralSeparator;
+
+  String schedulerName;
+
+  String localeMapping;
+
+  int batchSize;
+
+  boolean isJsonSync;
+
+  boolean isGlossarySync;
+
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  public long getSingularCount() {
+    return singularCount;
+  }
+
+  public void setSingularCount(long singularCount) {
+    this.singularCount = singularCount;
+  }
+
+  public long getPluralCount() {
+    return pluralCount;
+  }
+
+  public void setPluralCount(long pluralCount) {
+    this.pluralCount = pluralCount;
+  }
+
+  public String getRepositoryName() {
+    return repositoryName;
+  }
+
+  public void setRepositoryName(String repositoryName) {
+    this.repositoryName = repositoryName;
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public void setProjectId(String projectId) {
+    this.projectId = projectId;
+  }
+
+  public boolean isDeltaPull() {
+    return isDeltaPull;
+  }
+
+  public void setDeltaPull(boolean deltaPull) {
+    isDeltaPull = deltaPull;
+  }
+
+  public String getPluralFixForLocale() {
+    return pluralFixForLocale;
+  }
+
+  public void setPluralFixForLocale(String pluralFixForLocale) {
+    this.pluralFixForLocale = pluralFixForLocale;
+  }
+
+  public boolean isDryRun() {
+    return isDryRun;
+  }
+
+  public void setDryRun(boolean dryRun) {
+    isDryRun = dryRun;
+  }
+
+  public String getPluralSeparator() {
+    return pluralSeparator;
+  }
+
+  public void setPluralSeparator(String pluralSeparator) {
+    this.pluralSeparator = pluralSeparator;
+  }
+
+  public String getSchedulerName() {
+    return schedulerName;
+  }
+
+  public void setSchedulerName(String schedulerName) {
+    this.schedulerName = schedulerName;
+  }
+
+  public String getLocaleMapping() {
+    return localeMapping;
+  }
+
+  public void setLocaleMapping(String localeMapping) {
+    this.localeMapping = localeMapping;
+  }
+
+  public boolean isJsonSync() {
+    return isJsonSync;
+  }
+
+  public void setJsonSync(boolean jsonSync) {
+    isJsonSync = jsonSync;
+  }
+
+  public boolean isGlossarySync() {
+    return isGlossarySync;
+  }
+
+  public void setGlossarySync(boolean glossarySync) {
+    isGlossarySync = glossarySync;
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.service.thirdparty;
 
 import static com.box.l10n.mojito.entity.Screenshot.Status.ACCEPTED;
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import com.box.l10n.mojito.LocaleMappingHelper;
 import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.AssetContent;
+import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.Screenshot;
 import com.box.l10n.mojito.entity.ScreenshotRun;
@@ -651,6 +653,8 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
     thirdPartySync.setSkipAssetsWithPathPattern("asset_path_pattern");
     thirdPartySync.setOptions(Arrays.asList("option1=value1", "option2=value2"));
     ArgumentCaptor<Repository> repoCaptor = ArgumentCaptor.forClass(Repository.class);
+    ArgumentCaptor<PollableTask> pollableTaskArgumentCaptor =
+        ArgumentCaptor.forClass(PollableTask.class);
 
     thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(thirdPartySync).get();
 
@@ -662,11 +666,14 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
             localeMappingArgumentCaptor.capture(),
             eq("text_unit_pattern"),
             eq("asset_path_pattern"),
-            optionsArgumentCaptor.capture());
+            optionsArgumentCaptor.capture(),
+            eq(DEFAULT_SCHEDULER_NAME),
+            pollableTaskArgumentCaptor.capture());
 
     assertThat(repoCaptor.getValue().getId()).isEqualTo(repository.getId());
     assertThat(localeMappingArgumentCaptor.getValue()).contains(entry("ja-JP", "ja"));
     assertThat(optionsArgumentCaptor.getValue()).contains("option1=value1", "option2=value2");
+    assertThat(pollableTaskArgumentCaptor.getValue()).isNotNull();
   }
 
   @Test
@@ -686,6 +693,8 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
     thirdPartySync.setSkipAssetsWithPathPattern("asset_path_pattern");
     thirdPartySync.setOptions(Arrays.asList("option1=value1", "option2=value2"));
     ArgumentCaptor<Repository> repoCaptor = ArgumentCaptor.forClass(Repository.class);
+    ArgumentCaptor<PollableTask> pollableTaskArgumentCaptor =
+        ArgumentCaptor.forClass(PollableTask.class);
 
     thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(thirdPartySync).get();
 
@@ -697,11 +706,14 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
             localeMappingArgumentCaptor.capture(),
             eq("text_unit_pattern"),
             eq("asset_path_pattern"),
-            optionsArgumentCaptor.capture());
+            optionsArgumentCaptor.capture(),
+            eq(DEFAULT_SCHEDULER_NAME),
+            pollableTaskArgumentCaptor.capture());
 
     assertThat(repoCaptor.getValue().getId()).isEqualTo(repository.getId());
     assertThat(localeMappingArgumentCaptor.getValue()).contains(entry("ja-JP", "ja"));
     assertThat(optionsArgumentCaptor.getValue()).contains("option1=value1", "option2=value2");
+    assertThat(pollableTaskArgumentCaptor.getValue()).isNotNull();
   }
 
   @Test

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJobTest.java
@@ -1,0 +1,187 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.quartz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.box.l10n.mojito.LocaleMappingHelper;
+import com.box.l10n.mojito.entity.Locale;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.quartz.QuartzJobInfo;
+import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
+import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import com.box.l10n.mojito.service.repository.RepositoryService;
+import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+public class SmartlingPullBatchFileJobTest {
+
+  @Mock QuartzPollableTaskScheduler quartzPollableTaskSchedulerMock;
+
+  @Mock RepositoryRepository repositoryRepositoryMock;
+
+  @Mock Repository repositoryMock;
+
+  @Mock RepositoryService repositoryServiceMock;
+
+  @Captor ArgumentCaptor<QuartzJobInfo<SmartlingPullLocaleFileJobInput, Void>> quartzJobInfoCaptor;
+
+  @Spy SmartlingPullBatchFileJob smartlingPullBatchFileJob = new SmartlingPullBatchFileJob();
+
+  RepositoryLocale enRepoLocale;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    doReturn(1L).when(smartlingPullBatchFileJob).getParentId();
+    smartlingPullBatchFileJob.quartzPollableTaskScheduler = quartzPollableTaskSchedulerMock;
+    smartlingPullBatchFileJob.repositoryRepository = repositoryRepositoryMock;
+    smartlingPullBatchFileJob.localeMappingHelper = new LocaleMappingHelper();
+    smartlingPullBatchFileJob.repositoryService = repositoryServiceMock;
+    when(repositoryRepositoryMock.findByName("testRepo")).thenReturn(repositoryMock);
+    when(repositoryMock.getName()).thenReturn("testRepo");
+    Locale english = new Locale();
+    english.setBcp47Tag("en");
+    enRepoLocale = new RepositoryLocale();
+    enRepoLocale.setLocale(english);
+    enRepoLocale.setId(1L);
+    Locale french = new Locale();
+    french.setBcp47Tag("fr");
+    RepositoryLocale frRepoLocale = new RepositoryLocale();
+    frRepoLocale.setLocale(french);
+    frRepoLocale.setId(2L);
+    Locale gaelic = new Locale();
+    gaelic.setBcp47Tag("ga");
+    RepositoryLocale gaRepoLocale = new RepositoryLocale();
+    gaRepoLocale.setLocale(gaelic);
+    gaRepoLocale.setId(3L);
+    frRepoLocale.setParentLocale(enRepoLocale);
+    gaRepoLocale.setParentLocale(enRepoLocale);
+    when(repositoryServiceMock.getRepositoryLocalesWithoutRootLocale(isA(Repository.class)))
+        .thenReturn(Collections.unmodifiableSet(Sets.newHashSet(frRepoLocale, gaRepoLocale)));
+    when(repositoryMock.getRepositoryLocales())
+        .thenReturn(
+            Collections.unmodifiableSet(Sets.newHashSet(enRepoLocale, frRepoLocale, gaRepoLocale)));
+  }
+
+  @Test
+  public void testPullLocaleFileJobsAreScheduled() throws Exception {
+    SmartlingPullBatchFileJobInput jobInput = new SmartlingPullBatchFileJobInput();
+    jobInput.setBatchNumber(1L);
+    jobInput.setDeltaPull(false);
+    jobInput.setFilePrefix("singular");
+    jobInput.setDryRun(false);
+    jobInput.setRepositoryName("testRepo");
+    jobInput.setProjectId("testProjectId");
+    jobInput.setSchedulerName("customScheduler");
+
+    smartlingPullBatchFileJob.call(jobInput);
+
+    // Total repo locales is 3 but translations should not be pulled for source locale, so we expect
+    // 2 calls here
+    verify(quartzPollableTaskSchedulerMock, times(2)).scheduleJob(quartzJobInfoCaptor.capture());
+
+    List<QuartzJobInfo<SmartlingPullLocaleFileJobInput, Void>> quartzJobInfos =
+        quartzJobInfoCaptor.getAllValues();
+    assertThat(quartzJobInfos.stream().filter(q -> q.getParentId() == 1L).count()).isEqualTo(2);
+
+    assertThat(quartzJobInfos.stream().map(QuartzJobInfo::getInput))
+        .extracting(
+            "repositoryName",
+            "localeId",
+            "smartlingFilePrefix",
+            "fileName",
+            "pluralSeparator",
+            "smartlingLocale",
+            "deltaPull",
+            "pluralFixForLocale",
+            "dryRun",
+            "smartlingProjectId",
+            "localeBcp47Tag",
+            "smartlingLocale")
+        .containsExactlyInAnyOrder(
+            tuple(
+                "testRepo",
+                2L,
+                "singular",
+                "testRepo/00001_singular_source.xml",
+                null,
+                "fr",
+                false,
+                false,
+                false,
+                "testProjectId",
+                "fr",
+                "fr"),
+            tuple(
+                "testRepo",
+                3L,
+                "singular",
+                "testRepo/00001_singular_source.xml",
+                null,
+                "ga",
+                false,
+                false,
+                false,
+                "testProjectId",
+                "ga",
+                "ga"));
+  }
+
+  @Test
+  public void testNoJobsScheduledIfOnlyParentLocaleExists() throws Exception {
+    when(repositoryMock.getRepositoryLocales())
+        .thenReturn(Collections.unmodifiableSet(Sets.newHashSet(enRepoLocale)));
+    when(repositoryServiceMock.getRepositoryLocalesWithoutRootLocale(isA(Repository.class)))
+        .thenReturn(Collections.emptySet());
+
+    SmartlingPullBatchFileJobInput jobInput = new SmartlingPullBatchFileJobInput();
+    jobInput.setBatchNumber(1L);
+    jobInput.setDeltaPull(false);
+    jobInput.setFilePrefix("singular");
+    jobInput.setDryRun(false);
+    jobInput.setRepositoryName("testRepo");
+    jobInput.setProjectId("testProjectId");
+
+    smartlingPullBatchFileJob.call(jobInput);
+
+    verify(quartzPollableTaskSchedulerMock, times(0)).scheduleJob(quartzJobInfoCaptor.capture());
+  }
+
+  @Test
+  public void testLocaleMapping() throws Exception {
+    SmartlingPullBatchFileJobInput jobInput = new SmartlingPullBatchFileJobInput();
+    jobInput.setBatchNumber(1L);
+    jobInput.setDeltaPull(false);
+    jobInput.setFilePrefix("singular");
+    jobInput.setDryRun(false);
+    jobInput.setRepositoryName("testRepo");
+    jobInput.setProjectId("testProjectId");
+    jobInput.setLocaleMapping("fr:fr-CA");
+
+    smartlingPullBatchFileJob.call(jobInput);
+
+    verify(quartzPollableTaskSchedulerMock, times(2)).scheduleJob(quartzJobInfoCaptor.capture());
+
+    List<QuartzJobInfo<SmartlingPullLocaleFileJobInput, Void>> quartzJobInfos =
+        quartzJobInfoCaptor.getAllValues();
+    assertThat(quartzJobInfos.stream().filter(q -> q.getParentId() == 1L).count()).isEqualTo(2);
+
+    assertThat(quartzJobInfos.stream().map(QuartzJobInfo::getInput))
+        .extracting("smartlingLocale")
+        .containsExactlyInAnyOrder("ga", "fr-CA");
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullLocaleFileJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullLocaleFileJobTest.java
@@ -1,0 +1,419 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.quartz;
+
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.box.l10n.mojito.entity.Locale;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.ThirdPartyFileChecksum;
+import com.box.l10n.mojito.service.locale.LocaleRepository;
+import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import com.box.l10n.mojito.service.thirdparty.ThirdPartyFileChecksumRepository;
+import com.box.l10n.mojito.service.tm.importer.TextUnitBatchImporterService;
+import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.box.l10n.mojito.smartling.SmartlingClient;
+import com.box.l10n.mojito.smartling.SmartlingClientException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException;
+import reactor.util.retry.Retry;
+import reactor.util.retry.RetryBackoffSpec;
+
+public class SmartlingPullLocaleFileJobTest {
+
+  @Mock SmartlingClient smartlingClientMock;
+
+  @Mock TextUnitBatchImporterService textUnitBatchImporterServiceMock;
+
+  @Mock ThirdPartyFileChecksumRepository thirdPartyFileChecksumRepositoryMock;
+
+  @Mock RepositoryRepository repositoryRepositoryMock;
+
+  @Mock LocaleRepository localeRepositoryMock;
+
+  @Captor ArgumentCaptor<List<TextUnitDTO>> textUnitListCaptor;
+
+  SmartlingPullLocaleFileJob smartlingPullLocaleFileJob;
+
+  SmartlingPullLocaleFileJobInput smartlingPullLocaleFileJobInput;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+
+    doReturn(null)
+        .when(smartlingClientMock)
+        .uploadFile(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString());
+    doReturn(null)
+        .when(smartlingClientMock)
+        .uploadLocalizedFile(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString());
+    doReturn(null)
+        .when(textUnitBatchImporterServiceMock)
+        .importTextUnits(any(), eq(false), eq(true));
+
+    RetryBackoffSpec retryConfiguration =
+        Retry.backoff(10, Duration.ofMillis(1)).maxBackoff(Duration.ofMillis(10));
+    when(smartlingClientMock.getRetryConfiguration()).thenReturn(retryConfiguration);
+
+    smartlingPullLocaleFileJobInput = new SmartlingPullLocaleFileJobInput();
+    smartlingPullLocaleFileJobInput.setRepositoryName("testRepo");
+    smartlingPullLocaleFileJobInput.setLocaleBcp47Tag("fr-CA");
+    smartlingPullLocaleFileJobInput.setSmartlingLocale("fr-CA");
+    smartlingPullLocaleFileJobInput.setFileName("testFile");
+    smartlingPullLocaleFileJobInput.setDeltaPull(false);
+    smartlingPullLocaleFileJobInput.setDryRun(false);
+    smartlingPullLocaleFileJobInput.setSmartlingFilePrefix("singular");
+    smartlingPullLocaleFileJobInput.setSmartlingProjectId("testProjectId");
+    smartlingPullLocaleFileJobInput.setLocaleId(1);
+    smartlingPullLocaleFileJobInput.setSchedulerName(DEFAULT_SCHEDULER_NAME);
+    smartlingPullLocaleFileJobInput.setPluralSeparator(" _");
+
+    smartlingPullLocaleFileJob = new SmartlingPullLocaleFileJob();
+    smartlingPullLocaleFileJob.smartlingClient = smartlingClientMock;
+    smartlingPullLocaleFileJob.repositoryRepository = repositoryRepositoryMock;
+    smartlingPullLocaleFileJob.localeRepository = localeRepositoryMock;
+    smartlingPullLocaleFileJob.textUnitBatchImporterService = textUnitBatchImporterServiceMock;
+    smartlingPullLocaleFileJob.thirdPartyFileChecksumRepository =
+        thirdPartyFileChecksumRepositoryMock;
+    smartlingPullLocaleFileJob.meterRegistry = new SimpleMeterRegistry();
+  }
+
+  @Test
+  public void testPullSingular() throws Exception {
+
+    String pullResponse =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><resources>\n"
+            + "<!--comment 1-->\n"
+            + "<string name=\"src/main/res/values/strings.xml#@#hello\" tmTextUnitId=\"1\">Hello in fr-CA</string>\n"
+            + "<!--comment 2-->\n"
+            + "<string name=\"src/main/res/values/strings.xml#@#bye\" tmTextUnitId=\"2\">Bye in fr-CA</string>\n"
+            + "</resources>\n";
+
+    doReturn(pullResponse)
+        .when(smartlingClientMock)
+        .downloadPublishedFile(eq("testProjectId"), eq("fr-CA"), eq("testFile"), eq(false));
+
+    smartlingPullLocaleFileJob.call(smartlingPullLocaleFileJobInput);
+
+    verify(textUnitBatchImporterServiceMock, times(1))
+        .importTextUnits(textUnitListCaptor.capture(), eq(false), eq(true));
+
+    List<TextUnitDTO> captured = textUnitListCaptor.getValue();
+
+    assertThat(captured).hasSize(2);
+    assertThat(captured)
+        .extracting(
+            "name",
+            "comment",
+            "target",
+            "assetPath",
+            "targetLocale",
+            "repositoryName",
+            "pluralForm")
+        .containsExactlyInAnyOrder(
+            tuple(
+                "hello",
+                "comment 1",
+                "Hello in fr-CA",
+                "src/main/res/values/strings.xml",
+                "fr-CA",
+                "testRepo",
+                null),
+            tuple(
+                "bye",
+                "comment 2",
+                "Bye in fr-CA",
+                "src/main/res/values/strings.xml",
+                "fr-CA",
+                "testRepo",
+                null));
+  }
+
+  @Test
+  public void testPullPlural() throws Exception {
+
+    smartlingPullLocaleFileJobInput.setSmartlingFilePrefix("plural");
+
+    String pullResponse =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><resources>\n"
+            + "<plurals name=\"src/main/res/values/strings.xml#@#plural_things\">\n"
+            + "<item quantity=\"one\">One thing in fr-CA</item>\n"
+            + "<item quantity=\"few\">Few things in fr-CA</item>\n"
+            + "<item quantity=\"other\">Other things in fr-CA</item>\n"
+            + "</plurals>\n"
+            + "</resources>\n";
+
+    doReturn(pullResponse)
+        .when(smartlingClientMock)
+        .downloadPublishedFile(eq("testProjectId"), eq("fr-CA"), eq("testFile"), eq(false));
+
+    smartlingPullLocaleFileJob.call(smartlingPullLocaleFileJobInput);
+
+    verify(textUnitBatchImporterServiceMock, times(1))
+        .importTextUnits(textUnitListCaptor.capture(), eq(false), eq(true));
+
+    List<TextUnitDTO> captured = textUnitListCaptor.getValue();
+
+    assertThat(captured).hasSize(3);
+    assertThat(captured)
+        .extracting(
+            "name",
+            "comment",
+            "target",
+            "assetPath",
+            "targetLocale",
+            "repositoryName",
+            "pluralForm")
+        .containsExactlyInAnyOrder(
+            tuple(
+                "plural_things _one",
+                null,
+                "One thing in fr-CA",
+                "src/main/res/values/strings.xml",
+                "fr-CA",
+                "testRepo",
+                "one"),
+            tuple(
+                "plural_things _few",
+                null,
+                "Few things in fr-CA",
+                "src/main/res/values/strings.xml",
+                "fr-CA",
+                "testRepo",
+                "few"),
+            tuple(
+                "plural_things _other",
+                null,
+                "Other things in fr-CA",
+                "src/main/res/values/strings.xml",
+                "fr-CA",
+                "testRepo",
+                "other"));
+  }
+
+  @Test
+  public void testPullPluralsFix() throws Exception {
+
+    smartlingPullLocaleFileJobInput.setPluralFixForLocale(true);
+    smartlingPullLocaleFileJobInput.setLocaleBcp47Tag("ja-JP");
+    smartlingPullLocaleFileJobInput.setSmartlingLocale("ja-JP");
+    smartlingPullLocaleFileJobInput.setSmartlingFilePrefix("plural");
+
+    String pullResponse =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><resources>\n"
+            + "<plurals name=\"src/main/res/values/strings.xml#@#plural_things\">\n"
+            + "<item quantity=\"one\">One thing in ja-JP</item>\n"
+            + "<item quantity=\"few\">Few things in ja-JP</item>\n"
+            + "<item quantity=\"other\">Other things in ja-JP</item>\n"
+            + "</plurals>\n"
+            + "</resources>\n";
+
+    doReturn(pullResponse)
+        .when(smartlingClientMock)
+        .downloadPublishedFile(eq("testProjectId"), eq("ja-JP"), eq("testFile"), eq(false));
+
+    smartlingPullLocaleFileJob.call(smartlingPullLocaleFileJobInput);
+
+    verify(textUnitBatchImporterServiceMock, times(1))
+        .importTextUnits(textUnitListCaptor.capture(), eq(false), eq(true));
+
+    List<TextUnitDTO> captured = textUnitListCaptor.getValue();
+
+    assertThat(captured).hasSize(4);
+    assertThat(captured)
+        .extracting(
+            "name",
+            "comment",
+            "target",
+            "assetPath",
+            "targetLocale",
+            "repositoryName",
+            "pluralForm")
+        .containsExactlyInAnyOrder(
+            tuple(
+                "plural_things _one",
+                null,
+                "One thing in ja-JP",
+                "src/main/res/values/strings.xml",
+                "ja-JP",
+                "testRepo",
+                "one"),
+            tuple(
+                "plural_things _few",
+                null,
+                "Few things in ja-JP",
+                "src/main/res/values/strings.xml",
+                "ja-JP",
+                "testRepo",
+                "few"),
+            tuple(
+                "plural_things _other",
+                null,
+                "Other things in ja-JP",
+                "src/main/res/values/strings.xml",
+                "ja-JP",
+                "testRepo",
+                "other"),
+            tuple(
+                "plural_things _many",
+                null,
+                "Other things in ja-JP",
+                "src/main/res/values/strings.xml",
+                "ja-JP",
+                "testRepo",
+                "many"));
+  }
+
+  @Test
+  public void testPullDryRun() throws Exception {
+
+    smartlingPullLocaleFileJobInput.setDryRun(true);
+    String pullResponse =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><resources>\n"
+            + "<!--comment 1-->\n"
+            + "<string name=\"src/main/res/values/strings.xml#@#hello\" tmTextUnitId=\"1\">Hello in fr-CA</string>\n"
+            + "<!--comment 2-->\n"
+            + "<string name=\"src/main/res/values/strings.xml#@#bye\" tmTextUnitId=\"2\">Bye in fr-CA</string>\n"
+            + "</resources>\n";
+
+    doReturn(pullResponse)
+        .when(smartlingClientMock)
+        .downloadPublishedFile(eq("testProjectId"), eq("fr-CA"), eq("testFile"), eq(false));
+
+    smartlingPullLocaleFileJob.call(smartlingPullLocaleFileJobInput);
+
+    verify(textUnitBatchImporterServiceMock, times(0))
+        .importTextUnits(textUnitListCaptor.capture(), eq(false), eq(true));
+  }
+
+  @Test(expected = SmartlingClientException.class)
+  public void testRetriesExhaustedDuringPull() throws Exception {
+
+    doThrow(new SmartlingClientException(new HttpServerErrorException(HttpStatus.GATEWAY_TIMEOUT)))
+        .when(smartlingClientMock)
+        .downloadPublishedFile(anyString(), anyString(), anyString(), anyBoolean());
+
+    smartlingPullLocaleFileJob.call(smartlingPullLocaleFileJobInput);
+  }
+
+  @Test
+  public void testPullShortCircuitIfNoChanges() throws Exception {
+
+    String pullResponse =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><resources>\n"
+            + "<!--comment 1-->\n"
+            + "<string name=\"src/main/res/values/strings.xml#@#hello\" tmTextUnitId=\"1\">Hello in fr-CA</string>\n"
+            + "<!--comment 2-->\n"
+            + "<string name=\"src/main/res/values/strings.xml#@#bye\" tmTextUnitId=\"2\">Bye in fr-CA</string>\n"
+            + "</resources>\n";
+
+    ThirdPartyFileChecksum existingChecksum = new ThirdPartyFileChecksum();
+    existingChecksum.setMd5(DigestUtils.md5Hex(pullResponse.getBytes(StandardCharsets.UTF_8)));
+
+    Repository testRepo = new Repository();
+    testRepo.setId(1L);
+    testRepo.setName("testRepo");
+
+    Locale frCA = new Locale();
+    frCA.setBcp47Tag("fr-CA");
+    frCA.setId(1L);
+
+    when(repositoryRepositoryMock.findByName(isA(String.class))).thenReturn(testRepo);
+    when(localeRepositoryMock.findByBcp47Tag(isA(String.class))).thenReturn(frCA);
+
+    when(thirdPartyFileChecksumRepositoryMock.findByRepositoryAndFileNameAndLocale(
+            isA(Repository.class), isA(String.class), isA(Locale.class)))
+        .thenReturn(Optional.of(existingChecksum));
+
+    smartlingPullLocaleFileJobInput.setDeltaPull(true);
+
+    doReturn(pullResponse)
+        .when(smartlingClientMock)
+        .downloadPublishedFile(eq("testProjectId"), eq("fr-CA"), eq("testFile"), eq(false));
+
+    smartlingPullLocaleFileJob.call(smartlingPullLocaleFileJobInput);
+
+    verify(textUnitBatchImporterServiceMock, times(0))
+        .importTextUnits(textUnitListCaptor.capture(), eq(false), eq(true));
+
+    verify(thirdPartyFileChecksumRepositoryMock, times(0)).save(any(ThirdPartyFileChecksum.class));
+  }
+
+  @Test
+  public void testPullShortCircuitIfChanges() throws Exception {
+    ThirdPartyFileChecksum existingChecksum = new ThirdPartyFileChecksum();
+    existingChecksum.setMd5("existingChecksum");
+
+    Repository testRepo = new Repository();
+    testRepo.setId(1L);
+    testRepo.setName("testRepo");
+
+    Locale frCA = new Locale();
+    frCA.setBcp47Tag("fr-CA");
+    frCA.setId(1L);
+
+    when(repositoryRepositoryMock.findByName(isA(String.class))).thenReturn(testRepo);
+    when(localeRepositoryMock.findByBcp47Tag(isA(String.class))).thenReturn(frCA);
+
+    when(thirdPartyFileChecksumRepositoryMock.findByRepositoryAndFileNameAndLocale(
+            isA(Repository.class), isA(String.class), isA(Locale.class)))
+        .thenReturn(Optional.of(existingChecksum));
+
+    smartlingPullLocaleFileJobInput.setDeltaPull(true);
+
+    String pullResponse =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><resources>\n"
+            + "<!--comment 1-->\n"
+            + "<string name=\"src/main/res/values/strings.xml#@#hello\" tmTextUnitId=\"1\">Hello in fr-CA</string>\n"
+            + "<!--comment 2-->\n"
+            + "<string name=\"src/main/res/values/strings.xml#@#bye\" tmTextUnitId=\"2\">Bye in fr-CA</string>\n"
+            + "</resources>\n";
+
+    doReturn(pullResponse)
+        .when(smartlingClientMock)
+        .downloadPublishedFile(eq("testProjectId"), eq("fr-CA"), eq("testFile"), eq(false));
+
+    smartlingPullLocaleFileJob.call(smartlingPullLocaleFileJobInput);
+
+    verify(textUnitBatchImporterServiceMock, times(1))
+        .importTextUnits(textUnitListCaptor.capture(), eq(false), eq(true));
+
+    verify(thirdPartyFileChecksumRepositoryMock, times(1)).save(any(ThirdPartyFileChecksum.class));
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullTranslationsJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullTranslationsJobTest.java
@@ -1,0 +1,213 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.quartz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.box.l10n.mojito.quartz.QuartzJobInfo;
+import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
+import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+public class SmartlingPullTranslationsJobTest {
+
+  @Mock QuartzPollableTaskScheduler quartzPollableTaskSchedulerMock;
+
+  @Mock RepositoryRepository repositoryRepositoryMock;
+
+  @Captor ArgumentCaptor<QuartzJobInfo<SmartlingPullBatchFileJobInput, Void>> quartzJobInfoCaptor;
+
+  @Spy
+  SmartlingPullTranslationsJob smartlingPullTranslationsJob = new SmartlingPullTranslationsJob();
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    doReturn(1L).when(smartlingPullTranslationsJob).getParentId();
+    smartlingPullTranslationsJob.quartzPollableTaskScheduler = quartzPollableTaskSchedulerMock;
+    smartlingPullTranslationsJob.repositoryRepository = repositoryRepositoryMock;
+  }
+
+  @Test
+  public void testBatchFileJobsAreScheduled() throws Exception {
+    SmartlingPullTranslationsJobInput jobInput = new SmartlingPullTranslationsJobInput();
+    jobInput.setSingularCount(1);
+    jobInput.setPluralCount(1);
+    jobInput.setRepositoryName("testRepo");
+    jobInput.setProjectId("testProjectId");
+    jobInput.setSchedulerName("customScheduler");
+    jobInput.setLocaleMapping("fr:fr-CA");
+    jobInput.setBatchSize(10);
+    jobInput.setPluralFixForLocale("ja-JP");
+    jobInput.setDeltaPull(false);
+
+    smartlingPullTranslationsJob.call(jobInput);
+
+    verify(quartzPollableTaskSchedulerMock, times(2)).scheduleJob(quartzJobInfoCaptor.capture());
+    List<QuartzJobInfo<SmartlingPullBatchFileJobInput, Void>> quartzJobInfos =
+        quartzJobInfoCaptor.getAllValues();
+    assertThat(quartzJobInfos.stream().filter(q -> q.getParentId() != 1L).count()).isEqualTo(0);
+    assertThat(quartzJobInfos.stream().map(QuartzJobInfo::getInput))
+        .extracting(
+            "batchNumber",
+            "projectId",
+            "isDeltaPull",
+            "filePrefix",
+            "repositoryName",
+            "pluralFixForLocale",
+            "localeMapping")
+        .containsExactlyInAnyOrder(
+            tuple(0L, "testProjectId", false, "singular", "testRepo", "ja-JP", "fr:fr-CA"),
+            tuple(0L, "testProjectId", false, "plural", "testRepo", "ja-JP", "fr:fr-CA"));
+  }
+
+  @Test
+  public void testMultipleBatchFileJobsAreScheduled() throws Exception {
+    SmartlingPullTranslationsJobInput jobInput = new SmartlingPullTranslationsJobInput();
+    jobInput.setSingularCount(100);
+    jobInput.setPluralCount(100);
+    jobInput.setRepositoryName("testRepo");
+    jobInput.setProjectId("testProjectId");
+    jobInput.setSchedulerName("customScheduler");
+    jobInput.setBatchSize(20);
+    jobInput.setPluralFixForLocale("ja-JP");
+    jobInput.setLocaleMapping("fr:fr-CA");
+    jobInput.setDeltaPull(false);
+    jobInput.setSchedulerName("customScheduler");
+
+    smartlingPullTranslationsJob.call(jobInput);
+
+    verify(quartzPollableTaskSchedulerMock, times(10)).scheduleJob(quartzJobInfoCaptor.capture());
+    List<QuartzJobInfo<SmartlingPullBatchFileJobInput, Void>> quartzJobInfos =
+        quartzJobInfoCaptor.getAllValues();
+    assertThat(quartzJobInfos.stream().filter(q -> q.getParentId() != 1L).count()).isEqualTo(0);
+    assertThat(quartzJobInfos.stream().map(QuartzJobInfo::getInput))
+        .extracting(
+            "batchNumber",
+            "projectId",
+            "isDeltaPull",
+            "filePrefix",
+            "repositoryName",
+            "pluralFixForLocale",
+            "localeMapping",
+            "schedulerName")
+        .containsExactlyInAnyOrder(
+            tuple(
+                0L,
+                "testProjectId",
+                false,
+                "singular",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"),
+            tuple(
+                1L,
+                "testProjectId",
+                false,
+                "singular",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"),
+            tuple(
+                2L,
+                "testProjectId",
+                false,
+                "singular",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"),
+            tuple(
+                3L,
+                "testProjectId",
+                false,
+                "singular",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"),
+            tuple(
+                4L,
+                "testProjectId",
+                false,
+                "singular",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"),
+            tuple(
+                0L,
+                "testProjectId",
+                false,
+                "plural",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"),
+            tuple(
+                1L,
+                "testProjectId",
+                false,
+                "plural",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"),
+            tuple(
+                2L,
+                "testProjectId",
+                false,
+                "plural",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"),
+            tuple(
+                3L,
+                "testProjectId",
+                false,
+                "plural",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"),
+            tuple(
+                4L,
+                "testProjectId",
+                false,
+                "plural",
+                "testRepo",
+                "ja-JP",
+                "fr:fr-CA",
+                "customScheduler"));
+  }
+
+  @Test
+  public void testNoBatchJobsIfNoTextUnitsExist() throws Exception {
+    SmartlingPullTranslationsJobInput jobInput = new SmartlingPullTranslationsJobInput();
+    jobInput.setSingularCount(0);
+    jobInput.setPluralCount(0);
+    jobInput.setRepositoryName("testRepo");
+    jobInput.setProjectId("testProjectId");
+    jobInput.setSchedulerName("customScheduler");
+    jobInput.setBatchSize(20);
+    jobInput.setPluralFixForLocale("ja-JP");
+    jobInput.setLocaleMapping("fr:fr-CA");
+    jobInput.setDeltaPull(false);
+
+    smartlingPullTranslationsJob.call(jobInput);
+
+    verify(quartzPollableTaskSchedulerMock, times(0)).scheduleJob(quartzJobInfoCaptor.capture());
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/utils/PollableTaskJobMatcher.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/utils/PollableTaskJobMatcher.java
@@ -1,0 +1,21 @@
+package com.box.l10n.mojito.utils;
+
+import static com.box.l10n.mojito.quartz.QuartzConfig.DYNAMIC_GROUP_NAME;
+
+import com.box.l10n.mojito.quartz.QuartzPollableJob;
+import org.quartz.JobKey;
+import org.quartz.Matcher;
+
+public class PollableTaskJobMatcher<T extends QuartzPollableJob<?, ?>> implements Matcher<JobKey> {
+
+  private final Class<T> target;
+
+  public PollableTaskJobMatcher(Class<T> target) {
+    this.target = target;
+  }
+
+  @Override
+  public boolean isMatch(JobKey key) {
+    return key.getName().startsWith(target.getName()) && DYNAMIC_GROUP_NAME.equals(key.getGroup());
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/utils/TestingJobListener.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/utils/TestingJobListener.java
@@ -1,0 +1,79 @@
+package com.box.l10n.mojito.utils;
+
+import static com.box.l10n.mojito.quartz.QuartzPollableJob.INPUT;
+
+import com.box.l10n.mojito.json.ObjectMapper;
+import java.util.LinkedList;
+import java.util.Queue;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobListener;
+
+public class TestingJobListener implements JobListener {
+
+  private static int executionCount = 0;
+
+  private final Queue<JobExecutionContext> toBeExecuted = new LinkedList<>();
+  private final Queue<JobExecutionContext> executed = new LinkedList<>();
+  private final Queue<JobExecutionException> exceptions = new LinkedList<>();
+  private final ObjectMapper objectMapper;
+
+  public TestingJobListener(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public TestingJobListener() {
+    this.objectMapper = new ObjectMapper();
+  }
+
+  @Override
+  public String getName() {
+    return "TestingJobListener";
+  }
+
+  @Override
+  public void jobToBeExecuted(JobExecutionContext context) {
+    toBeExecuted.offer(context);
+  }
+
+  @Override
+  public void jobExecutionVetoed(JobExecutionContext context) {}
+
+  @Override
+  public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+    executed.offer(context);
+    exceptions.offer(jobException);
+    incrementExecutionCount();
+  }
+
+  public Queue<JobExecutionContext> getExecuted() {
+    return executed;
+  }
+
+  public int getExecutionCount() {
+    return executionCount;
+  }
+
+  private synchronized void incrementExecutionCount() {
+    executionCount++;
+  }
+
+  public synchronized void resetExecutionCount() {
+    executionCount = 0;
+  }
+
+  public Queue<JobExecutionContext> getToBeExecuted() {
+    return toBeExecuted;
+  }
+
+  public <T> T getFirstInputMapAs(Class<T> klass) {
+    String input =
+        getExecuted().stream()
+            .filter(context -> context.getMergedJobDataMap().containsKey(INPUT))
+            .map(context -> context.getMergedJobDataMap().getString(INPUT))
+            .findFirst()
+            .orElse("");
+
+    return objectMapper.readValueUnchecked(input, klass);
+  }
+}


### PR DESCRIPTION
Splits the third party Smartling pull into separate child jobs that can be processed in parallel across nodes in a worker cluster.