### PR TITLE
Add @DirtiesContext to the AssetExtractorTest

### DIFF
--- a/common/src/test/java/com/box/l10n/mojito/okapi/extractor/AssetExtractorTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/okapi/extractor/AssetExtractorTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -27,6 +28,11 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
       AssetExtractorTest.class
     })
 @EnableSpringConfigured
+/**
+ * DirtiesContext is required to avoid the Okapi filter tests being run as SpringBootTests and
+ * failing due to dependency errors if this test runs before them.
+ */
+@DirtiesContext
 public class AssetExtractorTest {
 
   @Autowired AssetExtractor assetExtractor;


### PR DESCRIPTION
Fixes the issue where if the AssetExtractorTest runs before the okapi filter tests it causes them to fail.