### PR TITLE
Allow direct selection of a single repository in workbench

### DIFF
--- a/webapp/src/main/resources/public/js/components/workbench/RepositoryDropdown.js
+++ b/webapp/src/main/resources/public/js/components/workbench/RepositoryDropdown.js
@@ -95,18 +95,24 @@ let RepositoryDropDown = createReactClass({
      *
      * @param repository the repository that was selected
      */
-    onRepositorySelected(repository) {
+    onRepositorySelected(repository, event) {
 
         this.forceDropdownOpen = true;
 
         let id = repository.id;
 
-        let newSelectedRepoIds = this.state.selectedRepoIds.slice();
+        let newSelectedRepoIds = null;
 
-        if (repository.selected) {
-            _.pull(newSelectedRepoIds, id);
+        if (event.shiftKey) {
+            newSelectedRepoIds = [id];
         } else {
-            newSelectedRepoIds.push(id);
+            newSelectedRepoIds = this.state.selectedRepoIds.slice();
+
+            if (repository.selected) {
+                _.pull(newSelectedRepoIds, id);
+            } else {
+                newSelectedRepoIds.push(id);
+            }
         }
 
         this.searchParamChanged(newSelectedRepoIds);


### PR DESCRIPTION
The repository dropdown is a multi select dropdown. Regular click will either add or remove the current repository that is clicked.

At times, it is useful to directly select a single repository when a list of repositories is already selected. This can now be accomplished by use shit+click on the repository name.