### PR TITLE
Add an option to HTML filter to skip extraction of text unit with emp…

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/okapi/filters/HtmlFilter.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/filters/HtmlFilter.java
@@ -31,6 +31,8 @@ public class HtmlFilter extends net.sf.okapi.filters.html.HtmlFilter {
 
   boolean processImageUrls;
 
+  boolean markEmptyAndNbspAsNotTranslatable = true;
+
   @Override
   public String getName() {
     return FILTER_CONFIG_ID;
@@ -69,12 +71,24 @@ public class HtmlFilter extends net.sf.okapi.filters.html.HtmlFilter {
     Event next = super.next();
 
     if (next.isTextUnit()) {
+      setEmptyAndNbspAsNotTranslatable(next.getTextUnit());
       setTextUnitName(next.getTextUnit());
     } else if (next.isDocumentPart()) {
       processDocumentPart(next.getDocumentPart());
     }
 
     return next;
+  }
+
+  void setEmptyAndNbspAsNotTranslatable(ITextUnit textUnit) {
+    if (markEmptyAndNbspAsNotTranslatable) {
+      String source = textUnit.getSource().toString();
+      // whitespaces are collapsed by the filter so just checking for empty string & for the usage
+      // of &nbsp;
+      if (source.isEmpty() || "\u00A0".equals(source)) {
+        textUnit.setIsTranslatable(false);
+      }
+    }
   }
 
   void processDocumentPart(DocumentPart documentPart) {
@@ -113,6 +127,8 @@ public class HtmlFilter extends net.sf.okapi.filters.html.HtmlFilter {
     if (filterOptions != null) {
       // mojito options
       filterOptions.getBoolean("processImageUrls", b -> processImageUrls = b);
+      filterOptions.getBoolean(
+          "emptyAndNbspNotTranslatable", b -> markEmptyAndNbspAsNotTranslatable = b);
     }
   }
 }

--- a/common/src/test/java/com/box/l10n/mojito/okapi/extractor/AssetExtractorTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/okapi/extractor/AssetExtractorTest.java
@@ -91,6 +91,9 @@ public class AssetExtractorTest {
                 + "    <li>item1</li>\n"
                 + "    <li>item2</li>\n"
                 + "</ul>\n"
+                + "<table><tr><td style=\"font-size:0px\" class=\"nomob\">&nbsp;</td></tr></table>\n"
+                + "<table><tr><td></td></tr></table>\n"
+                + "<table><tr><td></td>  </tr></table>\n"
                 + "</body>\n"
                 + "</html>",
             FilterConfigIdOverride.HTML_ALPHA,


### PR DESCRIPTION
…ty sources

In this context, empty source means the empty string or a nbsp character. The "isTranslatable" field is set on the text units that have an empty source by the HTML filter. The side effect is that those text units will be skipped during the extraction process.

The option is "emptyAndNbspNotTranslatable" and can be passed as a regular filter option. It is "true" by default, meaning the text unit with an empty source will be skipped.