### PR TITLE
Fixes empty string breaks locale mapping

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJob.java
@@ -10,6 +10,7 @@ import com.box.l10n.mojito.quartz.QuartzPollableJob;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.repository.RepositoryService;
+import com.google.common.base.Strings;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collections;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class SmartlingPullBatchFileJob
   }
 
   private Map<String, String> parseLocaleMapping(String input) {
-    return Optional.ofNullable(localeMappingHelper.getLocaleMapping(input))
+    return Optional.ofNullable(localeMappingHelper.getLocaleMapping(Strings.emptyToNull(input)))
         .orElseGet(Collections::emptyMap);
   }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/quartz/SmartlingPullBatchFileJobTest.java
@@ -184,4 +184,24 @@ public class SmartlingPullBatchFileJobTest {
         .extracting("smartlingLocale")
         .containsExactlyInAnyOrder("ga", "fr-CA");
   }
+
+  @Test
+  public void testLocaleMappingEmptyString() throws Exception {
+    SmartlingPullBatchFileJobInput jobInput = new SmartlingPullBatchFileJobInput();
+    jobInput.setBatchNumber(1L);
+    jobInput.setDeltaPull(false);
+    jobInput.setFilePrefix("singular");
+    jobInput.setDryRun(false);
+    jobInput.setRepositoryName("testRepo");
+    jobInput.setProjectId("testProjectId");
+    jobInput.setLocaleMapping("");
+
+    smartlingPullBatchFileJob.call(jobInput);
+
+    verify(quartzPollableTaskSchedulerMock, times(2)).scheduleJob(quartzJobInfoCaptor.capture());
+
+    List<QuartzJobInfo<SmartlingPullLocaleFileJobInput, Void>> quartzJobInfos =
+        quartzJobInfoCaptor.getAllValues();
+    assertThat(quartzJobInfos.stream().filter(q -> q.getParentId() == 1L).count()).isEqualTo(2);
+  }
 }


### PR DESCRIPTION
Fixes the `java.lang.IllegalArgumentException: Chunk [] is not a valid entry` exception thrown if an empty string locale mapping parameter is provided. 

Added unit test to avoid `Strings.emptyToNull()` being removed in future.