### PR TITLE
Replacing Joda-time with Java-time

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -35,8 +37,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
 import org.fusesource.jansi.Ansi;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -350,10 +350,10 @@ public class CommandHelper {
    * @param condition
    * @return
    */
-  DateTime getLastWeekDateIfTrue(boolean condition) {
-    DateTime dateTime = null;
+  ZonedDateTime getLastWeekDateIfTrue(boolean condition) {
+    ZonedDateTime dateTime = null;
     if (condition) {
-      dateTime = DateTime.now(DateTimeZone.UTC).minusWeeks(1);
+      dateTime = ZonedDateTime.now(ZoneOffset.UTC).minusWeeks(1);
     }
     return dateTime;
   }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/CommitCreateCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/CommitCreateCommand.java
@@ -10,6 +10,9 @@ import com.box.l10n.mojito.rest.entity.Commit;
 import com.box.l10n.mojito.rest.entity.Repository;
 import com.google.common.collect.Streams;
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
@@ -17,8 +20,6 @@ import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.fusesource.jansi.Ansi;
-import org.joda.time.DateTime;
-import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,7 +75,7 @@ public class CommitCreateCommand extends Command {
       arity = 1,
       description = Param.CREATION_DATE_DESCRIPTION,
       converter = DateTimeConverter.class)
-  DateTime creationDateParam;
+  ZonedDateTime creationDateParam;
 
   @Parameter(
       names = {"--read-from-git"},
@@ -151,7 +152,7 @@ public class CommitCreateCommand extends Command {
               revCommit.getName(),
               authorIdent.getEmailAddress(),
               authorIdent.getName(),
-              Instant.ofEpochSecond(revCommit.getCommitTime()).toDateTime());
+              Instant.ofEpochSecond(revCommit.getCommitTime()).atZone(ZoneId.systemDefault()));
 
       consoleWriter
           .a("Read from Git - hash: '")
@@ -176,9 +177,10 @@ public class CommitCreateCommand extends Command {
     String hash;
     String authorEmail;
     String authorName;
-    DateTime creationDate;
+    ZonedDateTime creationDate;
 
-    public CommitInfo(String hash, String authorEmail, String authorName, DateTime creationDate) {
+    public CommitInfo(
+        String hash, String authorEmail, String authorName, ZonedDateTime creationDate) {
       this.hash = hash;
       this.authorEmail = authorEmail;
       this.authorName = authorName;

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/DateTimeConverter.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/DateTimeConverter.java
@@ -1,11 +1,14 @@
 package com.box.l10n.mojito.cli.command;
 
 import com.beust.jcommander.IStringConverter;
-import org.joda.time.DateTime;
+import com.box.l10n.mojito.DateTimeUtils;
+import java.time.ZonedDateTime;
 
-public class DateTimeConverter implements IStringConverter<DateTime> {
+public class DateTimeConverter implements IStringConverter<ZonedDateTime> {
+
   @Override
-  public DateTime convert(String dateAsText) {
-    return DateTime.parse(dateAsText);
+  public ZonedDateTime convert(String dateAsText) {
+
+    return DateTimeUtils.strAsZonedDate(dateAsText);
   }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/console/ConsoleWriter.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/console/ConsoleWriter.java
@@ -1,8 +1,8 @@
 package com.box.l10n.mojito.cli.console;
 
 import com.google.common.base.CharMatcher;
+import java.time.ZonedDateTime;
 import org.fusesource.jansi.Ansi;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +86,7 @@ public class ConsoleWriter {
    * @param value
    * @return this instance
    */
-  public ConsoleWriter a(DateTime value) {
+  public ConsoleWriter a(ZonedDateTime value) {
     stringBuilder.append(value.toString());
     ansi.a(value);
     return this;

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/BranchDeleteCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/BranchDeleteCommandTest.java
@@ -8,12 +8,12 @@ import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.rest.client.RepositoryClient;
 import com.box.l10n.mojito.rest.entity.Branch;
 import com.box.l10n.mojito.service.branch.BranchRepository;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -114,13 +114,13 @@ public class BranchDeleteCommandTest extends CLITestBase {
 
     com.box.l10n.mojito.entity.Branch master =
         branchRepository.findByNameAndRepository("master", repository);
-    master.setCreatedDate(DateTime.now().minusDays(14));
+    master.setCreatedDate(ZonedDateTime.now().minusDays(14));
     branchRepository.save(master);
 
     checkBranches(
         "There should be only master that is older than a week",
         repository,
-        DateTime.now().minusDays(7),
+        ZonedDateTime.now().minusDays(7),
         null,
         "master");
 
@@ -163,7 +163,7 @@ public class BranchDeleteCommandTest extends CLITestBase {
   void checkBranches(
       String message,
       Repository repository,
-      DateTime createdBefore,
+      ZonedDateTime createdBefore,
       Boolean translated,
       String... branchNames) {
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/CommitCreateCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/CommitCreateCommandTest.java
@@ -8,12 +8,12 @@ import com.box.l10n.mojito.entity.Commit;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.service.commit.CommitService;
 import com.google.common.collect.Streams;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.joda.time.DateTime;
 import org.junit.Assume;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +32,7 @@ public class CommitCreateCommandTest extends CLITestBase {
     String commitHash = "ABC123";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime creationDate = DateTime.now();
+    ZonedDateTime creationDate = ZonedDateTime.now();
 
     L10nJCommander l10nJCommander = getL10nJCommander();
     l10nJCommander.run(
@@ -65,9 +65,7 @@ public class CommitCreateCommandTest extends CLITestBase {
     assertEquals(commitHash, createdCommit.getName());
     assertEquals(authorEmail, createdCommit.getAuthorEmail());
     assertEquals(authorName, createdCommit.getAuthorName());
-    assertEquals(
-        creationDate.withMillisOfSecond(0).getMillis(),
-        createdCommit.getSourceCreationDate().withMillisOfSecond(0).getMillis());
+    assertEquals(creationDate.withNano(0), createdCommit.getSourceCreationDate().withNano(0));
   }
 
   @Test
@@ -77,7 +75,7 @@ public class CommitCreateCommandTest extends CLITestBase {
     String commitHash = "ABC456";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime creationDate = DateTime.now();
+    ZonedDateTime creationDate = ZonedDateTime.now();
 
     L10nJCommander l10nJCommanderFirstRun = getL10nJCommander();
     l10nJCommanderFirstRun.run(
@@ -127,9 +125,7 @@ public class CommitCreateCommandTest extends CLITestBase {
     assertEquals(commitHash, createdCommit.getName());
     assertEquals(authorEmail, createdCommit.getAuthorEmail());
     assertEquals(authorName, createdCommit.getAuthorName());
-    assertEquals(
-        creationDate.withMillisOfSecond(0).getMillis(),
-        createdCommit.getSourceCreationDate().withMillisOfSecond(0).getMillis());
+    assertEquals(creationDate.withNano(0), createdCommit.getSourceCreationDate().withNano(0));
   }
 
   @Test
@@ -153,7 +149,7 @@ public class CommitCreateCommandTest extends CLITestBase {
     assertEquals("Jean Aurambault", commit.getAuthorName());
     assertEquals("aurambaj@users.noreply.github.com", commit.getAuthorEmail());
     assertEquals(
-        DateTime.parse("2022-09-20T10:55:39.000-07:00").toInstant(),
+        ZonedDateTime.parse("2022-09-20T10:55:39.000-07:00").toInstant(),
         commit.getSourceCreationDate().toInstant());
   }
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
@@ -28,10 +28,10 @@ import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitVariantRepository;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import org.assertj.core.api.Assertions;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1951,7 +1951,7 @@ public class PullCommandTest extends CLITestBase {
             "--author-name",
             "coder",
             "--creation-date",
-            DateTime.now().toString());
+            ZonedDateTime.now().toString());
 
     logger.debug("Initial push");
     getL10nJCommander()
@@ -2025,7 +2025,7 @@ public class PullCommandTest extends CLITestBase {
             "--author-name",
             "coder",
             "--creation-date",
-            DateTime.now().toString());
+            ZonedDateTime.now().toString());
     getL10nJCommander()
         .run(
             "commit-to-pull-run",
@@ -2106,7 +2106,7 @@ public class PullCommandTest extends CLITestBase {
             "--author-name",
             "coder",
             "--creation-date",
-            DateTime.now().toString());
+            ZonedDateTime.now().toString());
 
     logger.debug("Initial push");
     getL10nJCommander()
@@ -2152,7 +2152,7 @@ public class PullCommandTest extends CLITestBase {
             "--author-name",
             "coder",
             "--creation-date",
-            DateTime.now().toString());
+            ZonedDateTime.now().toString());
 
     getL10nJCommander()
         .run(
@@ -2220,7 +2220,7 @@ public class PullCommandTest extends CLITestBase {
             "--author-name",
             "coder",
             "--creation-date",
-            DateTime.now().toString());
+            ZonedDateTime.now().toString());
     getL10nJCommander()
         .run(
             "commit-to-pull-run",
@@ -2290,7 +2290,7 @@ public class PullCommandTest extends CLITestBase {
             "--author-name",
             "coder",
             "--creation-date",
-            DateTime.now().toString());
+            ZonedDateTime.now().toString());
     getL10nJCommander()
         .run(
             "commit-to-pull-run",
@@ -2357,7 +2357,7 @@ public class PullCommandTest extends CLITestBase {
             "--author-name",
             "coder",
             "--creation-date",
-            DateTime.now().toString());
+            ZonedDateTime.now().toString());
 
     getL10nJCommander()
         .run(
@@ -2427,7 +2427,7 @@ public class PullCommandTest extends CLITestBase {
             "--author-name",
             "coder",
             "--creation-date",
-            DateTime.now().toString());
+            ZonedDateTime.now().toString());
     getL10nJCommander()
         .run(
             "commit-to-pull-run",

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PushCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PushCommandTest.java
@@ -24,6 +24,7 @@ import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import com.box.l10n.mojito.service.tm.search.UsedFilter;
 import java.io.File;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -459,7 +459,7 @@ public class PushCommandTest extends CLITestBase {
     String commitHash = "ABC123";
     Commit commit =
         commitService.getOrCreateCommit(
-            repository, commitHash, "authorEmail", "authorName", DateTime.now());
+            repository, commitHash, "authorEmail", "authorName", ZonedDateTime.now());
     assertNull(
         commitRepository
             .findById(commit.getId())

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/QuartzJobsDeleteCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/QuartzJobsDeleteCommandTest.java
@@ -8,7 +8,9 @@ import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableJob;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.quartz.QuartzService;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import org.junit.Test;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
@@ -46,12 +48,14 @@ public class QuartzJobsDeleteCommandTest extends CLITestBase {
 
     quartzPollableTaskScheduler.scheduleJob(
         QuartzJobInfo.newBuilder(AJob.class)
-            .withTriggerStartDate(DateTime.now().plus(100000).toDate())
+            .withTriggerStartDate(
+                Date.from(ZonedDateTime.now().plus(100, ChronoUnit.SECONDS).toInstant()))
             .withUniqueId(testJobName1)
             .build());
     quartzPollableTaskScheduler.scheduleJob(
         QuartzJobInfo.newBuilder(AJob.class)
-            .withTriggerStartDate(DateTime.now().plus(100000).toDate())
+            .withTriggerStartDate(
+                Date.from(ZonedDateTime.now().plus(100, ChronoUnit.SECONDS).toInstant()))
             .withUniqueId(testJobName2)
             .build());
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/TMImportCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/TMImportCommandTest.java
@@ -20,6 +20,8 @@ import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitVariantRepository;
 import java.io.File;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -27,7 +29,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -135,11 +136,15 @@ public class TMImportCommandTest extends CLITestBase {
 
     tmTextUnitVariant = iterator.next();
     assertEquals("1時間", tmTextUnitVariant.getContent());
-    assertEquals(new DateTime(1447198865000L), tmTextUnitVariant.getCreatedDate());
+    assertEquals(
+        Instant.ofEpochMilli(1447198865000L).atZone(ZoneId.systemDefault()),
+        tmTextUnitVariant.getCreatedDate());
 
     tmTextUnitVariant = iterator.next();
     assertEquals("1か月", tmTextUnitVariant.getContent());
-    assertEquals(new DateTime(1447198865000L), tmTextUnitVariant.getCreatedDate());
+    assertEquals(
+        Instant.ofEpochMilli(1447198865000L).atZone(ZoneId.systemDefault()),
+        tmTextUnitVariant.getCreatedDate());
 
     Set<TMTextUnitVariantComment> tmTextUnitVariantComments =
         tmTextUnitVariant.getTmTextUnitVariantComments();

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,10 +24,6 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
         </dependency>
 

--- a/common/src/main/java/com/box/l10n/mojito/DateTimeUtils.java
+++ b/common/src/main/java/com/box/l10n/mojito/DateTimeUtils.java
@@ -1,0 +1,75 @@
+package com.box.l10n.mojito;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+
+/**
+ * Util class to provide Date/DateTime utility methods such as converters.
+ *
+ * @author hylston.barbosa
+ */
+public class DateTimeUtils {
+
+  /**
+   * Converts an Instant into {@link ZonedDateTime}. The input should be an {@link Instant}. Defines
+   * the timezone as UTC.
+   *
+   * @author hylston.barbosa
+   */
+  public static ZonedDateTime fromDateToZonedDate(Date date) {
+
+    if (date != null) {
+      return date.toInstant().atZone(ZoneOffset.UTC);
+    }
+
+    return null;
+  }
+
+  /**
+   * Converts an instant into {@link ZonedDateTime}. The input should be an instant long value such
+   * as 1701374258000. Defines the timezone as UTC.
+   *
+   * @author hylston.barbosa
+   */
+  public static ZonedDateTime longAsZonedDate(Long instant) {
+    return Instant.ofEpochMilli(instant).atZone(ZoneOffset.UTC);
+  }
+
+  /**
+   * Converts a string into {@link ZonedDateTime}. The input should be a string representing a date
+   * following the ISO format, such as '2023-11-28T22:15:30.000Z'. If the provided input does not
+   * have a timezone defined, sets the UTC as the timezone.
+   *
+   * @author hylston.barbosa
+   */
+  public static ZonedDateTime strAsZonedDate(String dateStr) {
+    try {
+      return ZonedDateTime.parse(dateStr);
+    } catch (DateTimeParseException e) {
+      return LocalDateTime.parse(dateStr).atZone(ZoneOffset.UTC);
+    }
+  }
+
+  /**
+   * Converts a string into {@link ZonedDateTime}. The object can either be a number of milliseconds
+   * from 1970-01-01T00:00:00Z such as 1701374258000 or a string representing a date following the
+   * ISO format, such as '2023-11-28T22:15:30.000Z'.
+   *
+   * @author hylston.barbosa
+   */
+  public static ZonedDateTime longOrStrAsZonedDate(String datetime) {
+    if (datetime == null) {
+      return null;
+    }
+
+    try {
+      return longAsZonedDate(Long.parseLong(datetime));
+    } catch (NumberFormatException nfe) {
+      return strAsZonedDate(datetime);
+    }
+  }
+}

--- a/common/src/main/java/com/box/l10n/mojito/json/ObjectMapper.java
+++ b/common/src/main/java/com/box/l10n/mojito/json/ObjectMapper.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -21,20 +21,18 @@ import java.nio.file.Path;
 public class ObjectMapper extends com.fasterxml.jackson.databind.ObjectMapper {
 
   public ObjectMapper() {
-    JodaModule jodaModule = new JodaModule();
-    registerJodaModule();
     registerGuavaModule();
+    registerJavaTimeModule();
   }
 
   public ObjectMapper(ObjectMapper objectMapper) {
     super(objectMapper);
-    registerJodaModule();
+    registerJavaTimeModule();
     registerGuavaModule();
   }
 
-  private final void registerJodaModule() {
-    JodaModule jodaModule = new JodaModule();
-    registerModule(jodaModule);
+  private final void registerJavaTimeModule() {
+    registerModule(new JavaTimeModule());
   }
 
   private final void registerGuavaModule() {

--- a/common/src/main/java/com/box/l10n/mojito/localtm/merger/AbstractBranch.java
+++ b/common/src/main/java/com/box/l10n/mojito/localtm/merger/AbstractBranch.java
@@ -2,8 +2,8 @@ package com.box.l10n.mojito.localtm.merger;
 
 import com.box.l10n.mojito.immutables.NoPrefixNoBuiltinContainer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.time.ZonedDateTime;
 import org.immutables.value.Value;
-import org.joda.time.DateTime;
 
 @Value.Immutable
 @NoPrefixNoBuiltinContainer
@@ -12,5 +12,5 @@ public abstract class AbstractBranch {
 
   public abstract String getName();
 
-  public abstract DateTime getCreatedAt();
+  public abstract ZonedDateTime getCreatedAt();
 }

--- a/common/src/main/java/com/box/l10n/mojito/localtm/merger/AbstractBranchStateTextUnit.java
+++ b/common/src/main/java/com/box/l10n/mojito/localtm/merger/AbstractBranchStateTextUnit.java
@@ -3,9 +3,9 @@ package com.box.l10n.mojito.localtm.merger;
 import com.box.l10n.mojito.immutables.NoPrefixNoBuiltinContainer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableMap;
+import java.time.ZonedDateTime;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
-import org.joda.time.DateTime;
 
 @Value.Immutable
 @NoPrefixNoBuiltinContainer
@@ -22,7 +22,7 @@ public abstract class AbstractBranchStateTextUnit {
   public abstract String getMd5();
 
   @Nullable
-  public abstract DateTime getCreatedDate();
+  public abstract ZonedDateTime getCreatedDate();
 
   @Nullable
   public abstract String getName();

--- a/common/src/main/java/com/box/l10n/mojito/localtm/merger/AssetExtractorTextUnitsToMultiBranchStateConverter.java
+++ b/common/src/main/java/com/box/l10n/mojito/localtm/merger/AssetExtractorTextUnitsToMultiBranchStateConverter.java
@@ -6,8 +6,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.time.ZonedDateTime;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -25,7 +25,7 @@ public class AssetExtractorTextUnitsToMultiBranchStateConverter {
   public MultiBranchState convert(
       List<AssetExtractorTextUnit> assetExtractorTextUnits, Branch branch) {
 
-    DateTime now = DateTime.now();
+    ZonedDateTime now = ZonedDateTime.now();
 
     ImmutableList<BranchStateTextUnit> branchStateTextUnitImmutableMap =
         assetExtractorTextUnits.stream()
@@ -40,7 +40,7 @@ public class AssetExtractorTextUnitsToMultiBranchStateConverter {
   }
 
   BranchStateTextUnit convertToBranchStateTextUnit(
-      AssetExtractorTextUnit assetExtractorTextUnit, Branch branch, DateTime createdDate) {
+      AssetExtractorTextUnit assetExtractorTextUnit, Branch branch, ZonedDateTime createdDate) {
 
     BranchData branchData =
         BranchData.of()

--- a/common/src/test/java/com/box/l10n/mojito/DateTimeUtilsTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/DateTimeUtilsTest.java
@@ -1,0 +1,111 @@
+package com.box.l10n.mojito;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+import org.junit.Test;
+
+public class DateTimeUtilsTest {
+
+  @Test
+  public void testLongOrStrAsZonedDateNull() {
+    String source = null;
+    ZonedDateTime expResult = null;
+    assertEquals(expResult, DateTimeUtils.longOrStrAsZonedDate(source));
+  }
+
+  @Test
+  public void testLongOrStrAsZonedDateMillisecond() {
+    String source = "1525887295000";
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-09T17:34:55.000Z");
+    ZonedDateTime result = DateTimeUtils.longOrStrAsZonedDate(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
+  }
+
+  @Test
+  public void testLongOrStrAsZonedDateISO() {
+    String source = "2018-05-09T17:34:55.000Z";
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-09T17:34:55.000Z");
+    ZonedDateTime result = DateTimeUtils.longOrStrAsZonedDate(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
+  }
+
+  @Test
+  public void testLongOrStrAsZonedDateISONoTZ() {
+    String source = "2018-05-09T17:34:55.000";
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-09T17:34:55.000Z");
+    ZonedDateTime result = DateTimeUtils.longOrStrAsZonedDate(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
+  }
+
+  @Test
+  public void testLongOrStrAsZonedDateISOTZ() {
+    String source = "2018-05-09T17:34:55.000-07:00";
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-10T00:34:55.000Z");
+    ZonedDateTime result = DateTimeUtils.longOrStrAsZonedDate(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
+  }
+
+  @Test
+  public void testLongOrStrAsZonedDateISOTZNoMillisecond() {
+    String source = "2018-05-09T17:34:55-07:00";
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-10T00:34:55.000Z");
+    ZonedDateTime result = DateTimeUtils.longOrStrAsZonedDate(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
+  }
+
+  @Test(expected = DateTimeParseException.class)
+  public void testLongOrStrAsZonedDateInvalidDateFormat() {
+    String source = "09-05-2018T17:34:55-07:00";
+    DateTimeUtils.longOrStrAsZonedDate(source);
+  }
+
+  @Test()
+  public void testFromDateToZonedDate() {
+    Date date = new Date();
+    ZonedDateTime expResult = date.toInstant().atZone(ZoneOffset.UTC);
+    ZonedDateTime result = DateTimeUtils.fromDateToZonedDate(date);
+    assertEquals(expResult, result);
+  }
+
+  @Test()
+  public void testFromDateToZonedDateNull() {
+    ZonedDateTime expResult = null;
+    assertEquals(expResult, DateTimeUtils.fromDateToZonedDate(null));
+  }
+
+  @Test()
+  public void testLongAsZonedDate() {
+    Long source = 1525887295000L;
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-09T17:34:55.000Z");
+    ZonedDateTime result = DateTimeUtils.longAsZonedDate(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testLongAsZonedDateNull() {
+    DateTimeUtils.longAsZonedDate(null);
+  }
+
+  @Test()
+  public void testStrAsZonedDate() {
+    String source = "2018-05-09T17:34:55.000Z";
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-09T17:34:55.000Z");
+    ZonedDateTime result = DateTimeUtils.strAsZonedDate(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
+  }
+
+  @Test(expected = DateTimeParseException.class)
+  public void testStrAsZonedDateParseException() {
+    String source = "2018-05-09T17:34:55.000-INVALID";
+    DateTimeUtils.strAsZonedDate(source);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testStrAsZonedDateNull() {
+    DateTimeUtils.strAsZonedDate(null);
+  }
+}

--- a/common/src/test/java/com/box/l10n/mojito/localtm/merger/AssetExtractorTextUnitsToMultiBranchStateConverterTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/localtm/merger/AssetExtractorTextUnitsToMultiBranchStateConverterTest.java
@@ -7,11 +7,12 @@ import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 public class AssetExtractorTextUnitsToMultiBranchStateConverterTest {
@@ -32,7 +33,10 @@ public class AssetExtractorTextUnitsToMultiBranchStateConverterTest {
             .collect(Collectors.toList());
 
     Branch branch1 =
-        Branch.builder().name("branch1").createdAt(new DateTime(2020, 7, 14, 0, 0)).build();
+        Branch.builder()
+            .name("branch1")
+            .createdAt(ZonedDateTime.of(2020, 7, 14, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     AssetExtractorTextUnitsToMultiBranchStateConverter
         assetExtractorTextUnitsToMultiBranchStateConverter =
@@ -70,10 +74,13 @@ public class AssetExtractorTextUnitsToMultiBranchStateConverterTest {
     assetExtractorTextUnit.setPluralFormOther("name_other");
     assetExtractorTextUnit.setUsages(Sets.newHashSet("location1", "location2"));
 
-    DateTime createdDate = new DateTime(2020, 7, 15, 0, 0);
+    ZonedDateTime createdDate = ZonedDateTime.of(2020, 7, 15, 0, 0, 0, 0, ZoneId.systemDefault());
 
     Branch branch =
-        Branch.builder().name("branch1").createdAt(new DateTime(2020, 7, 14, 0, 0)).build();
+        Branch.builder()
+            .name("branch1")
+            .createdAt(ZonedDateTime.of(2020, 7, 14, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     BranchStateTextUnit branchStateTextUnit =
         assetExtractorTextUnitsToMultiBranchStateConverter.convertToBranchStateTextUnit(

--- a/common/src/test/java/com/box/l10n/mojito/localtm/merger/MultiBranchStateMergerTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/localtm/merger/MultiBranchStateMergerTest.java
@@ -6,12 +6,13 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.joda.time.DateTime;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -21,13 +22,22 @@ public class MultiBranchStateMergerTest {
   static Stream<Arguments> merge() {
 
     Branch branch1 =
-        Branch.builder().name("branch1").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch1")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch2 =
-        Branch.builder().name("branch2").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch2")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch3 =
-        Branch.builder().name("branch3").createdAt(new DateTime(2020, 6, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch3")
+            .createdAt(ZonedDateTime.of(2020, 6, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     BranchStateTextUnit state1BranchStateTextUnit1 =
         createBranchStateTextUnit("MD5HASH1", createBranchMap(branch1, branch2));
@@ -95,16 +105,28 @@ public class MultiBranchStateMergerTest {
 
   static Stream<Arguments> mergeBranchesByPriorityThenCreatedDateThenName() {
     Branch branch1 =
-        Branch.builder().name("branch1").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch1")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch2 =
-        Branch.builder().name("branch2").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch2")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch masterBranch =
-        Branch.builder().name("master").createdAt(new DateTime(2020, 8, 10, 0, 0)).build();
+        Branch.builder()
+            .name("master")
+            .createdAt(ZonedDateTime.of(2020, 8, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch3 =
-        Branch.builder().name("branch3").createdAt(new DateTime(2020, 6, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch3")
+            .createdAt(ZonedDateTime.of(2020, 6, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     return Stream.of(
         Arguments.of(
@@ -159,16 +181,28 @@ public class MultiBranchStateMergerTest {
 
   static Stream<Arguments> sortBranchesByPriorityThenCreatedDateThenName() {
     Branch branch1 =
-        Branch.builder().name("branch1").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch1")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch2 =
-        Branch.builder().name("branch2").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch2")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch masterBranch =
-        Branch.builder().name("master").createdAt(new DateTime(2020, 8, 10, 0, 0)).build();
+        Branch.builder()
+            .name("master")
+            .createdAt(ZonedDateTime.of(2020, 8, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch3 =
-        Branch.builder().name("branch3").createdAt(new DateTime(2020, 6, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch3")
+            .createdAt(ZonedDateTime.of(2020, 6, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     return Stream.of(
         Arguments.of("Empty lists", ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of()),
@@ -203,13 +237,22 @@ public class MultiBranchStateMergerTest {
 
   static Stream<Arguments> mergerMultiBranchStateIntoBranchStateTextUnit() {
     Branch branch1 =
-        Branch.builder().name("branch1").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch1")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch2 =
-        Branch.builder().name("branch2").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch2")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch3 =
-        Branch.builder().name("branch3").createdAt(new DateTime(2020, 6, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch3")
+            .createdAt(ZonedDateTime.of(2020, 6, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     BranchStateTextUnit baseBranchStateTextUnit =
         createBranchStateTextUnit("MD5HASH", createBranchMap(branch1, branch2));
@@ -273,16 +316,28 @@ public class MultiBranchStateMergerTest {
 
   static Stream<Arguments> sortBranchDataByBranch() {
     Branch branch1 =
-        Branch.builder().name("branch1").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch1")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch2 =
-        Branch.builder().name("branch2").createdAt(new DateTime(2020, 7, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch2")
+            .createdAt(ZonedDateTime.of(2020, 7, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch masterBranch =
-        Branch.builder().name("master").createdAt(new DateTime(2020, 8, 10, 0, 0)).build();
+        Branch.builder()
+            .name("master")
+            .createdAt(ZonedDateTime.of(2020, 8, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     Branch branch3 =
-        Branch.builder().name("branch3").createdAt(new DateTime(2020, 6, 10, 0, 0)).build();
+        Branch.builder()
+            .name("branch3")
+            .createdAt(ZonedDateTime.of(2020, 6, 10, 0, 0, 0, 0, ZoneId.systemDefault()))
+            .build();
 
     return Stream.of(
         Arguments.of("Empty lists", ImmutableMap.of(), ImmutableSet.of(), ImmutableMap.of()),

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
         <maven.release.version>2.5.3</maven.release.version>
         <okapi.version>1.43.0</okapi.version>
         <guava.version>29.0-jre</guava.version>
-        <hibernate.joda-time.version>1.4</hibernate.joda-time.version>
         <usertype.core.version>6.0.1.GA</usertype.core.version>
         <aspectj-maven-plugin.version>1.13.1</aspectj-maven-plugin.version>
         <!-- org.codehaus.mojo doesn't support Java 17+, use fork for now -->
@@ -79,6 +78,12 @@
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
             <version>${icu4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.15.3</version>
         </dependency>
     </dependencies>
 

--- a/restclient/pom.xml
+++ b/restclient/pom.xml
@@ -46,11 +46,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/CommitClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/CommitClient.java
@@ -4,7 +4,7 @@ import com.box.l10n.mojito.rest.entity.Commit;
 import com.box.l10n.mojito.rest.entity.CommitBody;
 import com.box.l10n.mojito.rest.entity.CommitToPullRunBody;
 import com.box.l10n.mojito.rest.entity.CommitToPushRunBody;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 import org.springframework.stereotype.Component;
 
 /** @author garion */
@@ -24,7 +24,7 @@ public class CommitClient extends BaseClient {
       Long repositoryId,
       String authorName,
       String authorEmail,
-      DateTime sourceCreationDate) {
+      ZonedDateTime sourceCreationDate) {
     CommitBody commitBody = new CommitBody();
     commitBody.setCommitName(commitHash);
     commitBody.setRepositoryId(repositoryId);

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
@@ -10,6 +10,7 @@ import com.box.l10n.mojito.rest.entity.Locale;
 import com.box.l10n.mojito.rest.entity.PollableTask;
 import com.box.l10n.mojito.rest.entity.Repository;
 import com.box.l10n.mojito.rest.entity.RepositoryLocale;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +18,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -223,7 +223,7 @@ public class RepositoryClient extends BaseClient {
       Boolean deleted,
       Boolean translated,
       boolean includeNullBranch,
-      DateTime createdBefore) {
+      ZonedDateTime createdBefore) {
     Map<String, String> filterParams = new HashMap<>();
 
     if (branchName != null) {
@@ -239,7 +239,7 @@ public class RepositoryClient extends BaseClient {
     }
 
     if (createdBefore != null) {
-      filterParams.put("createdBefore", String.valueOf(createdBefore.getMillis()));
+      filterParams.put("createdBefore", String.valueOf(createdBefore.toInstant().toEpochMilli()));
     }
 
     List<Branch> branches =

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/Commit.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/Commit.java
@@ -1,7 +1,7 @@
 package com.box.l10n.mojito.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /**
  * Entity that describes a Commit entry. This entity mirrors: com.box.l10n.mojito.entity.Commit
@@ -12,7 +12,7 @@ import org.joda.time.DateTime;
 public class Commit {
 
   protected Long id;
-  protected DateTime createdDate;
+  protected ZonedDateTime createdDate;
   private Repository repository;
   private String name;
   private String authorEmail;
@@ -23,7 +23,7 @@ public class Commit {
    * The date when the commit was actually commited / merged to the target final branch, i.e.:
    * commit date instead of author date.
    */
-  private DateTime sourceCreationDate;
+  private ZonedDateTime sourceCreationDate;
 
   private CommitToPushRun commitToPushRun;
 
@@ -37,11 +37,11 @@ public class Commit {
     this.id = id;
   }
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 
@@ -77,11 +77,11 @@ public class Commit {
     this.name = name;
   }
 
-  public DateTime getSourceCreationDate() {
+  public ZonedDateTime getSourceCreationDate() {
     return sourceCreationDate;
   }
 
-  public void setSourceCreationDate(DateTime sourceCreationDate) {
+  public void setSourceCreationDate(ZonedDateTime sourceCreationDate) {
     this.sourceCreationDate = sourceCreationDate;
   }
 

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/CommitBody.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/CommitBody.java
@@ -1,6 +1,6 @@
 package com.box.l10n.mojito.rest.entity;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /**
  * Entity that describes the information needed for creating a new Commit entry. This entity
@@ -22,7 +22,7 @@ public class CommitBody {
   String authorName;
 
   /** The commit date (instead of the author date). */
-  DateTime sourceCreationDate;
+  ZonedDateTime sourceCreationDate;
 
   public Long getRepositoryId() {
     return repositoryId;
@@ -56,11 +56,11 @@ public class CommitBody {
     this.authorName = authorName;
   }
 
-  public DateTime getSourceCreationDate() {
+  public ZonedDateTime getSourceCreationDate() {
     return sourceCreationDate;
   }
 
-  public void setSourceCreationDate(DateTime sourceCreationDate) {
+  public void setSourceCreationDate(ZonedDateTime sourceCreationDate) {
     this.sourceCreationDate = sourceCreationDate;
   }
 }

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/CommitToPullRun.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/CommitToPullRun.java
@@ -1,7 +1,7 @@
 package com.box.l10n.mojito.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /**
  * Entity that describes a Commit entry. This entity mirrors:
@@ -12,7 +12,7 @@ import org.joda.time.DateTime;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CommitToPullRun {
   protected Long id;
-  protected DateTime createdDate;
+  protected ZonedDateTime createdDate;
 
   public Long getId() {
     return id;
@@ -22,11 +22,11 @@ public class CommitToPullRun {
     this.id = id;
   }
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 }

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/CommitToPushRun.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/CommitToPushRun.java
@@ -1,7 +1,7 @@
 package com.box.l10n.mojito.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /**
  * Entity that describes a Commit entry. This entity mirrors:
@@ -12,7 +12,7 @@ import org.joda.time.DateTime;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CommitToPushRun {
   protected Long id;
-  protected DateTime createdDate;
+  protected ZonedDateTime createdDate;
 
   public Long getId() {
     return id;
@@ -22,11 +22,11 @@ public class CommitToPushRun {
     this.id = id;
   }
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 }

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/Drop.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/Drop.java
@@ -1,6 +1,6 @@
 package com.box.l10n.mojito.rest.entity;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /** @author jaurambault */
 public class Drop {
@@ -9,7 +9,7 @@ public class Drop {
 
   String name;
 
-  DateTime lastImportedDate;
+  ZonedDateTime lastImportedDate;
 
   Boolean canceled;
 
@@ -29,11 +29,11 @@ public class Drop {
     this.name = name;
   }
 
-  public DateTime getLastImportedDate() {
+  public ZonedDateTime getLastImportedDate() {
     return lastImportedDate;
   }
 
-  public void setLastImportedDate(DateTime lastImportedDate) {
+  public void setLastImportedDate(ZonedDateTime lastImportedDate) {
     this.lastImportedDate = lastImportedDate;
   }
 

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/PollableTask.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/PollableTask.java
@@ -2,9 +2,9 @@ package com.box.l10n.mojito.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.time.ZonedDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import org.joda.time.DateTime;
 
 /** @author jaurambault */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -13,9 +13,9 @@ public class PollableTask {
   private Long id;
   private String name;
 
-  private DateTime finishedDate;
+  private ZonedDateTime finishedDate;
 
-  private DateTime createdDate;
+  private ZonedDateTime createdDate;
 
   private String message;
 
@@ -46,11 +46,11 @@ public class PollableTask {
     this.name = name;
   }
 
-  public DateTime getFinishedDate() {
+  public ZonedDateTime getFinishedDate() {
     return finishedDate;
   }
 
-  public void setFinishedDate(DateTime finishedDate) {
+  public void setFinishedDate(ZonedDateTime finishedDate) {
     this.finishedDate = finishedDate;
   }
 
@@ -102,11 +102,11 @@ public class PollableTask {
     this.message = message;
   }
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 }

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/PushRun.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/PushRun.java
@@ -3,8 +3,8 @@ package com.box.l10n.mojito.rest.entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.ZonedDateTime;
 import java.util.Set;
-import org.joda.time.DateTime;
 
 /**
  * Entity that describes a PushRun. This entity mirrors: com.box.l10n.mojito.entity.PushRun
@@ -14,7 +14,7 @@ import org.joda.time.DateTime;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PushRun {
   protected Long id;
-  protected DateTime createdDate;
+  protected ZonedDateTime createdDate;
 
   @JsonProperty("repository_id")
   private Long repositoryId;
@@ -47,11 +47,11 @@ public class PushRun {
     this.name = name;
   }
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/PushRunAsset.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/PushRunAsset.java
@@ -3,9 +3,9 @@ package com.box.l10n.mojito.rest.entity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
-import org.joda.time.DateTime;
 
 /**
  * Entity that describes a PushRun. This entity mirrors: com.box.l10n.mojito.entity.PushRunAsset
@@ -15,7 +15,7 @@ import org.joda.time.DateTime;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PushRunAsset {
   protected Long id;
-  protected DateTime createdDate;
+  protected ZonedDateTime createdDate;
 
   @JsonBackReference private PushRun pushRun;
 

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/PushRunAssetTmTextUnit.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/PushRunAssetTmTextUnit.java
@@ -2,7 +2,7 @@ package com.box.l10n.mojito.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /**
  * Entity that describes a PushRun. This entity mirrors:
@@ -13,7 +13,7 @@ import org.joda.time.DateTime;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PushRunAssetTmTextUnit {
   protected Long id;
-  protected DateTime createdDate;
+  protected ZonedDateTime createdDate;
 
   @JsonBackReference private PushRunAsset pushRunAsset;
 

--- a/restclient/src/test/java/com/box/l10n/mojito/rest/client/VirtualAssetPerformanceTest.java
+++ b/restclient/src/test/java/com/box/l10n/mojito/rest/client/VirtualAssetPerformanceTest.java
@@ -7,13 +7,13 @@ import com.box.l10n.mojito.rest.entity.VirtualAssetTextUnit;
 import com.box.l10n.mojito.rest.resttemplate.AuthenticatedRestTemplate;
 import com.box.l10n.mojito.rest.resttemplate.AuthenticatedRestTemplateTest;
 import com.google.common.base.Strings;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.joda.time.DateTime;
-import org.joda.time.Period;
-import org.joda.time.format.PeriodFormat;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,14 +68,15 @@ public class VirtualAssetPerformanceTest {
 
     logger.debug("virtual asset id: {}", virtualAsset.getId());
 
-    DateTime start = DateTime.now();
+    ZonedDateTime start = ZonedDateTime.now();
     //        createSourceStrings(virtualAsset);
     //        importTranslations(repository, virtualAsset);
 
     pullSourceString(virtualAsset, repository);
 
     pullTranslations(virtualAsset, repository);
-    logger.debug("total: {}", PeriodFormat.getDefault().print(new Period(start, DateTime.now())));
+    Duration duration = Duration.between(start, ZonedDateTime.now());
+    logger.debug("total: {}", duration.toString());
   }
 
   private void pullSourceString(VirtualAsset virtualAsset, Repository repository) {
@@ -89,8 +90,9 @@ public class VirtualAssetPerformanceTest {
                   virtualAssetClient.getLocalizedTextUnits(
                       virtualAsset.getId(), rl.getLocale().getId(), "REMOVE_UNTRANSLATED");
               long end = System.currentTimeMillis();
-              logger.debug(
-                  "file generation: {}", PeriodFormat.getDefault().print(new Period(start, end)));
+              Duration duration =
+                  Duration.between(Instant.ofEpochMilli(start), Instant.ofEpochMilli(end));
+              logger.debug("file generation: {}", duration.toString());
 
               //                    ObjectMapper objectMapper = new ObjectMapper();
               //                    objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
@@ -113,8 +115,9 @@ public class VirtualAssetPerformanceTest {
                   virtualAssetClient.getLocalizedTextUnits(
                       virtualAsset.getId(), rl.getLocale().getId(), "REMOVE_UNTRANSLATED");
               long end = System.currentTimeMillis();
-              logger.debug(
-                  "file generation: {}", PeriodFormat.getDefault().print(new Period(start, end)));
+              Duration duration =
+                  Duration.between(Instant.ofEpochMilli(start), Instant.ofEpochMilli(end));
+              logger.debug("file generation: {}", duration.toString());
 
               //                    ObjectMapper objectMapper = new ObjectMapper();
               //                    objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
@@ -184,7 +187,8 @@ public class VirtualAssetPerformanceTest {
   }
 
   String getElapsedTime(PollableTask pollableTask) {
-    Period period = new Period(pollableTask.getCreatedDate(), pollableTask.getFinishedDate());
-    return PeriodFormat.getDefault().print(period);
+    Duration duration =
+        Duration.between(pollableTask.getCreatedDate(), pollableTask.getFinishedDate());
+    return duration.toString();
   }
 }

--- a/test-common/src/main/java/com/box/l10n/mojito/test/XliffUtils.java
+++ b/test-common/src/main/java/com/box/l10n/mojito/test/XliffUtils.java
@@ -31,7 +31,7 @@ public class XliffUtils {
 
       @Override
       public String apply(String input) {
-        return input.replaceAll("\"createdDate\":\\d+,?", "").replaceAll(",\\}", "}");
+        return input.replaceAll("\"createdDate\":\\d+\\.\\d+,?", "").replaceAll(",\\}", "}");
       }
     };
   }

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -261,31 +261,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Joda Time -->
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time-hibernate</artifactId>
-            <version>${hibernate.joda-time.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jadira.usertype</groupId>
-            <artifactId>usertype.core</artifactId>
-            <version>${usertype.core.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.10.6</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-        </dependency>
-
-        <!-- Joda Time -->
-
         <!-- TODO(P1) to be removed? -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/webapp/src/main/java/com/box/l10n/mojito/Application.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/Application.java
@@ -4,6 +4,8 @@ import com.box.l10n.mojito.entity.BaseEntity;
 import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.xml.XmlParsingConfiguration;
 import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.Optional;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -13,6 +15,7 @@ import org.springframework.context.annotation.AdviceMode;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.converter.json.Jackson2ObjectMapperFactoryBean;
@@ -31,7 +34,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
       QuartzAutoConfiguration.class, // We integrated with Quartz before spring supported it
     })
 @EnableSpringConfigured
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 @EnableJpaRepositories
 @EnableScheduling
 @EnableTransactionManagement(mode = AdviceMode.ASPECTJ)
@@ -114,5 +117,10 @@ public class Application {
     template.setThrowLastExceptionOnExhausted(true);
 
     return template;
+  }
+
+  @Bean(name = "auditingDateTimeProvider")
+  public DateTimeProvider dateTimeProvider() {
+    return () -> Optional.of(ZonedDateTime.now());
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKService.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.boxsdk;
 
+import com.box.l10n.mojito.DateTimeUtils;
 import com.box.sdk.BoxAPIConnection;
 import com.box.sdk.BoxAPIException;
 import com.box.sdk.BoxFile;
@@ -11,10 +12,10 @@ import com.google.common.base.Strings;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -344,7 +345,7 @@ public class BoxSDKService {
    * @param olderThan an instant to check against
    * @throws BoxSDKServiceException
    */
-  public void deleteFolderContentOlderThan(String folderId, DateTime olderThan)
+  public void deleteFolderContentOlderThan(String folderId, ZonedDateTime olderThan)
       throws BoxSDKServiceException {
     try {
       BoxFolder boxFolder = new BoxFolder(getBoxAPIConnection(), folderId);
@@ -353,16 +354,18 @@ public class BoxSDKService {
 
         if (itemInfo instanceof BoxFolder.Info) {
           BoxFolder subFolder = (BoxFolder) itemInfo.getResource();
-
-          if (olderThan.isAfter(subFolder.getInfo().getCreatedAt().getTime())) {
+          ZonedDateTime subFolderCreatedAt =
+              DateTimeUtils.fromDateToZonedDate(subFolder.getInfo().getCreatedAt());
+          if (olderThan.isAfter(subFolderCreatedAt)) {
             subFolder.delete(true);
           }
 
         } else if (itemInfo instanceof BoxFile.Info) {
 
           BoxFile file = (BoxFile) itemInfo.getResource();
-
-          if (olderThan.isAfter(file.getInfo().getCreatedAt().getTime())) {
+          ZonedDateTime fileCreatedAt =
+              DateTimeUtils.fromDateToZonedDate(file.getInfo().getCreatedAt());
+          if (olderThan.isAfter(fileCreatedAt)) {
             file.delete();
           }
         }

--- a/webapp/src/main/java/com/box/l10n/mojito/converter/LocalTimeConverter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/converter/LocalTimeConverter.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.converter;
 
-import org.joda.time.LocalTime;
+import com.google.common.base.Strings;
+import java.time.LocalTime;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,9 @@ public class LocalTimeConverter implements Converter<String, LocalTime> {
 
   @Override
   public LocalTime convert(String source) {
-    return new LocalTime(source);
+    if (Strings.isNullOrEmpty(source)) {
+      return LocalTime.now();
+    }
+    return LocalTime.parse(source);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/converter/PeriodConverter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/converter/PeriodConverter.java
@@ -1,6 +1,6 @@
 package com.box.l10n.mojito.converter;
 
-import org.joda.time.Period;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConfigurationPropertiesBinding
-public class PeriodConverter implements Converter<String, Period> {
+public class PeriodConverter implements Converter<String, Duration> {
 
   @Override
-  public Period convert(String source) {
-    long sourceAsLong = Long.valueOf(source);
-    return new Period(sourceAsLong);
+  public Duration convert(String source) {
+    long sourceAsLong = Long.parseLong(source);
+    return Duration.ofMillis(sourceAsLong);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/ApplicationCache.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/ApplicationCache.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.entity;
 
+import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -9,8 +10,6 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 
 /**
  * Entity that contains the cache entry details for a database-backed application cache. Each entity
@@ -46,17 +45,18 @@ public class ApplicationCache extends BaseEntity {
   private byte[] value;
 
   @Column(name = "created_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  private DateTime createdDate;
+  private ZonedDateTime createdDate;
 
   @Column(name = "expiry_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  private DateTime expiryDate;
+  private ZonedDateTime expiryDate;
 
   public ApplicationCache() {}
 
   public ApplicationCache(
-      ApplicationCacheType applicationCacheType, String keyMD5, byte[] value, DateTime expiryDate) {
+      ApplicationCacheType applicationCacheType,
+      String keyMD5,
+      byte[] value,
+      ZonedDateTime expiryDate) {
     this.applicationCacheType = applicationCacheType;
     this.keyMD5 = keyMD5;
     this.value = value;
@@ -71,19 +71,19 @@ public class ApplicationCache extends BaseEntity {
     this.value = value;
   }
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 
-  public DateTime getExpiryDate() {
+  public ZonedDateTime getExpiryDate() {
     return expiryDate;
   }
 
-  public void setExpiryDate(DateTime expireDate) {
+  public void setExpiryDate(ZonedDateTime expireDate) {
     this.expiryDate = expireDate;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/AuditableEntity.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/AuditableEntity.java
@@ -4,11 +4,10 @@ import com.box.l10n.mojito.rest.View;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
+import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -25,30 +24,28 @@ public abstract class AuditableEntity extends BaseEntity implements Serializable
 
   @CreatedDate
   @Column(name = "created_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
   @JsonView(View.IdAndNameAndCreated.class)
-  protected DateTime createdDate;
+  protected ZonedDateTime createdDate;
 
   @LastModifiedDate
   @Column(name = "last_modified_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
   @JsonView(View.Modified.class)
-  protected DateTime lastModifiedDate;
+  protected ZonedDateTime lastModifiedDate;
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public DateTime getLastModifiedDate() {
+  public ZonedDateTime getLastModifiedDate() {
     return lastModifiedDate;
   }
 
   @VisibleForTesting
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 
-  public void setLastModifiedDate(DateTime lastModifiedDate) {
+  public void setLastModifiedDate(ZonedDateTime lastModifiedDate) {
     this.lastModifiedDate = lastModifiedDate;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/BranchNotification.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/BranchNotification.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.entity;
 
 import com.box.l10n.mojito.rest.View;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -9,8 +10,6 @@ import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 
 /** @author jeanaurambault */
 @Entity
@@ -32,20 +31,16 @@ public class BranchNotification extends BaseEntity {
   private Branch branch;
 
   @Column(name = "new_msg_sent_at")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  DateTime newMsgSentAt;
+  ZonedDateTime newMsgSentAt;
 
   @Column(name = "updated_msg_sent_at")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  DateTime updatedMsgSentAt;
+  ZonedDateTime updatedMsgSentAt;
 
   @Column(name = "screenshot_missing_msg_sent_at")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  DateTime screenshotMissingMsgSentAt;
+  ZonedDateTime screenshotMissingMsgSentAt;
 
   @Column(name = "translated_msg_sent_at")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  DateTime translatedMsgSentAt;
+  ZonedDateTime translatedMsgSentAt;
 
   @Column(name = "content_md5")
   String contentMD5;
@@ -67,35 +62,35 @@ public class BranchNotification extends BaseEntity {
     this.branch = branch;
   }
 
-  public DateTime getNewMsgSentAt() {
+  public ZonedDateTime getNewMsgSentAt() {
     return newMsgSentAt;
   }
 
-  public void setNewMsgSentAt(DateTime newMsgSentAt) {
+  public void setNewMsgSentAt(ZonedDateTime newMsgSentAt) {
     this.newMsgSentAt = newMsgSentAt;
   }
 
-  public DateTime getUpdatedMsgSentAt() {
+  public ZonedDateTime getUpdatedMsgSentAt() {
     return updatedMsgSentAt;
   }
 
-  public void setUpdatedMsgSentAt(DateTime updatedMsgSentAt) {
+  public void setUpdatedMsgSentAt(ZonedDateTime updatedMsgSentAt) {
     this.updatedMsgSentAt = updatedMsgSentAt;
   }
 
-  public DateTime getScreenshotMissingMsgSentAt() {
+  public ZonedDateTime getScreenshotMissingMsgSentAt() {
     return screenshotMissingMsgSentAt;
   }
 
-  public void setScreenshotMissingMsgSentAt(DateTime screenshotMissingMsgSentAt) {
+  public void setScreenshotMissingMsgSentAt(ZonedDateTime screenshotMissingMsgSentAt) {
     this.screenshotMissingMsgSentAt = screenshotMissingMsgSentAt;
   }
 
-  public DateTime getTranslatedMsgSentAt() {
+  public ZonedDateTime getTranslatedMsgSentAt() {
     return translatedMsgSentAt;
   }
 
-  public void setTranslatedMsgSentAt(DateTime translatedMsgSentAt) {
+  public void setTranslatedMsgSentAt(ZonedDateTime translatedMsgSentAt) {
     this.translatedMsgSentAt = translatedMsgSentAt;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Commit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Commit.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -14,8 +15,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 
 /** @author garion */
 @Entity
@@ -66,8 +65,7 @@ public class Commit extends AuditableEntity {
    */
   @JsonView(View.Commit.class)
   @Column(name = "source_creation_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  private DateTime sourceCreationDate;
+  private ZonedDateTime sourceCreationDate;
 
   @JsonView(View.CommitDetailed.class)
   @JsonManagedReference
@@ -111,11 +109,11 @@ public class Commit extends AuditableEntity {
     this.name = name;
   }
 
-  public DateTime getSourceCreationDate() {
+  public ZonedDateTime getSourceCreationDate() {
     return sourceCreationDate;
   }
 
-  public void setSourceCreationDate(DateTime sourceCreationDate) {
+  public void setSourceCreationDate(ZonedDateTime sourceCreationDate) {
     this.sourceCreationDate = sourceCreationDate;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Drop.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Drop.java
@@ -5,6 +5,7 @@ import com.box.l10n.mojito.rest.View;
 import com.box.l10n.mojito.service.drop.exporter.DropExporterType;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.time.ZonedDateTime;
 import java.util.Set;
 import javax.persistence.Basic;
 import javax.persistence.Column;
@@ -17,8 +18,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 import org.springframework.data.annotation.CreatedBy;
 
 /**
@@ -72,9 +71,8 @@ public class Drop extends AuditableEntity {
    * the status only in one place
    */
   @Column(name = "last_imported_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
   @JsonView(View.DropSummary.class)
-  protected DateTime lastImportedDate;
+  protected ZonedDateTime lastImportedDate;
 
   /**
    * To mark a Drop as canceled so it can be hidden in a dashboard. This shouldn't prevent to
@@ -145,11 +143,11 @@ public class Drop extends AuditableEntity {
     this.dropExporterConfig = dropExporterConfig;
   }
 
-  public DateTime getLastImportedDate() {
+  public ZonedDateTime getLastImportedDate() {
     return lastImportedDate;
   }
 
-  public void setLastImportedDate(DateTime lastImportedDate) {
+  public void setLastImportedDate(ZonedDateTime lastImportedDate) {
     this.lastImportedDate = lastImportedDate;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/PollableTask.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/PollableTask.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.time.ZonedDateTime;
 import java.util.Set;
 import javax.persistence.Basic;
 import javax.persistence.Column;
@@ -23,8 +24,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 import org.springframework.data.annotation.CreatedBy;
 
 /** @author jaurambault */
@@ -50,8 +49,7 @@ public class PollableTask extends AuditableEntity {
   private String name;
 
   @Column(name = "finished_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  private DateTime finishedDate;
+  private ZonedDateTime finishedDate;
 
   @JsonIgnore
   @Column(name = "message", length = Integer.MAX_VALUE)
@@ -107,11 +105,11 @@ public class PollableTask extends AuditableEntity {
     this.name = name;
   }
 
-  public DateTime getFinishedDate() {
+  public ZonedDateTime getFinishedDate() {
     return finishedDate;
   }
 
-  public void setFinishedDate(DateTime finishedDate) {
+  public void setFinishedDate(ZonedDateTime finishedDate) {
     this.finishedDate = finishedDate;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/PushRun.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/PushRun.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.time.ZonedDateTime;
 import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,7 +16,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import org.hibernate.annotations.BatchSize;
-import org.joda.time.DateTime;
 
 /**
  * Represents a single instance/run of the push command against a repository.
@@ -69,11 +69,11 @@ public class PushRun extends SettableAuditableEntity {
     this.name = name;
   }
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/RepositoryStatistic.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/RepositoryStatistic.java
@@ -5,6 +5,7 @@ import com.box.l10n.mojito.rest.View;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.Entity;
@@ -16,8 +17,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 import org.springframework.data.annotation.CreatedBy;
 
 /**
@@ -61,8 +60,7 @@ public class RepositoryStatistic extends AuditableEntity {
   private Long ooslaTextUnitWordCount = 0L;
 
   @JsonView(View.RepositorySummary.class)
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  private DateTime ooslaCreatedBefore;
+  private ZonedDateTime ooslaCreatedBefore;
 
   /** The number of text unit without comments */
   private Long uncommentedTextUnitCount = 0L;
@@ -186,11 +184,11 @@ public class RepositoryStatistic extends AuditableEntity {
     this.ooslaTextUnitWordCount = ooslaTextUnitWordCount;
   }
 
-  public DateTime getOoslaCreatedBefore() {
+  public ZonedDateTime getOoslaCreatedBefore() {
     return ooslaCreatedBefore;
   }
 
-  public void setOoslaCreatedBefore(DateTime ooslaCreatedBefore) {
+  public void setOoslaCreatedBefore(ZonedDateTime ooslaCreatedBefore) {
     this.ooslaCreatedBefore = ooslaCreatedBefore;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/SettableAuditableEntity.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/SettableAuditableEntity.java
@@ -2,11 +2,10 @@ package com.box.l10n.mojito.entity;
 
 import com.box.l10n.mojito.rest.View;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.PrePersist;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 
 /**
  * Similar to {@link AuditableEntity} but allows to override the attributes.
@@ -18,22 +17,21 @@ import org.joda.time.DateTime;
 public abstract class SettableAuditableEntity extends BaseEntity {
 
   @Column(name = "created_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
   @JsonView(View.IdAndNameAndCreated.class)
-  protected DateTime createdDate;
+  protected ZonedDateTime createdDate;
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 
   @PrePersist
   public void onPrePersist() {
     if (createdDate == null) {
-      createdDate = new DateTime();
+      createdDate = ZonedDateTime.now();
     }
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/SlaIncident.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/SlaIncident.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.entity;
 
+import java.time.ZonedDateTime;
 import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -9,8 +10,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 
 /** @author jaurambault */
 @Entity
@@ -18,8 +17,7 @@ import org.joda.time.DateTime;
 public class SlaIncident extends AuditableEntity {
 
   @Column(name = "closed_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  private DateTime closedDate;
+  private ZonedDateTime closedDate;
 
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(
@@ -38,11 +36,11 @@ public class SlaIncident extends AuditableEntity {
     this.repositories = repositories;
   }
 
-  public DateTime getClosedDate() {
+  public ZonedDateTime getClosedDate() {
     return closedDate;
   }
 
-  public void setClosedDate(DateTime closedDate) {
+  public void setClosedDate(ZonedDateTime closedDate) {
     this.closedDate = closedDate;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/StatisticsSchedule.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/StatisticsSchedule.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.entity;
 
+import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -7,8 +8,6 @@ import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 
 /**
  * Entity to keep track of which repository's statistics are outdated.
@@ -33,8 +32,7 @@ public class StatisticsSchedule extends BaseEntity {
   private Repository repository;
 
   @Column(name = "time_to_update")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  protected DateTime timeToUpdate;
+  protected ZonedDateTime timeToUpdate;
 
   public Repository getRepository() {
     return repository;
@@ -44,11 +42,11 @@ public class StatisticsSchedule extends BaseEntity {
     this.repository = repository;
   }
 
-  public DateTime getTimeToUpdate() {
+  public ZonedDateTime getTimeToUpdate() {
     return timeToUpdate;
   }
 
-  public void setTimeToUpdate(DateTime timeToUpdate) {
+  public void setTimeToUpdate(ZonedDateTime timeToUpdate) {
     this.timeToUpdate = timeToUpdate;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnitStatistic.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnitStatistic.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.entity;
 
+import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -8,8 +9,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 
 /** @author garion */
 @Entity
@@ -37,8 +36,7 @@ public class TMTextUnitStatistic extends AuditableEntity {
   private Double lastPeriodUsageCount = 0d;
 
   @Column(name = "last_seen_date")
-  @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
-  private DateTime lastSeenDate;
+  private ZonedDateTime lastSeenDate;
 
   public TMTextUnit getTMTextUnit() {
     return tmTextUnit;
@@ -64,11 +62,11 @@ public class TMTextUnitStatistic extends AuditableEntity {
     this.lastPeriodUsageCount = lastPeriodUsageCount;
   }
 
-  public DateTime getLastSeenDate() {
+  public ZonedDateTime getLastSeenDate() {
     return lastSeenDate;
   }
 
-  public void setLastSeenDate(DateTime lastSeenDate) {
+  public void setLastSeenDate(ZonedDateTime lastSeenDate) {
     this.lastSeenDate = lastSeenDate;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/nativecriteria/JpaNativeQuery.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/nativecriteria/JpaNativeQuery.java
@@ -2,11 +2,12 @@ package com.box.l10n.mojito.nativecriteria;
 
 import com.github.pnowy.nc.core.NativeQuery;
 import com.github.pnowy.nc.core.QueryInfo;
+import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import javax.persistence.Query;
 import javax.persistence.TemporalType;
-import org.joda.time.DateTime;
 
 /** @author jeanaurambault */
 public class JpaNativeQuery implements NativeQuery {
@@ -74,9 +75,9 @@ public class JpaNativeQuery implements NativeQuery {
     return queryInfo;
   }
 
-  public NativeQuery setParameter(String name, DateTime dateTime) {
+  public NativeQuery setParameter(String name, ZonedDateTime dateTime) {
     queryInfo.getParameters().put(name, dateTime);
-    query.setParameter(name, dateTime.toDate(), TemporalType.TIMESTAMP);
+    query.setParameter(name, Date.from(dateTime.toInstant()), TemporalType.TIMESTAMP);
     return this;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/nativecriteria/NativeDateGteExp.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/nativecriteria/NativeDateGteExp.java
@@ -3,7 +3,7 @@ package com.box.l10n.mojito.nativecriteria;
 import com.github.pnowy.nc.core.NativeQuery;
 import com.github.pnowy.nc.core.expressions.NativeExp;
 import com.github.pnowy.nc.utils.Strings;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /** @author jeanaurambault */
 public class NativeDateGteExp implements NativeExp {
@@ -14,13 +14,13 @@ public class NativeDateGteExp implements NativeExp {
   private String varName;
 
   /** Compared value. */
-  private DateTime value;
+  private ZonedDateTime value;
 
   /**
    * @param columnName the column name
    * @param value the value
    */
-  public NativeDateGteExp(String columnName, DateTime value) {
+  public NativeDateGteExp(String columnName, ZonedDateTime value) {
     if (Strings.isBlank(columnName)) throw new IllegalStateException("columnName is null!");
     if (value == null) throw new IllegalStateException("value is null!");
 

--- a/webapp/src/main/java/com/box/l10n/mojito/nativecriteria/NativeDateLteExp.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/nativecriteria/NativeDateLteExp.java
@@ -3,7 +3,7 @@ package com.box.l10n.mojito.nativecriteria;
 import com.github.pnowy.nc.core.NativeQuery;
 import com.github.pnowy.nc.core.expressions.NativeExp;
 import com.github.pnowy.nc.utils.Strings;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /** @author jeanaurambault */
 public class NativeDateLteExp implements NativeExp {
@@ -14,13 +14,13 @@ public class NativeDateLteExp implements NativeExp {
   private String varName;
 
   /** Compared value. */
-  private DateTime value;
+  private ZonedDateTime value;
 
   /**
    * @param columnName the column name
    * @param value the value
    */
-  public NativeDateLteExp(String columnName, DateTime value) {
+  public NativeDateLteExp(String columnName, ZonedDateTime value) {
     if (Strings.isBlank(columnName)) throw new IllegalStateException("columnName is null!");
     if (value == null) throw new IllegalStateException("value is null!");
 

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/AbstractImportTranslationsStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/AbstractImportTranslationsStep.java
@@ -17,6 +17,7 @@ import com.box.l10n.mojito.service.tm.TMTextUnitCurrentVariantRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitVariantCommentService;
 import com.box.l10n.mojito.service.tm.TMTextUnitVariantRepository;
+import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import net.sf.okapi.common.Event;
@@ -28,7 +29,6 @@ import net.sf.okapi.common.resource.Property;
 import net.sf.okapi.common.resource.RawDocument;
 import net.sf.okapi.common.resource.StartDocument;
 import net.sf.okapi.common.resource.TextContainer;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,7 +92,7 @@ public abstract class AbstractImportTranslationsStep extends AbstractMd5Computat
   boolean isMultilingual = false;
 
   /** Created date used for all the text unit imported */
-  DateTime createdDate;
+  ZonedDateTime createdDate;
 
   /** Target comment to set during import */
   String targetComment = null;
@@ -126,7 +126,7 @@ public abstract class AbstractImportTranslationsStep extends AbstractMd5Computat
     StartDocument startDocument = event.getStartDocument();
     isMultilingual = startDocument.isMultilingual();
 
-    createdDate = new DateTime();
+    createdDate = ZonedDateTime.now();
     if (dropImporterUsernameOverride == null) {
       createdBy = auditorAwareImpl.getCurrentAuditor().orElse(null);
     } else {
@@ -387,7 +387,7 @@ public abstract class AbstractImportTranslationsStep extends AbstractMd5Computat
       TMTextUnit tmTextUnit,
       TextContainer target,
       TMTextUnitVariant.Status status,
-      DateTime createdDate) {
+      ZonedDateTime createdDate) {
 
     Long targetLocaleId = getTargetLocaleId();
     Long tmTextUnitId = tmTextUnit.getId();

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/ImportTranslationsWithTranslationKitStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/ImportTranslationsWithTranslationKitStep.java
@@ -6,12 +6,12 @@ import com.box.l10n.mojito.entity.TranslationKit;
 import com.box.l10n.mojito.service.translationkit.TranslationKitExportedImportedAndCurrentTUV;
 import com.box.l10n.mojito.service.translationkit.TranslationKitRepository;
 import com.box.l10n.mojito.service.translationkit.TranslationKitService;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Objects;
 import net.sf.okapi.common.Event;
 import net.sf.okapi.common.resource.StartSubDocument;
 import net.sf.okapi.common.resource.TextContainer;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -116,7 +116,7 @@ public class ImportTranslationsWithTranslationKitStep extends ImportTranslations
       TMTextUnit tmTextUnit,
       TextContainer target,
       TMTextUnitVariant.Status status,
-      DateTime createdDate) {
+      ZonedDateTime createdDate) {
     TMTextUnitVariant importTextUnit =
         super.importTextUnit(tmTextUnit, target, status, createdDate);
     translationKitService.markTranslationKitTextUnitAsImported(translationKit, importTextUnit);

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableJob.java
@@ -64,7 +64,8 @@ public abstract class QuartzPollableJob<I, O> implements Job {
     meterRegistry
         .timer("QuartzPollableJob.currentPollableTask.timeFromScheduledToExecution", metricTags)
         .record(
-            System.currentTimeMillis() - currentPollableTask.getCreatedDate().getMillis(),
+            System.currentTimeMillis()
+                - currentPollableTask.getCreatedDate().toInstant().toEpochMilli(),
             TimeUnit.MILLISECONDS);
 
     ExceptionHolder exceptionHolder = new ExceptionHolder(currentPollableTask);
@@ -103,8 +104,8 @@ public abstract class QuartzPollableJob<I, O> implements Job {
       meterRegistry
           .timer("QuartzPollableJob.currentPollableTask.timeFromScheduledToFinish", metricTags)
           .record(
-              currentPollableTask.getFinishedDate().getMillis()
-                  - currentPollableTask.getCreatedDate().getMillis(),
+              currentPollableTask.getFinishedDate().toInstant().toEpochMilli()
+                  - currentPollableTask.getCreatedDate().toInstant().toEpochMilli(),
               TimeUnit.MILLISECONDS);
 
       executeSample.stop(

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/commit/CommitBody.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/commit/CommitBody.java
@@ -1,7 +1,7 @@
 package com.box.l10n.mojito.rest.commit;
 
 import com.box.l10n.mojito.entity.Repository;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /** @author garion */
 public class CommitBody {
@@ -18,7 +18,7 @@ public class CommitBody {
   String authorName;
 
   /** The commit date (instead of the author date). */
-  DateTime sourceCreationDate;
+  ZonedDateTime sourceCreationDate;
 
   public Long getRepositoryId() {
     return repositoryId;
@@ -52,11 +52,11 @@ public class CommitBody {
     this.authorName = authorName;
   }
 
-  public DateTime getSourceCreationDate() {
+  public ZonedDateTime getSourceCreationDate() {
     return sourceCreationDate;
   }
 
-  public void setSourceCreationDate(DateTime sourceCreationDate) {
+  public void setSourceCreationDate(ZonedDateTime sourceCreationDate) {
     this.sourceCreationDate = sourceCreationDate;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/delta/DeltaWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/delta/DeltaWS.java
@@ -18,10 +18,10 @@ import com.box.l10n.mojito.service.pullrun.PullRunRepository;
 import com.box.l10n.mojito.service.pushrun.PushRunRepository;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.tm.TextUnitVariantDeltaDTO;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import javax.persistence.EntityManager;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -78,8 +78,8 @@ public class DeltaWS {
   public Page<TextUnitVariantDeltaDTO> getDeltasFromDate(
       @RequestParam(value = "repositoryId") Long repositoryId,
       @RequestParam(value = "bcp47Tags", required = false) List<String> bcp47Tags,
-      @RequestParam(value = "fromDate", required = false) DateTime fromDate,
-      @RequestParam(value = "toDate", required = false) DateTime toDate,
+      @RequestParam(value = "fromDate", required = false) ZonedDateTime fromDate,
+      @RequestParam(value = "toDate", required = false) ZonedDateTime toDate,
       @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable)
       throws RepositoryWithIdNotFoundException {
 

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchSpecification.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchSpecification.java
@@ -6,13 +6,13 @@ import com.box.l10n.mojito.entity.BranchStatistic_;
 import com.box.l10n.mojito.entity.Branch_;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.specification.SingleParamSpecification;
+import java.time.ZonedDateTime;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-import org.joda.time.DateTime;
 
 /** @author jeanaurambault */
 public class BranchSpecification {
@@ -47,7 +47,7 @@ public class BranchSpecification {
     };
   }
 
-  public static SingleParamSpecification<Branch> createdBefore(final DateTime createdBefore) {
+  public static SingleParamSpecification<Branch> createdBefore(final ZonedDateTime createdBefore) {
     return new SingleParamSpecification<Branch>(createdBefore) {
       @Override
       public Predicate toPredicate(

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchStatisticSpecification.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchStatisticSpecification.java
@@ -7,13 +7,13 @@ import com.box.l10n.mojito.entity.Branch_;
 import com.box.l10n.mojito.entity.security.user.User;
 import com.box.l10n.mojito.entity.security.user.User_;
 import com.box.l10n.mojito.specification.SingleParamSpecification;
+import java.time.ZonedDateTime;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-import org.joda.time.DateTime;
 
 /** @author jeanaurambault */
 public class BranchStatisticSpecification {
@@ -86,7 +86,7 @@ public class BranchStatisticSpecification {
   }
 
   public static SingleParamSpecification<BranchStatistic> createdBefore(
-      final DateTime createdBefore) {
+      final ZonedDateTime createdBefore) {
     return new SingleParamSpecification<BranchStatistic>(createdBefore) {
       @Override
       public Predicate toPredicate(
@@ -99,7 +99,7 @@ public class BranchStatisticSpecification {
   }
 
   public static SingleParamSpecification<BranchStatistic> createdAfter(
-      final DateTime createdAfter) {
+      final ZonedDateTime createdAfter) {
     return new SingleParamSpecification<BranchStatistic>(createdAfter) {
       @Override
       public Predicate toPredicate(

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchStatisticWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchStatisticWS.java
@@ -20,9 +20,9 @@ import com.box.l10n.mojito.service.branch.BranchRepository;
 import com.box.l10n.mojito.service.branch.BranchStatisticRepository;
 import com.box.l10n.mojito.service.branch.SparseBranchStatisticRepository;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -60,8 +60,8 @@ public class BranchStatisticWS {
       @RequestParam(value = "empty", required = false) Boolean empty,
       @RequestParam(value = "totalCountLte", required = false, defaultValue = "30000")
           Long totalCountLte,
-      @RequestParam(value = "createdBefore", required = false) DateTime createdBefore,
-      @RequestParam(value = "createdAfter", required = false) DateTime createdAfter,
+      @RequestParam(value = "createdBefore", required = false) ZonedDateTime createdBefore,
+      @RequestParam(value = "createdAfter", required = false) ZonedDateTime createdAfter,
       @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
     // Two phase querying: 1. retrieve BranchStatistic IDs for pagination first
     // Retrieve all the Branch Statistic Ids without the totalCountLte filter:

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
@@ -24,8 +24,8 @@ import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.repository.RepositoryService;
 import com.box.l10n.mojito.service.tm.TMImportService;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.time.ZonedDateTime;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -236,7 +236,7 @@ public class RepositoryWS {
       @RequestParam(value = "name", required = false) String branchName,
       @RequestParam(value = "deleted", required = false) Boolean deleted,
       @RequestParam(value = "translated", required = false) Boolean translated,
-      @RequestParam(value = "createdBefore", required = false) DateTime createdBefore)
+      @RequestParam(value = "createdBefore", required = false) ZonedDateTime createdBefore)
       throws RepositoryWithIdNotFoundException {
     ResponseEntity<Repository> result;
     Repository repository = repositoryRepository.findById(repositoryId).orElse(null);

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/CustomZonedDateTimeDeserializer.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/CustomZonedDateTimeDeserializer.java
@@ -1,0 +1,25 @@
+package com.box.l10n.mojito.rest.textunit;
+
+import com.box.l10n.mojito.DateTimeUtils;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+/**
+ * Deserialize an object into {@link ZonedDateTime}. The object can either be a number of
+ * milliseconds from 1970-01-01T00:00:00Z or a string representing a date following the ISO format,
+ * such as '2023-11-28T22:15:30.000Z'.
+ *
+ * @author hylston.barbosa
+ */
+public class CustomZonedDateTimeDeserializer extends JsonDeserializer<ZonedDateTime> {
+
+  @Override
+  public ZonedDateTime deserialize(JsonParser parser, DeserializationContext context)
+      throws IOException {
+
+    return DateTimeUtils.longOrStrAsZonedDate(parser.getText());
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/ImportTextUnitStatisticsBody.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/ImportTextUnitStatisticsBody.java
@@ -1,6 +1,6 @@
 package com.box.l10n.mojito.rest.textunit;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 public class ImportTextUnitStatisticsBody {
   private String name;
@@ -13,7 +13,7 @@ public class ImportTextUnitStatisticsBody {
 
   private Double lastPeriodEstimatedVolume;
 
-  private DateTime lastSeenDate;
+  private ZonedDateTime lastSeenDate;
 
   public String getName() {
     return name;
@@ -55,11 +55,11 @@ public class ImportTextUnitStatisticsBody {
     this.lastPeriodEstimatedVolume = lastPeriodEstimatedVolume;
   }
 
-  public DateTime getLastSeenDate() {
+  public ZonedDateTime getLastSeenDate() {
     return lastSeenDate;
   }
 
-  public void setLastSeenDate(DateTime lastSeenDate) {
+  public void setLastSeenDate(ZonedDateTime lastSeenDate) {
     this.lastSeenDate = lastSeenDate;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/StringToDateTimeConverter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/StringToDateTimeConverter.java
@@ -1,35 +1,23 @@
 package com.box.l10n.mojito.rest.textunit;
 
-import org.joda.time.DateTime;
+import com.box.l10n.mojito.DateTimeUtils;
+import java.time.ZonedDateTime;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
 /**
- * Converts a {@link String} into {@link DateTime}. The string can either be a number of
- * milliseconds from 1970-01-01T00:00:00Z or any format recognized by {@link
- * DateTime#DateTime(java.lang.Object) }
+ * Converts a {@link String} into {@link ZonedDateTime}. The string can either be a number of
+ * milliseconds from 1970-01-01T00:00:00Z or a string representing a date following the ISO format,
+ * such as '2011-12-03T10:15:30'.
  *
  * @author jeanaurambault
  */
 @Component
-public class StringToDateTimeConverter implements Converter<String, DateTime> {
+public class StringToDateTimeConverter implements Converter<String, ZonedDateTime> {
 
   @Override
-  public DateTime convert(String source) {
+  public ZonedDateTime convert(String source) {
 
-    DateTime converted = null;
-
-    if (source != null) {
-      Object instant;
-
-      try {
-        instant = Long.parseLong(source);
-      } catch (NumberFormatException nfe) {
-        instant = source;
-      }
-      converted = new DateTime(instant);
-    }
-
-    return converted;
+    return DateTimeUtils.longOrStrAsZonedDate(source);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitSearchBody.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitSearchBody.java
@@ -3,8 +3,8 @@ package com.box.l10n.mojito.rest.textunit;
 import com.box.l10n.mojito.service.tm.search.SearchType;
 import com.box.l10n.mojito.service.tm.search.StatusFilter;
 import com.box.l10n.mojito.service.tm.search.UsedFilter;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import org.joda.time.DateTime;
 
 class TextUnitSearchBody {
   ArrayList<Long> repositoryIds;
@@ -22,8 +22,8 @@ class TextUnitSearchBody {
   UsedFilter usedFilter;
   StatusFilter statusFilter;
   Boolean doNotTranslateFilter;
-  DateTime tmTextUnitCreatedBefore;
-  DateTime tmTextUnitCreatedAfter;
+  ZonedDateTime tmTextUnitCreatedBefore;
+  ZonedDateTime tmTextUnitCreatedAfter;
   Long branchId;
   Integer limit = 10;
   Integer offset = 0;
@@ -148,19 +148,19 @@ class TextUnitSearchBody {
     this.doNotTranslateFilter = doNotTranslateFilter;
   }
 
-  public DateTime getTmTextUnitCreatedBefore() {
+  public ZonedDateTime getTmTextUnitCreatedBefore() {
     return tmTextUnitCreatedBefore;
   }
 
-  public void setTmTextUnitCreatedBefore(DateTime tmTextUnitCreatedBefore) {
+  public void setTmTextUnitCreatedBefore(ZonedDateTime tmTextUnitCreatedBefore) {
     this.tmTextUnitCreatedBefore = tmTextUnitCreatedBefore;
   }
 
-  public DateTime getTmTextUnitCreatedAfter() {
+  public ZonedDateTime getTmTextUnitCreatedAfter() {
     return tmTextUnitCreatedAfter;
   }
 
-  public void setTmTextUnitCreatedAfter(DateTime tmTextUnitCreatedAfter) {
+  public void setTmTextUnitCreatedAfter(ZonedDateTime tmTextUnitCreatedAfter) {
     this.tmTextUnitCreatedAfter = tmTextUnitCreatedAfter;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionService.java
@@ -65,6 +65,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.ibm.icu.text.MessageFormat;
 import io.micrometer.core.annotation.Timed;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -80,7 +81,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -362,7 +362,7 @@ public class AssetExtractionService {
 
     logger.debug(
         "Change asset extraction last modified date to create a new version for optimistic locking");
-    assetExtraction.setLastModifiedDate(new DateTime());
+    assetExtraction.setLastModifiedDate(ZonedDateTime.now());
     assetExtraction.setContentMd5(assetContentMd5s.getContentMd5());
     assetExtraction.setFilterOptionsMd5(assetContentMd5s.getFilterOptionsMd5());
     assetExtractionRepository.save(assetExtraction);
@@ -940,7 +940,7 @@ public class AssetExtractionService {
         asset.getRepository().getTm().getId(),
         asset.getId());
 
-    DateTime createdDate = DateTime.now();
+    ZonedDateTime createdDate = ZonedDateTime.now();
 
     ImmutableList<BranchStateTextUnit> createdTmTextUnits =
         Lists.partition(textUnits, BATCH_SIZE).stream()
@@ -951,7 +951,7 @@ public class AssetExtractionService {
   }
 
   Function<List<BranchStateTextUnit>, Stream<? extends BranchStateTextUnit>> createTmTextUnitsBatch(
-      Asset asset, User createdByUser, DateTime createdDate) {
+      Asset asset, User createdByUser, ZonedDateTime createdDate) {
     return textUnits -> {
       ImmutableList<BranchStateTextUnit> subCreatedTmTextUnits =
           textUnits.stream()

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/LocalBranchToEntityBranchConverter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/LocalBranchToEntityBranchConverter.java
@@ -2,7 +2,8 @@ package com.box.l10n.mojito.service.assetExtraction;
 
 import com.box.l10n.mojito.localtm.merger.Branch;
 import java.time.Instant;
-import org.joda.time.DateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -11,8 +12,8 @@ import org.springframework.stereotype.Component;
 public class LocalBranchToEntityBranchConverter {
 
   public static final String NULL_BRANCH_TEXT_PLACEHOLDER = "$$MOJITO_DEFAULT$$";
-  public static final DateTime NULL_BRANCH_DATE_PLACEHODLER =
-      new DateTime(Instant.EPOCH.toEpochMilli());
+  public static final ZonedDateTime NULL_BRANCH_DATE_PLACEHODLER =
+      ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault());
 
   /** logger */
   static Logger logger = LoggerFactory.getLogger(LocalBranchToEntityBranchConverter.class);
@@ -39,7 +40,7 @@ public class LocalBranchToEntityBranchConverter {
       builder.name(NULL_BRANCH_TEXT_PLACEHOLDER).createdAt(NULL_BRANCH_DATE_PLACEHODLER);
     } else {
       String branchName = b.getName() == null ? NULL_BRANCH_TEXT_PLACEHOLDER : b.getName();
-      DateTime createdDate =
+      ZonedDateTime createdDate =
           b.getCreatedDate() != null ? b.getCreatedDate() : NULL_BRANCH_DATE_PLACEHODLER;
       builder.name(branchName).createdAt(createdDate);
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
@@ -19,12 +19,12 @@ import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.utils.DateTimeUtils;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -165,7 +165,7 @@ public class BranchNotificationService {
    * @param notifierId
    */
   void scheduleMissingScreenshotNotificationsForBranch(Branch branch, String notifierId) {
-    Date date = DateTime.now().plusMinutes(30).toDate();
+    Date date = Date.from(ZonedDateTime.now().plusMinutes(30).toInstant());
 
     BranchNotificationMissingScreenshotsJobInput branchNotificationMissingScreenshotsJobInput =
         new BranchNotificationMissingScreenshotsJobInput();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheUpdaterService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheUpdaterService.java
@@ -5,10 +5,12 @@ import static org.slf4j.LoggerFactory.getLogger;
 import com.box.l10n.mojito.entity.ApplicationCache;
 import com.box.l10n.mojito.entity.ApplicationCacheType;
 import com.box.l10n.mojito.service.DBUtils;
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.query.Param;
@@ -56,7 +58,7 @@ public class ApplicationCacheUpdaterService {
       Optional<ApplicationCache> existingEntry =
           applicationCacheRepository.findByApplicationCacheTypeAndKeyMD5(
               applicationCacheType, keyMD5);
-      DateTime currentSqlTimestamp = getCurrentSqlTimestamp();
+      ZonedDateTime currentSqlTimestamp = getCurrentSqlTimestamp();
 
       ApplicationCache applicationCache;
 
@@ -104,7 +106,7 @@ public class ApplicationCacheUpdaterService {
           applicationCacheRepository.findByApplicationCacheTypeAndKeyMD5(
               applicationCacheType, keyMD5);
       ApplicationCache applicationCache;
-      DateTime currentSqlTimestamp = getCurrentSqlTimestamp();
+      ZonedDateTime currentSqlTimestamp = getCurrentSqlTimestamp();
 
       if (existingEntry.isPresent()) {
         applicationCache = existingEntry.get();
@@ -118,19 +120,19 @@ public class ApplicationCacheUpdaterService {
     }
   }
 
-  private DateTime getCurrentSqlTimestamp() {
-    DateTime currentTimestamp;
+  private ZonedDateTime getCurrentSqlTimestamp() {
+    ZonedDateTime currentTimestamp;
 
     try {
+      Object timestampResult =
+          entityManager
+              .createNativeQuery("SELECT TOP 1 CURRENT_TIMESTAMP FROM INFORMATION_SCHEMA.TABLES")
+              .getSingleResult();
       currentTimestamp =
-          new DateTime(
-              entityManager
-                  .createNativeQuery(
-                      "SELECT TOP 1 CURRENT_TIMESTAMP FROM INFORMATION_SCHEMA.TABLES")
-                  .getSingleResult());
+          ((Timestamp) timestampResult).toLocalDateTime().atZone(ZoneId.systemDefault());
     } catch (Exception ex) {
       logger.error("Could not retrieve current timestamp from the SQL DB", ex);
-      currentTimestamp = DateTime.now();
+      currentTimestamp = ZonedDateTime.now();
     }
     return currentTimestamp;
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitService.java
@@ -18,9 +18,10 @@ import com.box.l10n.mojito.service.pullrun.PullRunWithNameNotFoundException;
 import com.box.l10n.mojito.service.pushrun.PushRunRepository;
 import com.box.l10n.mojito.service.pushrun.PushRunWithNameNotFoundException;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -108,7 +109,7 @@ public class CommitService {
       String commitName,
       String authorEmail,
       String authorName,
-      DateTime sourceCreationDate)
+      ZonedDateTime sourceCreationDate)
       throws SaveCommitMismatchedExistingDataException {
     Commit commit = new Commit();
 
@@ -129,9 +130,13 @@ public class CommitService {
       }
 
       // Remove milliseconds when comparing as the dates are not stored with sub-second precision.
-      DateTime existingCreationDateWithoutMs = commit.getSourceCreationDate().withMillisOfSecond(0);
-      DateTime sourceCreationDateWithoutMs = sourceCreationDate.withMillisOfSecond(0);
-      if (existingCreationDateWithoutMs.getMillis() != sourceCreationDateWithoutMs.getMillis()) {
+      ZonedDateTime existingCreationDateWithoutMs =
+          commit.getSourceCreationDate().truncatedTo(ChronoUnit.SECONDS);
+      ZonedDateTime sourceCreationDateWithoutMs =
+          sourceCreationDate.truncatedTo(ChronoUnit.SECONDS);
+      if (!existingCreationDateWithoutMs
+          .toInstant()
+          .equals(sourceCreationDateWithoutMs.toInstant())) {
         throw new SaveCommitMismatchedExistingDataException(
             "sourceCreationDate",
             commit.getSourceCreationDate().toString(),

--- a/webapp/src/main/java/com/box/l10n/mojito/service/delta/DeltaService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/delta/DeltaService.java
@@ -18,7 +18,9 @@ import com.box.l10n.mojito.service.tm.TextUnitVariantDeltaDTO;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -27,7 +29,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.joda.time.DateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -65,8 +66,8 @@ public class DeltaService {
   public Page<TextUnitVariantDeltaDTO> getDeltasForDates(
       Repository repository,
       List<Locale> locales,
-      DateTime fromDate,
-      DateTime toDate,
+      ZonedDateTime fromDate,
+      ZonedDateTime toDate,
       Pageable pageable) {
     if (locales == null || locales.size() == 0) {
       locales =
@@ -76,11 +77,11 @@ public class DeltaService {
     }
 
     if (fromDate == null) {
-      fromDate = new DateTime(0);
+      fromDate = ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault());
     }
 
     if (toDate == null) {
-      toDate = DateTime.now();
+      toDate = ZonedDateTime.now();
     }
 
     return tmTextUnitVariantRepository.findAllUsedForRepositoryAndLocalesInDateRange(
@@ -123,16 +124,16 @@ public class DeltaService {
     List<Long> pushRunIds = getIds(pushRuns);
     List<Long> pullRunIds = getIds(pullRuns);
 
-    DateTime translationsFromDate =
+    ZonedDateTime translationsFromDate =
         Optional.ofNullable(pullRuns).orElse(Collections.emptyList()).stream()
             .min(Comparator.comparing(PullRun::getCreatedDate))
             .map(PullRun::getCreatedDate)
             // Remove milliseconds as the Mojito DB does not store dates with sub-second precision.
-            .map(dateTime -> dateTime.withMillisOfSecond(0))
-            .orElse(new DateTime(0));
-    Instant fromDateInstant = Instant.ofEpochMilli(translationsFromDate.getMillis());
+            .map(dateTime -> dateTime.withNano(0))
+            .orElse(ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC));
     Timestamp sqlTranslationsFromDate =
-        Timestamp.valueOf(LocalDateTime.ofInstant(fromDateInstant, ZoneOffset.UTC));
+        Timestamp.valueOf(
+            LocalDateTime.ofInstant(translationsFromDate.toInstant(), ZoneOffset.UTC));
 
     List<TextUnitVariantDelta> variants =
         tmTextUnitVariantRepository.findDeltasForRuns(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/delta/dtos/DeltaMetadataDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/delta/dtos/DeltaMetadataDTO.java
@@ -1,7 +1,7 @@
 package com.box.l10n.mojito.service.delta.dtos;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /**
  * Metadata for the Delta response.
@@ -15,28 +15,28 @@ public class DeltaMetadataDTO {
    * where created based on a date range.
    */
   @JsonProperty("fromDate")
-  public DateTime fromDate;
+  public ZonedDateTime fromDate;
 
   /**
    * This records the end date up to which point we would have captured deltas to, when deltas where
    * created based on a date range.
    */
   @JsonProperty("toDate")
-  public DateTime toDate;
+  public ZonedDateTime toDate;
 
-  public DateTime getFromDate() {
+  public ZonedDateTime getFromDate() {
     return fromDate;
   }
 
-  public void setFromDate(DateTime fromDate) {
+  public void setFromDate(ZonedDateTime fromDate) {
     this.fromDate = fromDate;
   }
 
-  public DateTime getToDate() {
+  public ZonedDateTime getToDate() {
     return toDate;
   }
 
-  public void setToDate(DateTime toDate) {
+  public void setToDate(ZonedDateTime toDate) {
     this.toDate = toDate;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
@@ -27,12 +27,12 @@ import com.box.l10n.mojito.service.tm.UpdateTMWithXLIFFResult;
 import com.box.l10n.mojito.service.translationkit.TranslationKitAsXliff;
 import com.box.l10n.mojito.service.translationkit.TranslationKitService;
 import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import net.sf.okapi.common.exceptions.OkapiBadFilterInputException;
 import net.sf.okapi.common.exceptions.OkapiIOException;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -225,7 +225,7 @@ public class DropService {
     logger.debug("Start importing drop");
 
     Drop drop = dropRepository.findById(dropId).orElse(null);
-    drop.setLastImportedDate(new DateTime());
+    drop.setLastImportedDate(ZonedDateTime.now());
     drop.setImportPollableTask(currentTask);
     drop.setImportFailed(null);
     dropRepository.save(drop);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskService.java
@@ -3,10 +3,10 @@ package com.box.l10n.mojito.service.pollableTask;
 import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.json.ObjectMapper;
 import com.google.common.base.Throwables;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,7 +86,7 @@ public class PollableTaskService {
       Integer expectedSubTaskNumberOverride) {
 
     PollableTask pollableTask = getPollableTask(id);
-    pollableTask.setFinishedDate(DateTime.now());
+    pollableTask.setFinishedDate(ZonedDateTime.now());
 
     if (exceptionHolder != null && exceptionHolder.getException() != null) {
       pollableTask.setErrorStack(Throwables.getStackTraceAsString(exceptionHolder.getException()));

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunService.java
@@ -5,7 +5,7 @@ import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.service.commit.CommitToPullRunRepository;
 import java.sql.Timestamp;
 import java.time.Duration;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,8 +46,8 @@ public class PullRunService {
   }
 
   public void deleteAllPullEntitiesOlderThan(Duration retentionDuration) {
-    DateTime beforeDate = DateTime.now().minusSeconds((int) retentionDuration.getSeconds());
-    Timestamp sqlBeforeDate = new Timestamp(beforeDate.toDate().getTime());
+    ZonedDateTime beforeDate = ZonedDateTime.now().minusSeconds(retentionDuration.getSeconds());
+    Timestamp sqlBeforeDate = Timestamp.from(beforeDate.toInstant());
 
     int batchNumber = 1;
     int deleteCount;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunService.java
@@ -8,16 +8,12 @@ import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.service.commit.CommitToPushRunRepository;
 import com.google.common.collect.Lists;
 import java.sql.Timestamp;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
@@ -147,8 +143,8 @@ public class PushRunService {
   }
 
   public void deleteAllPushEntitiesOlderThan(Duration retentionDuration) {
-    DateTime beforeDate = DateTime.now().minusSeconds((int) retentionDuration.getSeconds());
-    Timestamp sqlBeforeDate = new Timestamp(beforeDate.toDate().getTime());
+    ZonedDateTime beforeDate = ZonedDateTime.now().minusSeconds(retentionDuration.getSeconds());
+    Timestamp sqlBeforeDate = Timestamp.from(beforeDate.toInstant());
 
     int batchNumber = 1;
     int deleteCount;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticService.java
@@ -28,10 +28,10 @@ import com.box.l10n.mojito.service.tm.textunitdtocache.UpdateType;
 import com.google.common.collect.ImmutableList;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.util.ULocale;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.function.ToLongFunction;
 import javax.persistence.EntityManager;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -120,7 +120,7 @@ public class RepositoryStatisticService {
         newRepositoryStatistics.getOoslaTextUnitWordCount());
 
     // TODO(P1) This should be updated by spring but it's not, needs review
-    repositoryStatistic.setLastModifiedDate(DateTime.now());
+    repositoryStatistic.setLastModifiedDate(ZonedDateTime.now());
 
     repositoryStatisticRepository.save(repositoryStatistic);
 
@@ -462,7 +462,7 @@ public class RepositoryStatisticService {
   }
 
   TextUnitAndWordCount getUntranslatedTextUnitsCountBeforeCreatedDate(
-      Long repositoryId, DateTime createdBefore) {
+      Long repositoryId, ZonedDateTime createdBefore) {
     logger.debug(
         "Get untranslated text unit for repository id: {} and before date: {}",
         repositoryId,
@@ -481,7 +481,7 @@ public class RepositoryStatisticService {
       Long repositoryId, RepositoryStatistic repositoryStatistic) {
     if (computeOutOfSla) {
       logger.debug("Update repository statistic with out of SLA statistics");
-      DateTime lastDropCreatedDate = dropScheduleService.getLastDropCreatedDate();
+      ZonedDateTime lastDropCreatedDate = dropScheduleService.getLastDropCreatedDate();
       TextUnitAndWordCount countTextUnitAndWordCount =
           getUntranslatedTextUnitsCountBeforeCreatedDate(repositoryId, lastDropCreatedDate);
       repositoryStatistic.setOoslaTextUnitCount(countTextUnitAndWordCount.getTextUnitCount());

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/StatisticsScheduleRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/StatisticsScheduleRepository.java
@@ -1,9 +1,9 @@
 package com.box.l10n.mojito.service.repository.statistics;
 
 import com.box.l10n.mojito.entity.StatisticsSchedule;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
-import org.joda.time.DateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
@@ -16,5 +16,5 @@ public interface StatisticsScheduleRepository extends JpaRepository<StatisticsSc
   public Set<Long> findRepositoryIds();
 
   public List<StatisticsSchedule> findByRepositoryIdAndTimeToUpdateBefore(
-      Long repositoryId, DateTime timeToUpdate);
+      Long repositoryId, ZonedDateTime timeToUpdate);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/rollback/CurrentVariantRollbackService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/rollback/CurrentVariantRollbackService.java
@@ -4,6 +4,8 @@ import com.box.l10n.mojito.entity.TMTextUnitCurrentVariant;
 import com.box.l10n.mojito.entity.TMTextUnitCurrentVariant_;
 import com.box.l10n.mojito.service.tm.TMTextUnitCurrentVariantRepository;
 import com.google.common.base.Preconditions;
+import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -15,7 +17,6 @@ import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
 import org.hibernate.envers.query.AuditEntity;
 import org.hibernate.envers.query.AuditQuery;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,7 +42,7 @@ public class CurrentVariantRollbackService {
    * @param tmId ID of the TM the {@link TMTextUnitCurrentVariant}s to be rolled back should belong
    *     to
    */
-  public void rollbackCurrentVariantsFromTMToDate(DateTime rollbackDateTime, Long tmId) {
+  public void rollbackCurrentVariantsFromTMToDate(ZonedDateTime rollbackDateTime, Long tmId) {
     rollbackCurrentVariantsFromTMToDate(
         rollbackDateTime, tmId, new CurrentVariantRollbackParameters());
   }
@@ -58,7 +59,7 @@ public class CurrentVariantRollbackService {
    */
   @Transactional
   public void rollbackCurrentVariantsFromTMToDate(
-      DateTime rollbackDateTime, Long tmId, CurrentVariantRollbackParameters extraParameters) {
+      ZonedDateTime rollbackDateTime, Long tmId, CurrentVariantRollbackParameters extraParameters) {
 
     Preconditions.checkNotNull(extraParameters, "Extra parameters should not be null");
 
@@ -138,7 +139,7 @@ public class CurrentVariantRollbackService {
    * @param extraParameters Extra parameters to filter what to rollback
    */
   protected void addCurrentVariantsAsOfRollbackDate(
-      DateTime rollbackDateTime, Long tmId, CurrentVariantRollbackParameters extraParameters) {
+      ZonedDateTime rollbackDateTime, Long tmId, CurrentVariantRollbackParameters extraParameters) {
 
     logger.debug("Adding back TMTextUnitCurrentVariants as of {}", rollbackDateTime);
 
@@ -160,12 +161,13 @@ public class CurrentVariantRollbackService {
    * @return The insert audit query
    */
   protected AuditQuery buildInsertAuditQuery(
-      DateTime rollbackDateTime, Long tmId, CurrentVariantRollbackParameters extraParameters) {
+      ZonedDateTime rollbackDateTime, Long tmId, CurrentVariantRollbackParameters extraParameters) {
 
     logger.trace("Building the insert tmTextUnitCurrentVariants audit query");
 
     AuditReader auditReader = AuditReaderFactory.get(entityManager);
-    Number revNumberAtDate = auditReader.getRevisionNumberForDate(rollbackDateTime.toDate());
+    Date rollbackDate = Date.from(rollbackDateTime.toInstant());
+    Number revNumberAtDate = auditReader.getRevisionNumberForDate(rollbackDate);
 
     AuditQuery auditQuery =
         auditReader

--- a/webapp/src/main/java/com/box/l10n/mojito/service/sla/DropScheduleConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/sla/DropScheduleConfig.java
@@ -1,9 +1,9 @@
 package com.box.l10n.mojito.service.sla;
 
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalTime;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,21 +12,21 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "l10n.drop-schedule")
 public class DropScheduleConfig {
 
-  DateTimeZone timezone = DateTimeZone.forID("PST8PDT");
+  ZoneId timezone = ZoneId.of("America/Los_Angeles");
 
   List<Integer> createdDays = Arrays.asList(1, 2, 3, 4, 5);
 
   List<Integer> dueDays = Arrays.asList(3, 4, 5, 1, 2);
 
-  LocalTime createdLocalTime = new LocalTime("20:00");
+  LocalTime createdLocalTime = LocalTime.of(20, 0);
 
-  LocalTime dueLocalTime = new LocalTime("14:00");
+  LocalTime dueLocalTime = LocalTime.of(14, 0);
 
-  public DateTimeZone getTimezone() {
+  public ZoneId getTimezone() {
     return timezone;
   }
 
-  public void setTimezone(DateTimeZone timezone) {
+  public void setTimezone(ZoneId timezone) {
     this.timezone = timezone;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/sla/DropScheduleService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/sla/DropScheduleService.java
@@ -2,10 +2,11 @@ package com.box.l10n.mojito.service.sla;
 
 import com.box.l10n.mojito.utils.DateTimeUtils;
 import com.google.common.collect.Sets;
+import java.time.DayOfWeek;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,20 +22,25 @@ public class DropScheduleService {
 
   @Autowired DateTimeUtils dateTimeUtils;
 
-  public DateTime getLastDropCreatedDate() {
-    DateTime now = dateTimeUtils.now(dropScheduleConfig.getTimezone());
-    DateTime lastDropDueDate = getLastDropDueDate(now);
+  public ZonedDateTime getLastDropCreatedDate() {
+    ZonedDateTime now = dateTimeUtils.now(dropScheduleConfig.getTimezone());
+    ZonedDateTime lastDropDueDate = getLastDropDueDate(now);
     return getDropCreatedDate(lastDropDueDate);
   }
 
-  DateTime getDropCreatedDate(DateTime dropDueDate) {
+  ZonedDateTime getDropCreatedDate(ZonedDateTime dropDueDate) {
 
-    DateTime dropCreatedDate = dropDueDate.withTime(dropScheduleConfig.getCreatedLocalTime());
+    ZonedDateTime dropCreatedDate =
+        dropDueDate
+            .withHour(dropScheduleConfig.getCreatedLocalTime().getHour())
+            .withMinute(dropScheduleConfig.getCreatedLocalTime().getMinute())
+            .withSecond(dropScheduleConfig.getCreatedLocalTime().getSecond())
+            .withNano(dropScheduleConfig.getCreatedLocalTime().getNano());
 
-    Integer dropDueDateDay = dropDueDate.getDayOfWeek();
+    Integer dropDueDateDay = dropDueDate.getDayOfWeek().getValue();
     Integer dropStartDateDay = getDueDayToStartDay().get(dropDueDateDay);
 
-    dropCreatedDate = dropCreatedDate.withDayOfWeek(dropStartDateDay);
+    dropCreatedDate = dropCreatedDate.with(DayOfWeek.of(dropStartDateDay));
 
     if (dropStartDateDay > dropDueDateDay) {
       dropCreatedDate = dropCreatedDate.minusWeeks(1);
@@ -43,17 +49,18 @@ public class DropScheduleService {
     return dropCreatedDate;
   }
 
-  DateTime getLastDropDueDate(DateTime before) {
+  ZonedDateTime getLastDropDueDate(ZonedDateTime before) {
 
-    DateTime lastDropDueDate = null;
+    ZonedDateTime lastDropDueDate = null;
 
     HashSet<Integer> dropDueDaysSet = Sets.newHashSet(dropScheduleConfig.getDueDays());
 
-    for (int daysToSubstract = 0; daysToSubstract <= 7; daysToSubstract++) {
-      DateTime candidate =
-          before.minusDays(daysToSubstract).withTime(dropScheduleConfig.getDueLocalTime());
+    for (int daysToSubtract = 0; daysToSubtract <= 7; daysToSubtract++) {
+      ZonedDateTime candidate =
+          before.minusDays(daysToSubtract).with(dropScheduleConfig.getDueLocalTime());
 
-      if (dropDueDaysSet.contains(candidate.getDayOfWeek()) && !candidate.isAfter(before)) {
+      if (dropDueDaysSet.contains(candidate.getDayOfWeek().getValue())
+          && !candidate.isAfter(before)) {
         lastDropDueDate = candidate;
         break;
       }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/sla/SlaCheckerService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/sla/SlaCheckerService.java
@@ -6,9 +6,9 @@ import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.sla.email.SlaCheckerEmailService;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
 import com.box.l10n.mojito.utils.DateTimeUtils;
+import java.time.ZonedDateTime;
 import java.util.LinkedHashSet;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,7 +92,7 @@ public class SlaCheckerService {
   @Transactional
   void closeIncidents() {
     logger.debug("Close incidents (there should be only one)");
-    DateTime closedDate = dateTimeUtils.now();
+    ZonedDateTime closedDate = dateTimeUtils.now();
     List<SlaIncident> findByIsNullClosedDate = slaIncidentRepository.findByClosedDateIsNull();
     for (SlaIncident ooSLAIncident : findByIsNullClosedDate) {
       ooSLAIncident.setClosedDate(closedDate);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/sla/email/SlaCheckerEmailConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/sla/email/SlaCheckerEmailConfig.java
@@ -1,6 +1,6 @@
 package com.box.l10n.mojito.service.sla.email;
 
-import org.joda.time.Period;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,7 +18,7 @@ public class SlaCheckerEmailConfig {
    *
    * <p>The config property is a value in milliseconds.
    */
-  Period periodBetweenEmail = new Period(1, 0, 0, 0);
+  Duration periodBetweenEmail = Duration.ofHours(1);
 
   public String getFrom() {
     return from;
@@ -36,11 +36,11 @@ public class SlaCheckerEmailConfig {
     this.to = to;
   }
 
-  public Period getPeriodBetweenEmail() {
+  public Duration getPeriodBetweenEmail() {
     return periodBetweenEmail;
   }
 
-  public void setPeriodBetweenEmail(Period periodBetweenEmail) {
+  public void setPeriodBetweenEmail(Duration periodBetweenEmail) {
     this.periodBetweenEmail = periodBetweenEmail;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/sla/email/SlaCheckerEmailService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/sla/email/SlaCheckerEmailService.java
@@ -6,11 +6,11 @@ import com.box.l10n.mojito.utils.DateTimeUtils;
 import com.box.l10n.mojito.utils.ServerConfig;
 import com.ibm.icu.text.MessageFormat;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.mail.internet.MimeMessage;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,8 +49,8 @@ public class SlaCheckerEmailService {
     sendEmail(incidentId, getOpenIncidentEmailContent(incidentId, ooslaRepositories));
   }
 
-  public boolean shouldResendEmail(DateTime previousEmailDateTime) {
-    DateTime now = dateTimeUtils.now();
+  public boolean shouldResendEmail(ZonedDateTime previousEmailDateTime) {
+    ZonedDateTime now = dateTimeUtils.now();
     return previousEmailDateTime.isBefore(now.minus(slaCheckerEmailConfig.getPeriodBetweenEmail()));
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSUtils.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSUtils.java
@@ -5,9 +5,9 @@ import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.ThirdPartyFileChecksum;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.joda.time.DateTime;
 
 public class ThirdPartyTMSUtils {
 
@@ -32,7 +32,7 @@ public class ThirdPartyTMSUtils {
     } else if (thirdPartyFileChecksumOpt.isPresent()) {
       ThirdPartyFileChecksum thirdPartyFileChecksum = thirdPartyFileChecksumOpt.get();
       thirdPartyFileChecksum.setMd5(currentChecksum);
-      thirdPartyFileChecksum.setLastModifiedDate(new DateTime());
+      thirdPartyFileChecksum.setLastModifiedDate(ZonedDateTime.now());
       thirdPartyFileChecksumRepository.save(thirdPartyFileChecksum);
     } else {
       thirdPartyFileChecksumRepository.save(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/AddTMTextUnitCurrentVariantResult.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/AddTMTextUnitCurrentVariantResult.java
@@ -5,7 +5,7 @@ import com.box.l10n.mojito.entity.TMTextUnitCurrentVariant;
 /**
  * Result of {@link TMService#addTMTextUnitCurrentVariantWithResult(java.lang.Long, java.lang.Long,
  * java.lang.String, java.lang.String, com.box.l10n.mojito.entity.TMTextUnitVariant.Status, boolean,
- * org.joda.time.DateTime) }
+ * java.time.ZonedDateTime) }
  *
  * @author jeanaurambault
  */

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/ImportExportNote.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/ImportExportNote.java
@@ -2,10 +2,12 @@ package com.box.l10n.mojito.service.tm;
 
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
 import com.box.l10n.mojito.entity.TMTextUnitVariantComment;
+import com.box.l10n.mojito.rest.textunit.CustomZonedDateTimeDeserializer;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import org.joda.time.DateTime;
 
 /**
  * Used to serialize/deserialize the note element used for import/export.
@@ -24,7 +26,10 @@ public class ImportExportNote {
   boolean includedInLocalizedFile = true;
   TMTextUnitVariant.Status status = TMTextUnitVariant.Status.APPROVED;
   List<TMTextUnitVariantComment> variantComments = new ArrayList<>();
-  DateTime createdDate;
+
+  @JsonDeserialize(using = CustomZonedDateTimeDeserializer.class)
+  ZonedDateTime createdDate;
+
   String pluralForm;
   String pluralFormOther;
 
@@ -68,11 +73,11 @@ public class ImportExportNote {
     this.variantComments = variantComments;
   }
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -64,6 +64,7 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -78,7 +79,6 @@ import net.sf.okapi.filters.xliff.XLIFFFilter;
 import net.sf.okapi.steps.common.FilterEventsWriterStep;
 import net.sf.okapi.steps.common.RawDocumentToFilterEventsStep;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -186,7 +186,7 @@ public class TMService {
       String name,
       String content,
       String comment,
-      DateTime createdDate,
+      ZonedDateTime createdDate,
       PluralForm pluralForm,
       String pluralFormOther) {
 
@@ -215,7 +215,7 @@ public class TMService {
       String content,
       String comment,
       User createdByUser,
-      DateTime createdDate,
+      ZonedDateTime createdDate,
       PluralForm pluralForm,
       String pluralFormOther) {
 
@@ -246,7 +246,7 @@ public class TMService {
       final String content,
       final String comment,
       final User createdByUser,
-      final DateTime createdDate,
+      final ZonedDateTime createdDate,
       final PluralForm pluralForm,
       final String pluralFormOther,
       final Long sourceLocaleId) {
@@ -357,7 +357,7 @@ public class TMService {
       String content,
       TMTextUnitVariant.Status status,
       boolean includedInLocalizedFile,
-      DateTime createdDate) {
+      ZonedDateTime createdDate) {
     return addTMTextUnitCurrentVariant(
             tmTextUnitId, localeId, content, null, status, includedInLocalizedFile, createdDate)
         .getTmTextUnitVariant();
@@ -462,7 +462,7 @@ public class TMService {
       String comment,
       TMTextUnitVariant.Status status,
       boolean includedInLocalizedFile,
-      DateTime createdDate) {
+      ZonedDateTime createdDate) {
 
     return addTMTextUnitCurrentVariantWithResult(
             tmTextUnitId, localeId, content, comment, status, includedInLocalizedFile, createdDate)
@@ -498,7 +498,7 @@ public class TMService {
       String comment,
       TMTextUnitVariant.Status status,
       boolean includedInLocalizedFile,
-      DateTime createdDate) {
+      ZonedDateTime createdDate) {
 
     logger.debug("Check if there is a current TMTextUnitVariant");
     TMTextUnitCurrentVariant currentTmTextUnitCurrentVariant =
@@ -564,7 +564,7 @@ public class TMService {
       String comment,
       TMTextUnitVariant.Status status,
       boolean includedInLocalizedFile,
-      DateTime createdDate,
+      ZonedDateTime createdDate,
       User createdBy) {
 
     boolean noUpdate = false;
@@ -709,7 +709,7 @@ public class TMService {
       String comment,
       TMTextUnitVariant.Status status,
       boolean includedInLocalizedFile,
-      DateTime createdDate) {
+      ZonedDateTime createdDate) {
     User createdBy = auditorAwareImpl.getCurrentAuditor().orElse(null);
     return addTMTextUnitVariant(
         tmTextUnitId,
@@ -749,7 +749,7 @@ public class TMService {
       String comment,
       TMTextUnitVariant.Status status,
       boolean includedInLocalizedFile,
-      DateTime createdDate,
+      ZonedDateTime createdDate,
       User createdBy) {
 
     logger.debug(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticService.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import java.time.ZonedDateTime;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -169,9 +169,9 @@ public class TMTextUnitStatisticService {
                               stat1.getLastDayUsageCount() + stat2.getLastDayUsageCount());
                           stat1.setLastPeriodUsageCount(
                               stat1.getLastPeriodUsageCount() + stat2.getLastPeriodUsageCount());
-                          DateTime stat1date = stat1.getLastSeenDate();
-                          DateTime stat2date = stat2.getLastSeenDate();
-                          DateTime maxDate =
+                          ZonedDateTime stat1date = stat1.getLastSeenDate();
+                          ZonedDateTime stat2date = stat2.getLastSeenDate();
+                          ZonedDateTime maxDate =
                               stat1date.compareTo(stat2date) >= 0 ? stat1date : stat2date;
                           stat1.setLastSeenDate(maxDate);
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitVariantRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitVariantRepository.java
@@ -6,8 +6,8 @@ import com.box.l10n.mojito.entity.PushRun;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
 import java.sql.Timestamp;
+import java.time.ZonedDateTime;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -63,8 +63,8 @@ public interface TMTextUnitVariantRepository extends JpaRepository<TMTextUnitVar
   Page<TextUnitVariantDeltaDTO> findAllUsedForRepositoryAndLocalesInDateRange(
       @Param("repository") Repository repository,
       @Param("locales") List<Locale> locales,
-      @Param("fromDate") DateTime fromDate,
-      @Param("toDate") DateTime toDate,
+      @Param("fromDate") ZonedDateTime fromDate,
+      @Param("toDate") ZonedDateTime toDate,
       Pageable pageable);
 
   /**
@@ -79,7 +79,7 @@ public interface TMTextUnitVariantRepository extends JpaRepository<TMTextUnitVar
    * to provided deltas relevant for a specific snapshot.
    *
    * @param translationsFromDate A java.sql.Date type needs to be provided for native queries,
-   *     otherwise, if Joda Time's DateTime is used, that parameter is passed in as a VARBINARY to
+   *     otherwise, if Java Time's DateTime is used, that parameter is passed in as a VARBINARY to
    *     the SQL query and will silently mis-behave.
    */
   @Query(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
@@ -40,6 +40,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import java.time.ZonedDateTime;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +49,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -215,7 +215,7 @@ public class TextUnitBatchImporterService {
   @Transactional
   void importTextUnitsOfLocaleAndAsset(
       Locale locale, Asset asset, List<TextUnitForBatchMatcherImport> textUnitsToImport) {
-    DateTime importTime = new DateTime();
+    ZonedDateTime importTime = ZonedDateTime.now();
     logger.debug(
         "Start import text units for asset: {} and locale: {}",
         asset.getPath(),

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
@@ -1,7 +1,7 @@
 package com.box.l10n.mojito.service.tm.search;
 
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 /**
  * DTO to build text units from TM entities
@@ -25,14 +25,14 @@ public class TextUnitDTO {
   private Long tmTextUnitCurrentVariantId;
   private TMTextUnitVariant.Status status;
   private boolean includedInLocalizedFile;
-  private DateTime createdDate;
+  private ZonedDateTime createdDate;
   private boolean assetDeleted;
   private String pluralForm;
   private String pluralFormOther;
   private String repositoryName;
   private String assetPath;
   private Long assetTextUnitId;
-  private DateTime tmTextUnitCreatedDate;
+  private ZonedDateTime tmTextUnitCreatedDate;
   private boolean doNotTranslate;
 
   public Long getTmTextUnitId() {
@@ -171,11 +171,11 @@ public class TextUnitDTO {
     this.includedInLocalizedFile = includedInLocalizedFile;
   }
 
-  public DateTime getCreatedDate() {
+  public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
 
-  public void setCreatedDate(DateTime createdDate) {
+  public void setCreatedDate(ZonedDateTime createdDate) {
     this.createdDate = createdDate;
   }
 
@@ -227,11 +227,11 @@ public class TextUnitDTO {
     this.assetTextUnitId = assetTextUnitId;
   }
 
-  public DateTime getTmTextUnitCreatedDate() {
+  public ZonedDateTime getTmTextUnitCreatedDate() {
     return tmTextUnitCreatedDate;
   }
 
-  public void setTmTextUnitCreatedDate(DateTime tmTextUnitCreatedDate) {
+  public void setTmTextUnitCreatedDate(ZonedDateTime tmTextUnitCreatedDate) {
     this.tmTextUnitCreatedDate = tmTextUnitCreatedDate;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTONativeObjectMapper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTONativeObjectMapper.java
@@ -3,10 +3,10 @@ package com.box.l10n.mojito.service.tm.search;
 import static com.box.l10n.mojito.entity.TMTextUnitVariant.Status.TRANSLATION_NEEDED;
 import static com.box.l10n.mojito.entity.TMTextUnitVariant.Status.valueOf;
 
+import com.box.l10n.mojito.DateTimeUtils;
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
 import com.github.pnowy.nc.core.CriteriaResult;
 import com.github.pnowy.nc.core.mappers.NativeObjectMapper;
-import org.joda.time.DateTime;
 
 /** @author jaurambault */
 public class TextUnitDTONativeObjectMapper implements NativeObjectMapper<TextUnitDTO> {
@@ -15,7 +15,6 @@ public class TextUnitDTONativeObjectMapper implements NativeObjectMapper<TextUni
   public TextUnitDTO mapObject(CriteriaResult cr) {
 
     int idx = 0;
-
     TextUnitDTO t = new TextUnitDTO();
     t.setTmTextUnitId(cr.getLong(idx++));
     t.setTmTextUnitVariantId(cr.getLong(idx++));
@@ -40,7 +39,7 @@ public class TextUnitDTONativeObjectMapper implements NativeObjectMapper<TextUni
     // implementation to understand why getBoolean doesn't work. This
     // seems to work fine, use this code for now.
     t.setIncludedInLocalizedFile(Boolean.valueOf(includedInLocalizedFile));
-    t.setCreatedDate(new DateTime(cr.getDate(idx++)));
+    t.setCreatedDate(DateTimeUtils.fromDateToZonedDate(cr.getDate(idx++)));
     String assetDeleted = cr.getString(idx++);
     t.setAssetDeleted(Boolean.valueOf(assetDeleted));
     t.setPluralForm(cr.getString(idx++));
@@ -48,7 +47,7 @@ public class TextUnitDTONativeObjectMapper implements NativeObjectMapper<TextUni
     t.setRepositoryName(cr.getString(idx++));
     t.setAssetPath(cr.getString(idx++));
     t.setAssetTextUnitId(cr.getLong(idx++));
-    t.setTmTextUnitCreatedDate(new DateTime(cr.getDate(idx++)));
+    t.setTmTextUnitCreatedDate(DateTimeUtils.fromDateToZonedDate(cr.getDate(idx++)));
     t.setDoNotTranslate(Boolean.valueOf(includedInLocalizedFile));
 
     String doNotTranslate = cr.getString(idx++);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
@@ -1,11 +1,11 @@
 package com.box.l10n.mojito.service.tm.search;
 
 import com.box.l10n.mojito.service.NormalizationUtils;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.joda.time.DateTime;
 
 /**
  * Parameters for {@link
@@ -43,8 +43,8 @@ public class TextUnitSearcherParameters {
   boolean isOrderedByTextUnitID = false;
   Long pluralFormId;
   Boolean doNotTranslateFilter;
-  DateTime tmTextUnitCreatedBefore;
-  DateTime tmTextUnitCreatedAfter;
+  ZonedDateTime tmTextUnitCreatedBefore;
+  ZonedDateTime tmTextUnitCreatedAfter;
   Long branchId;
   String skipTextUnitWithPattern;
   String includeTextUnitsWithPattern;
@@ -246,19 +246,19 @@ public class TextUnitSearcherParameters {
     this.doNotTranslateFilter = doNotTranslateFilter;
   }
 
-  public DateTime getTmTextUnitCreatedBefore() {
+  public ZonedDateTime getTmTextUnitCreatedBefore() {
     return tmTextUnitCreatedBefore;
   }
 
-  public void setTmTextUnitCreatedBefore(DateTime tmTextUnitCreatedBefore) {
+  public void setTmTextUnitCreatedBefore(ZonedDateTime tmTextUnitCreatedBefore) {
     this.tmTextUnitCreatedBefore = tmTextUnitCreatedBefore;
   }
 
-  public DateTime getTmTextUnitCreatedAfter() {
+  public ZonedDateTime getTmTextUnitCreatedAfter() {
     return tmTextUnitCreatedAfter;
   }
 
-  public void setTmTextUnitCreatedAfter(DateTime tmTextUnitCreatedAfter) {
+  public void setTmTextUnitCreatedAfter(ZonedDateTime tmTextUnitCreatedAfter) {
     this.tmTextUnitCreatedAfter = tmTextUnitCreatedAfter;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
@@ -4,9 +4,10 @@ import com.box.l10n.mojito.smartling.response.AuthenticationData;
 import com.box.l10n.mojito.smartling.response.AuthenticationResponse;
 import com.box.l10n.mojito.utils.RestTemplateUtils;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
@@ -59,7 +60,7 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
           refreshAccessToken(details, existingToken.getRefreshToken(), accessTokenRequest);
     } else {
       try {
-        DateTime now = getNowForToken();
+        ZonedDateTime now = getNowForToken();
         AuthenticationResponse authenticationResponse =
             getRestTemplate()
                 .postForObject(details.getAccessTokenUri(), request, AuthenticationResponse.class);
@@ -90,7 +91,7 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
 
     DefaultOAuth2AccessToken defaultOAuth2AccessToken = null;
     try {
-      DateTime now = getNowForToken();
+      ZonedDateTime now = getNowForToken();
       AuthenticationResponse authenticationResponse =
           getRestTemplate()
               .postForObject(
@@ -113,14 +114,16 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
   }
 
   DefaultOAuth2AccessToken getDefaultOAuth2AccessToken(
-      DateTime now, AuthenticationResponse authenticationResponse) {
+      ZonedDateTime now, AuthenticationResponse authenticationResponse) {
     AuthenticationData data = authenticationResponse.getData();
     DefaultOAuth2AccessToken defaultOAuth2AccessToken =
         new DefaultOAuth2AccessToken(data.getAccessToken());
-    defaultOAuth2AccessToken.setExpiration(now.plusSeconds(data.getExpiresIn()).toDate());
+    defaultOAuth2AccessToken.setExpiration(
+        Date.from(now.plusSeconds(data.getExpiresIn()).toInstant()));
     defaultOAuth2AccessToken.setRefreshToken(
         new DefaultExpiringOAuth2RefreshToken(
-            data.getRefreshToken(), now.plusSeconds(data.getRefreshExpiresIn()).toDate()));
+            data.getRefreshToken(),
+            Date.from(now.plusSeconds(data.getRefreshExpiresIn()).toInstant())));
     return defaultOAuth2AccessToken;
   }
 
@@ -131,8 +134,8 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
    *
    * @return
    */
-  DateTime getNowForToken() {
-    return DateTime.now().minusSeconds(15);
+  ZonedDateTime getNowForToken() {
+    return ZonedDateTime.now().minusSeconds(15);
   }
 
   protected RestTemplate getRestTemplate() {

--- a/webapp/src/main/java/com/box/l10n/mojito/utils/DateTimeUtils.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/utils/DateTimeUtils.java
@@ -1,18 +1,18 @@
 package com.box.l10n.mojito.utils;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import org.springframework.stereotype.Component;
 
 /** @author jeanaurambault */
 @Component
 public class DateTimeUtils {
 
-  public DateTime now() {
-    return new DateTime();
+  public ZonedDateTime now() {
+    return ZonedDateTime.now();
   }
 
-  public DateTime now(DateTimeZone dateTimeZone) {
-    return new DateTime(dateTimeZone);
+  public ZonedDateTime now(ZoneId zoneId) {
+    return ZonedDateTime.now(zoneId);
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceTest.java
@@ -14,6 +14,7 @@ import com.box.sdk.BoxFile;
 import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxItem;
 import com.box.sdk.BoxSharedLink;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -24,7 +25,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -227,7 +227,7 @@ public class BoxSDKServiceTest extends WSTestBase {
 
     BoxFolder rootFolder = boxSDKService.getRootFolder();
 
-    DateTime dateTime = new DateTime();
+    ZonedDateTime dateTime = ZonedDateTime.now();
     dateTime = dateTime.minusDays(1);
 
     boxSDKService.deleteFolderContentOlderThan(rootFolder.getID(), dateTime);

--- a/webapp/src/test/java/com/box/l10n/mojito/converter/LocalTimeConverterTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/converter/LocalTimeConverterTest.java
@@ -3,7 +3,8 @@ package com.box.l10n.mojito.converter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.joda.time.LocalTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import org.junit.Test;
 
 /** @author jeanaurambault */
@@ -13,7 +14,7 @@ public class LocalTimeConverterTest {
   public void testConvert() {
     String source = "14:00";
     LocalTimeConverter localTimeConverter = new LocalTimeConverter();
-    LocalTime expResult = new LocalTime(14, 0, 0);
+    LocalTime expResult = LocalTime.of(14, 0, 0);
     LocalTime result = localTimeConverter.convert(source);
     assertEquals(expResult, result);
   }
@@ -25,8 +26,8 @@ public class LocalTimeConverterTest {
     assertNotNull(convert);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testConvertInvaild() {
+  @Test(expected = DateTimeParseException.class)
+  public void testConvertInvalid() {
     LocalTimeConverter localTimeConverter = new LocalTimeConverter();
     localTimeConverter.convert("invalid");
   }

--- a/webapp/src/test/java/com/box/l10n/mojito/converter/PeriodConverterTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/converter/PeriodConverterTest.java
@@ -2,7 +2,7 @@ package com.box.l10n.mojito.converter;
 
 import static org.junit.Assert.assertEquals;
 
-import org.joda.time.Period;
+import java.time.Duration;
 import org.junit.Test;
 
 /** @author jeanaurambault */
@@ -11,8 +11,8 @@ public class PeriodConverterTest {
   @Test
   public void testConvert() {
     PeriodConverter periodConverter = new PeriodConverter();
-    Period expResult = new Period(0, 1, 0, 0);
-    Period result = periodConverter.convert("60000");
+    Duration expResult = Duration.ofMillis(60000);
+    Duration result = periodConverter.convert("60000");
     assertEquals(expResult, result);
   }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/textunit/StringToDateTimeConverterTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/textunit/StringToDateTimeConverterTest.java
@@ -2,7 +2,8 @@ package com.box.l10n.mojito.rest.textunit;
 
 import static org.junit.Assert.assertEquals;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import org.junit.Test;
 
 /** @author jeanaurambault */
@@ -12,8 +13,8 @@ public class StringToDateTimeConverterTest {
   public void testConvertNull() {
     String source = null;
     StringToDateTimeConverter instance = new StringToDateTimeConverter();
-    DateTime expResult = null;
-    DateTime result = instance.convert(source);
+    ZonedDateTime expResult = null;
+    ZonedDateTime result = instance.convert(source);
     assertEquals(expResult, result);
   }
 
@@ -21,53 +22,60 @@ public class StringToDateTimeConverterTest {
   public void testConvertMillisecond() {
     String source = "1525887295000";
     StringToDateTimeConverter instance = new StringToDateTimeConverter();
-    DateTime expResult = new DateTime("2018-05-09T17:34:55.000Z");
-    DateTime result = instance.convert(source);
-    assertEquals(expResult, result);
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-09T17:34:55.000Z");
+    ZonedDateTime result = instance.convert(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
   }
 
   @Test
   public void testConvertISO() {
     String source = "2018-05-09T17:34:55.000Z";
     StringToDateTimeConverter instance = new StringToDateTimeConverter();
-    DateTime expResult = new DateTime("2018-05-09T17:34:55.000Z");
-    DateTime result = instance.convert(source);
-    assertEquals(expResult, result);
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-09T17:34:55.000Z");
+    ZonedDateTime result = instance.convert(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
   }
 
   @Test
   public void testConvertISONoTZ() {
     String source = "2018-05-09T17:34:55.000";
     StringToDateTimeConverter instance = new StringToDateTimeConverter();
-    DateTime expResult = new DateTime("2018-05-09T17:34:55.000Z");
-    DateTime result = instance.convert(source);
-    assertEquals(expResult, result);
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-09T17:34:55.000Z");
+    ZonedDateTime result = instance.convert(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
   }
 
   @Test
   public void testConvertISOUTC() {
     String source = "2018-05-09T17:34:55.000";
     StringToDateTimeConverter instance = new StringToDateTimeConverter();
-    DateTime expResult = new DateTime("2018-05-09T17:34:55.000Z");
-    DateTime result = instance.convert(source);
-    assertEquals(expResult, result);
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-09T17:34:55.000Z");
+    ZonedDateTime result = instance.convert(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
   }
 
   @Test
   public void testConvertISOTZ() {
     String source = "2018-05-09T17:34:55.000-07:00";
     StringToDateTimeConverter instance = new StringToDateTimeConverter();
-    DateTime expResult = new DateTime("2018-05-10T00:34:55.000Z");
-    DateTime result = instance.convert(source);
-    assertEquals(expResult, result);
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-10T00:34:55.000Z");
+    ZonedDateTime result = instance.convert(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
   }
 
   @Test
   public void testConvertISOTZNoMillisecond() {
     String source = "2018-05-09T17:34:55-07:00";
     StringToDateTimeConverter instance = new StringToDateTimeConverter();
-    DateTime expResult = new DateTime("2018-05-10T00:34:55.000Z");
-    DateTime result = instance.convert(source);
-    assertEquals(expResult, result);
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-05-10T00:34:55.000Z");
+    ZonedDateTime result = instance.convert(source);
+    assertEquals(expResult.toInstant(), result.toInstant());
+  }
+
+  @Test(expected = DateTimeParseException.class)
+  public void testConvertInvalidDateFormat() {
+    String source = "09-05-2018T17:34:55-07:00";
+    StringToDateTimeConverter instance = new StringToDateTimeConverter();
+    instance.convert(source);
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionCleanupServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionCleanupServiceTest.java
@@ -14,9 +14,9 @@ import com.box.l10n.mojito.service.pollableTask.PollableTaskRepository;
 import com.box.l10n.mojito.service.pollableTask.PollableTaskService;
 import com.box.l10n.mojito.service.repository.RepositoryService;
 import com.box.l10n.mojito.test.TestIdWatcher;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -111,7 +111,7 @@ public class AssetExtractionCleanupServiceTest extends ServiceTestBase {
     Asset asset = createOrUpdateAssetAndWaitUntilProcessingEnds(repository, assetPath, 0, null);
     PollableTask pollableTask = new PollableTask();
     pollableTask.setName("fortest");
-    pollableTask.setFinishedDate(new DateTime());
+    pollableTask.setFinishedDate(ZonedDateTime.now());
     pollableTaskRepository.save(pollableTask);
     AssetExtraction createAssetExtraction =
         assetExtractionService.createAssetExtraction(asset, pollableTask);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/MultiBranchStateBlobStorageTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/MultiBranchStateBlobStorageTest.java
@@ -10,8 +10,9 @@ import com.box.l10n.mojito.localtm.merger.MultiBranchState;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
@@ -35,7 +36,7 @@ public class MultiBranchStateBlobStorageTest extends ServiceTestBase {
             assetExtractionId, version);
     Assertions.assertFalse(multiBranchStateForAssetExtractionId.isPresent());
 
-    Branch branchTest = Branch.builder().name("test").createdAt(new DateTime()).build();
+    Branch branchTest = Branch.builder().name("test").createdAt(ZonedDateTime.now()).build();
     MultiBranchState multiBranchState =
         MultiBranchState.builder()
             .branches(ImmutableSet.of(branchTest))
@@ -58,6 +59,8 @@ public class MultiBranchStateBlobStorageTest extends ServiceTestBase {
         multiBranchStateBlobStorage.getMultiBranchStateForAssetExtractionId(
             assetExtractionId, version);
     assertThat(multiBranchStateForAssetExtractionId.get())
-        .isEqualToComparingFieldByField(multiBranchState);
+        .usingRecursiveComparison()
+        .withComparatorForType(Comparator.comparing(ZonedDateTime::toInstant), ZonedDateTime.class)
+        .isEqualTo(multiBranchState);
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/MultiBranchStateServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/MultiBranchStateServiceTest.java
@@ -16,9 +16,12 @@ import com.box.l10n.mojito.test.TestIdWatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
-import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +67,9 @@ public class MultiBranchStateServiceTest extends ServiceTestBase {
 
     Assertions.assertThat(multiBranchStateForAssetExtractionId)
         .usingRecursiveComparison()
+        .withComparatorForType(
+            Comparator.comparing(zdt -> zdt.truncatedTo(ChronoUnit.SECONDS).toInstant()),
+            ZonedDateTime.class)
         .isEqualTo(expectedMultiBranchState);
 
     Optional<MultiBranchState> multiBranchStateForAssetExtractionAfter =
@@ -99,12 +105,12 @@ public class MultiBranchStateServiceTest extends ServiceTestBase {
     return expectedMultiBranchState;
   }
 
-  DateTime roundDateTimeToSecond(DateTime dateTime) {
-
-    if (dateTime.getMillisOfSecond() > 500) {
-      dateTime = dateTime.withMillisOfSecond(0).plusSeconds(1);
+  ZonedDateTime roundDateTimeToSecond(ZonedDateTime dateTime) {
+    long millisOfSecond = TimeUnit.NANOSECONDS.toMillis(dateTime.getNano());
+    if (millisOfSecond > 500) {
+      dateTime = dateTime.withNano(0).plusSeconds(1);
     } else {
-      dateTime = dateTime.withMillisOfSecond(0);
+      dateTime = dateTime.withNano(0);
     }
 
     return dateTime;

--- a/webapp/src/test/java/com/box/l10n/mojito/service/blobstorage/database/DatabaseBlobStorageTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/blobstorage/database/DatabaseBlobStorageTest.java
@@ -7,7 +7,7 @@ import com.box.l10n.mojito.entity.MBlob;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import com.box.l10n.mojito.service.blobstorage.BlobStorage;
 import com.box.l10n.mojito.service.blobstorage.BlobStorageTestShared;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,7 +77,7 @@ public class DatabaseBlobStorageTest extends ServiceTestBase implements BlobStor
   @Test
   public void testCleanup() {
 
-    DateTime now = DateTime.now();
+    ZonedDateTime now = ZonedDateTime.now();
     MBlob notExperied = new MBlob();
     notExperied.setCreatedDate(now);
     notExperied.setExpireAfterSeconds(1000);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationServiceTest.java
@@ -17,9 +17,9 @@ import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import com.box.l10n.mojito.test.TestIdWatcher;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -113,7 +113,7 @@ public class BranchNotificationServiceTest extends ServiceTestBase {
     BranchNotification branchNotification =
         branchNotificationRepository.findByBranchAndNotifierId(
             branchTestData.getBranch1(), branchNotifierId);
-    branchNotification.setScreenshotMissingMsgSentAt(DateTime.now().minusMinutes(31));
+    branchNotification.setScreenshotMissingMsgSentAt(ZonedDateTime.now().minusMinutes(31));
     branchNotificationRepository.save(branchNotification);
 
     branchNotificationService.scheduleMissingScreenshotNotificationsForBranch(

--- a/webapp/src/test/java/com/box/l10n/mojito/service/commit/CommitServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/commit/CommitServiceTest.java
@@ -10,9 +10,9 @@ import com.box.l10n.mojito.service.pushrun.PushRunRepository;
 import com.box.l10n.mojito.service.repository.RepositoryService;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import com.google.common.collect.ImmutableList;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +43,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitName = "commitName";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommit =
         commitService.getOrCreateCommit(
@@ -67,7 +67,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitName = "commitName";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommit =
         commitService.getOrCreateCommit(
@@ -88,7 +88,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitName = "commitName";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime creationTime = DateTime.now();
+    ZonedDateTime creationTime = ZonedDateTime.now();
     Commit commit1 =
         commitService.getOrCreateCommit(
             repository, commitName, authorEmail, authorName, creationTime);
@@ -107,9 +107,9 @@ public class CommitServiceTest extends ServiceTestBase {
     String authorEmail = "authorEmail";
     String authorName = "authorName";
     commitService.getOrCreateCommit(
-        repository, commitName, authorEmail, authorName, DateTime.now());
+        repository, commitName, authorEmail, authorName, ZonedDateTime.now());
     commitService.getOrCreateCommit(
-        repository, commitName, authorEmail, authorName, DateTime.now().plusHours(3));
+        repository, commitName, authorEmail, authorName, ZonedDateTime.now().plusHours(3));
   }
 
   @Test
@@ -119,8 +119,8 @@ public class CommitServiceTest extends ServiceTestBase {
     Repository repositoryB =
         repositoryService.createRepository(testIdWatcher.getEntityName("repository") + 'B');
 
-    commitService.getOrCreateCommit(repositoryA, "n1", "ae1", "an1", DateTime.now());
-    commitService.getOrCreateCommit(repositoryB, "n1", "ae2", "an2", DateTime.now());
+    commitService.getOrCreateCommit(repositoryA, "n1", "ae1", "an1", ZonedDateTime.now());
+    commitService.getOrCreateCommit(repositoryB, "n1", "ae2", "an2", ZonedDateTime.now());
   }
 
   @Test
@@ -131,7 +131,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitName = "commitName";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommit =
         commitService.getOrCreateCommit(
@@ -163,7 +163,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitNameB = "commitNameB";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommitA =
         commitService.getOrCreateCommit(
@@ -208,7 +208,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitNameB = "commitNameB";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommitA =
         commitService.getOrCreateCommit(
@@ -252,7 +252,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitName = "commitName";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommit =
         commitService.getOrCreateCommit(
@@ -284,7 +284,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitNameB = "commitNameB";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommitA =
         commitService.getOrCreateCommit(
@@ -329,7 +329,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitNameB = "commitNameB";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommitA =
         commitService.getOrCreateCommit(
@@ -373,7 +373,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitName = "commitName";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommit =
         commitService.getOrCreateCommit(
@@ -399,7 +399,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitName = "commitName";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommit =
         commitService.getOrCreateCommit(
@@ -426,7 +426,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitName = "commitName";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommit =
         commitService.getOrCreateCommit(
@@ -452,7 +452,7 @@ public class CommitServiceTest extends ServiceTestBase {
     String commitName = "commitName";
     String authorEmail = "authorEmail";
     String authorName = "authorName";
-    DateTime sourceCreationTime = DateTime.now();
+    ZonedDateTime sourceCreationTime = ZonedDateTime.now();
 
     Commit createdCommit =
         commitService.getOrCreateCommit(

--- a/webapp/src/test/java/com/box/l10n/mojito/service/delta/DeltaServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/delta/DeltaServiceTest.java
@@ -35,6 +35,8 @@ import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitVariantRepository;
 import com.box.l10n.mojito.service.tm.TextUnitVariantDeltaDTO;
 import com.box.l10n.mojito.test.TestIdWatcher;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -42,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -97,7 +98,7 @@ public class DeltaServiceTest extends ServiceTestBase {
             .getDeltasForDates(
                 tmTestData.repository,
                 Arrays.asList(tmTestData.frFR, tmTestData.frCA, tmTestData.koKR, tmTestData.jaJP),
-                DateTime.now().plusSeconds(1),
+                ZonedDateTime.now().plusSeconds(1),
                 null,
                 Pageable.unpaged())
             .getContent();
@@ -108,8 +109,8 @@ public class DeltaServiceTest extends ServiceTestBase {
             .getDeltasForDates(
                 tmTestData.repository,
                 Arrays.asList(tmTestData.frFR, tmTestData.frCA, tmTestData.koKR, tmTestData.jaJP),
-                new DateTime(0),
-                DateTime.now().plusHours(1),
+                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.now().plusHours(1),
                 PageRequest.of(0, 1, Sort.Direction.ASC, "id"))
             .getContent();
     Assert.assertNotEquals(0, deltasFromCreation.size());
@@ -125,7 +126,7 @@ public class DeltaServiceTest extends ServiceTestBase {
             .getDeltasForDates(
                 tmTestData.repository,
                 Arrays.asList(tmTestData.frFR, tmTestData.frCA, tmTestData.koKR, tmTestData.jaJP),
-                DateTime.now().plusSeconds(1),
+                ZonedDateTime.now().plusSeconds(1),
                 null,
                 Pageable.unpaged())
             .getContent();
@@ -136,8 +137,8 @@ public class DeltaServiceTest extends ServiceTestBase {
             .getDeltasForDates(
                 tmTestData.repository,
                 Arrays.asList(tmTestData.frFR, tmTestData.frCA, tmTestData.koKR, tmTestData.jaJP),
-                new DateTime(0),
-                new DateTime(0),
+                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                 PageRequest.of(0, 1, Sort.Direction.ASC, "id"))
             .getContent();
 
@@ -190,7 +191,11 @@ public class DeltaServiceTest extends ServiceTestBase {
     List<TextUnitVariantDeltaDTO> deltasFromBeggining =
         deltaService
             .getDeltasForDates(
-                repository, null, new DateTime(0), DateTime.now().plusHours(1), Pageable.unpaged())
+                repository,
+                null,
+                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.now().plusHours(1),
+                Pageable.unpaged())
             .getContent();
 
     Assert.assertEquals(2, deltasFromBeggining.size());
@@ -243,7 +248,11 @@ public class DeltaServiceTest extends ServiceTestBase {
     List<TextUnitVariantDeltaDTO> deltasFromBeggining =
         deltaService
             .getDeltasForDates(
-                repository, null, new DateTime(0), DateTime.now().plusHours(1), Pageable.unpaged())
+                repository,
+                null,
+                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.now().plusHours(1),
+                Pageable.unpaged())
             .getContent();
 
     Assert.assertEquals(1, deltasFromBeggining.size());
@@ -308,8 +317,8 @@ public class DeltaServiceTest extends ServiceTestBase {
             .getDeltasForDates(
                 repository,
                 Collections.singletonList(frFR),
-                new DateTime(0),
-                DateTime.now().plusHours(1),
+                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.now().plusHours(1),
                 Pageable.unpaged())
             .getContent();
     Assert.assertEquals(2, frDeltasFromStart.size());
@@ -319,8 +328,8 @@ public class DeltaServiceTest extends ServiceTestBase {
             .getDeltasForDates(
                 repository,
                 Collections.singletonList(koKR),
-                new DateTime(0),
-                DateTime.now().plusHours(1),
+                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.now().plusHours(1),
                 Pageable.unpaged())
             .getContent();
     Assert.assertEquals(1, koKrDeltasFromStart.size());
@@ -328,7 +337,11 @@ public class DeltaServiceTest extends ServiceTestBase {
     List<TextUnitVariantDeltaDTO> noSpecificLocalesDeltasFromStart =
         deltaService
             .getDeltasForDates(
-                repository, null, new DateTime(0), DateTime.now().plusHours(1), Pageable.unpaged())
+                repository,
+                null,
+                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.now().plusHours(1),
+                Pageable.unpaged())
             .getContent();
     Assert.assertEquals(3, noSpecificLocalesDeltasFromStart.size());
 
@@ -337,8 +350,8 @@ public class DeltaServiceTest extends ServiceTestBase {
             .getDeltasForDates(
                 repository,
                 Arrays.asList(koKR, frFR),
-                new DateTime(0),
-                DateTime.now().plusHours(1),
+                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.now().plusHours(1),
                 Pageable.unpaged())
             .getContent();
     Assert.assertEquals(3, allLocalesDeltasFromStart.size());

--- a/webapp/src/test/java/com/box/l10n/mojito/service/pollableTask/PollableTaskCleanupServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/pollableTask/PollableTaskCleanupServiceTest.java
@@ -7,8 +7,8 @@ import static org.slf4j.LoggerFactory.getLogger;
 import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
+import java.time.ZonedDateTime;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -32,7 +32,7 @@ public class PollableTaskCleanupServiceTest extends ServiceTestBase {
   public void finishAllPollableTasks() {
     List<PollableTask> pollableTasks = pollableTaskRepository.findAll();
     for (PollableTask pollableTask : pollableTasks) {
-      pollableTask.setFinishedDate(new DateTime());
+      pollableTask.setFinishedDate(ZonedDateTime.now());
     }
     pollableTaskRepository.saveAll(pollableTasks);
   }
@@ -59,7 +59,7 @@ public class PollableTaskCleanupServiceTest extends ServiceTestBase {
 
   @Transactional
   private PollableTask setPollableTaskCreatedDateInPast(PollableTask pollableTask) {
-    DateTime pastCreatedDate = (pollableTask.getCreatedDate()).minusHours(2);
+    ZonedDateTime pastCreatedDate = (pollableTask.getCreatedDate()).minusHours(2);
     pollableTask.setCreatedDate(pastCreatedDate);
     pollableTaskRepository.save(pollableTask);
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/rollback/CurrentVariantRollbackServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/rollback/CurrentVariantRollbackServiceTest.java
@@ -19,9 +19,9 @@ import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.TMTextUnitCurrentVariantRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.test.TestIdWatcher;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -86,7 +86,7 @@ public class CurrentVariantRollbackServiceTest extends ServiceTestBase {
         tmService.addTMTextUnit(
             tm.getId(), asset.getId(), "hello_world", "Hello World!", "Comments about hello world");
     Long tmTextUnitId = tmTextUnit.getId();
-    DateTime dateTimeBeforeAddingVariant = new DateTime();
+    ZonedDateTime dateTimeBeforeAddingVariant = ZonedDateTime.now();
 
     assertOnlyEnglishVariantIsPresent(tmTextUnitId);
 
@@ -116,7 +116,7 @@ public class CurrentVariantRollbackServiceTest extends ServiceTestBase {
         tmService.addTMTextUnit(
             tm.getId(), asset.getId(), "hello_world", "Hello World!", "Comments about hello world");
     Long tmTextUnitId = tmTextUnit.getId();
-    DateTime dateTimeBeforeAddingVariant = new DateTime();
+    ZonedDateTime dateTimeBeforeAddingVariant = ZonedDateTime.now();
 
     assertOnlyEnglishVariantIsPresent(tmTextUnitId);
 
@@ -157,7 +157,7 @@ public class CurrentVariantRollbackServiceTest extends ServiceTestBase {
     tmService.addCurrentTMTextUnitVariant(tmTextUnit.getId(), frLocaleId, "Bonjour le monde!");
     tmService.addCurrentTMTextUnitVariant(tmTextUnit.getId(), jaLocaleId, "こんにちは、世界!");
 
-    DateTime dateTimeBeforeChangingCurrentVariant = new DateTime();
+    ZonedDateTime dateTimeBeforeChangingCurrentVariant = ZonedDateTime.now();
 
     assertVariantContentForCurrentVariantEquals("Bonjour le monde!", frLocaleId, tmTextUnitId);
     assertVariantContentForCurrentVariantEquals("こんにちは、世界!", jaLocaleId, tmTextUnitId);
@@ -191,7 +191,7 @@ public class CurrentVariantRollbackServiceTest extends ServiceTestBase {
     tmService.addCurrentTMTextUnitVariant(tmTextUnit.getId(), frLocaleId, "Bonjour le monde!");
     tmService.addCurrentTMTextUnitVariant(tmTextUnit.getId(), jaLocaleId, "こんにちは、世界!");
 
-    DateTime dateTimeBeforeChangingCurrentVariant = new DateTime();
+    ZonedDateTime dateTimeBeforeChangingCurrentVariant = ZonedDateTime.now();
 
     assertVariantContentForCurrentVariantEquals("Bonjour le monde!", frLocaleId, tmTextUnitId);
     assertVariantContentForCurrentVariantEquals("こんにちは、世界!", jaLocaleId, tmTextUnitId);
@@ -246,7 +246,7 @@ public class CurrentVariantRollbackServiceTest extends ServiceTestBase {
     assertOnlyEnglishVariantIsPresent(tmTextUnit1Id);
     assertOnlyEnglishVariantIsPresent(tmTextUnit2Id);
 
-    DateTime dateTimeBeforeAddingVariant = new DateTime();
+    ZonedDateTime dateTimeBeforeAddingVariant = ZonedDateTime.now();
 
     Thread.sleep(10);
 
@@ -315,7 +315,7 @@ public class CurrentVariantRollbackServiceTest extends ServiceTestBase {
         "Bonjour le nouveau monde!", frLocaleId, tmTextUnit2Id);
     assertVariantContentForCurrentVariantEquals("新しい世界をこんにちは!", jaLocaleId, tmTextUnit2Id);
 
-    DateTime dateTimeBeforeChangingCurrentVariant = new DateTime();
+    ZonedDateTime dateTimeBeforeChangingCurrentVariant = ZonedDateTime.now();
 
     Thread.sleep(10);
 
@@ -388,7 +388,7 @@ public class CurrentVariantRollbackServiceTest extends ServiceTestBase {
         tmTextUnit2.getId(), frLocaleId, "Bonjour le nouveau monde!");
     tmService.addCurrentTMTextUnitVariant(tmTextUnit2.getId(), jaLocaleId, "新しい世界をこんにちは!");
 
-    DateTime dateTimeBeforeChangingCurrentVariant = new DateTime();
+    ZonedDateTime dateTimeBeforeChangingCurrentVariant = ZonedDateTime.now();
 
     Thread.sleep(10);
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/sla/DropScheduleServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/sla/DropScheduleServiceTest.java
@@ -5,9 +5,9 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 
 import com.box.l10n.mojito.utils.DateTimeUtils;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -25,88 +25,80 @@ public class DropScheduleServiceTest {
 
   @Spy DropScheduleConfig dropScheduleConfig;
 
-  DateTimeZone dateTimeZone = DateTimeZone.forID("PST8PDT");
+  ZoneId dateTimeZone = ZoneId.of("America/Los_Angeles");
 
   @Test
   public void testGetLastDropCreatedDate() {
-    DateTime now = new DateTime("2018-06-08T14:00:00.000-07:00", dateTimeZone);
+    ZonedDateTime now = ZonedDateTime.parse("2018-06-08T14:00:00.000-07:00");
     doReturn(now).when(dateTimeUtils).now(dateTimeZone);
-    DateTime expResult = new DateTime("2018-06-06T20:00:00.000-07:00", dateTimeZone);
-    DateTime result = dropSchedule.getLastDropCreatedDate();
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-06-06T20:00:00.000-07:00");
+    ZonedDateTime result = dropSchedule.getLastDropCreatedDate();
     assertEquals(expResult, result);
   }
 
   @Test
   public void testGetLastDropCreatedDatePreviousWeek() {
-    DateTime now = new DateTime("2018-06-05T14:00:00.000-07:00", dateTimeZone);
+    ZonedDateTime now = ZonedDateTime.parse("2018-06-05T14:00:00.000-07:00");
     doReturn(now).when(dateTimeUtils).now(dateTimeZone);
-    DateTime expResult = new DateTime("2018-06-01T20:00:00.000-07:00", dateTimeZone);
-    DateTime result = dropSchedule.getLastDropCreatedDate();
+    ZonedDateTime expResult = ZonedDateTime.parse("2018-06-01T20:00:00.000-07:00");
+    ZonedDateTime result = dropSchedule.getLastDropCreatedDate();
     assertEquals(expResult, result);
   }
 
   @Test
   public void testGetLastDropDueDateDuringWeekend() {
-    DateTime before = new DateTime("2018-06-09T21:00:00.000-07:00", dateTimeZone);
-    assertEquals(
-        "2018-06-08T14:00:00.000-07:00", dropSchedule.getLastDropDueDate(before).toString());
+    ZonedDateTime before = ZonedDateTime.parse("2018-06-09T21:00:00.000-07:00");
+    assertEquals("2018-06-08T14:00-07:00", dropSchedule.getLastDropDueDate(before).toString());
   }
 
   @Test
   public void testGetLastDropDueDateExactSameTime() {
-    DateTime before = new DateTime("2018-06-08T14:00:00.000-07:00", dateTimeZone);
-    assertEquals(
-        "2018-06-08T14:00:00.000-07:00", dropSchedule.getLastDropDueDate(before).toString());
+    ZonedDateTime before = ZonedDateTime.parse("2018-06-08T14:00:00.000-07:00");
+    assertEquals("2018-06-08T14:00-07:00", dropSchedule.getLastDropDueDate(before).toString());
   }
 
   @Test
   public void testGetLastDropDueDateSameDayBeforeDropTime() {
-    DateTime before = new DateTime("2018-06-08T11:00:00.000-07:00", dateTimeZone);
-    assertEquals(
-        "2018-06-07T14:00:00.000-07:00", dropSchedule.getLastDropDueDate(before).toString());
+    ZonedDateTime before = ZonedDateTime.parse("2018-06-08T11:00:00.000-07:00");
+    assertEquals("2018-06-07T14:00-07:00", dropSchedule.getLastDropDueDate(before).toString());
   }
 
   @Test
   public void testGetLastDropDueDateSameDayAfterDropTime() {
-    DateTime before = new DateTime("2018-06-08T16:00:00.000-07:00", dateTimeZone);
-    assertEquals(
-        "2018-06-08T14:00:00.000-07:00", dropSchedule.getLastDropDueDate(before).toString());
+    ZonedDateTime before = ZonedDateTime.parse("2018-06-08T16:00:00.000-07:00");
+    assertEquals("2018-06-08T14:00-07:00", dropSchedule.getLastDropDueDate(before).toString());
   }
 
   @Test
   public void testGetLastDropDueDateEmptyWorkingDays() {
     doReturn(Arrays.asList()).when(dropScheduleConfig).getDueDays();
-    DateTime before = new DateTime("2018-06-08T16:00:00.000-07:00", dateTimeZone);
+    ZonedDateTime before = ZonedDateTime.parse("2018-06-08T16:00:00.000-07:00");
     assertNull(dropSchedule.getLastDropDueDate(before));
   }
 
   @Test
   public void testGetLastDropDueDatePreviousWeek() {
     doReturn(Arrays.asList(5)).when(dropScheduleConfig).getDueDays();
-    DateTime before = new DateTime("2018-06-06T16:00:00.000-07:00", dateTimeZone);
-    assertEquals(
-        "2018-06-01T14:00:00.000-07:00", dropSchedule.getLastDropDueDate(before).toString());
+    ZonedDateTime before = ZonedDateTime.parse("2018-06-06T16:00:00.000-07:00");
+    assertEquals("2018-06-01T14:00-07:00", dropSchedule.getLastDropDueDate(before).toString());
   }
 
   @Test
   public void testGetLastDropDueDateOneWeekAgo() {
     doReturn(Arrays.asList(5)).when(dropScheduleConfig).getDueDays();
-    DateTime before = new DateTime("2018-06-08T11:00:00.000-07:00", dateTimeZone);
-    assertEquals(
-        "2018-06-01T14:00:00.000-07:00", dropSchedule.getLastDropDueDate(before).toString());
+    ZonedDateTime before = ZonedDateTime.parse("2018-06-08T11:00:00.000-07:00");
+    assertEquals("2018-06-01T14:00-07:00", dropSchedule.getLastDropDueDate(before).toString());
   }
 
   @Test
   public void testGetDropCreatedDate() {
-    DateTime before = new DateTime("2018-06-08T14:00:00.000-07:00", dateTimeZone);
-    assertEquals(
-        "2018-06-06T20:00:00.000-07:00", dropSchedule.getDropCreatedDate(before).toString());
+    ZonedDateTime before = ZonedDateTime.parse("2018-06-08T14:00:00.000-07:00");
+    assertEquals("2018-06-06T20:00-07:00", dropSchedule.getDropCreatedDate(before).toString());
   }
 
   @Test
   public void testGetDropCreatedDatePreviousWeek() {
-    DateTime before = new DateTime("2018-06-05T14:00:00.000-07:00", dateTimeZone);
-    assertEquals(
-        "2018-06-01T20:00:00.000-07:00", dropSchedule.getDropCreatedDate(before).toString());
+    ZonedDateTime before = ZonedDateTime.parse("2018-06-05T14:00:00.000-07:00");
+    assertEquals("2018-06-01T20:00-07:00", dropSchedule.getDropCreatedDate(before).toString());
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/sla/SlaCheckerServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/sla/SlaCheckerServiceTest.java
@@ -15,10 +15,10 @@ import com.box.l10n.mojito.entity.SlaIncident;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.sla.email.SlaCheckerEmailService;
 import com.box.l10n.mojito.utils.DateTimeUtils;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
@@ -159,7 +159,7 @@ public class SlaCheckerServiceTest {
     List<SlaIncident> incidentIn = Arrays.asList(mock(SlaIncident.class), mock(SlaIncident.class));
     List<SlaIncident> incidentOut = Arrays.asList(mock(SlaIncident.class), mock(SlaIncident.class));
 
-    DateTime now = new DateTime();
+    ZonedDateTime now = ZonedDateTime.now();
     doReturn(now).when(dateTimeUtils).now();
 
     doReturn(incidentIn).when(slaIncidentRepository).findByClosedDateIsNull();
@@ -189,7 +189,7 @@ public class SlaCheckerServiceTest {
   }
 
   SlaIncident getSlaIncidentForTest() {
-    DateTime createDate = new DateTime();
+    ZonedDateTime createDate = ZonedDateTime.now();
     SlaIncident openIncident = new SlaIncident();
     openIncident.setId(1212L);
     openIncident.setCreatedDate(createDate);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/sla/email/SlaCheckerEmailServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/sla/email/SlaCheckerEmailServiceTest.java
@@ -18,12 +18,12 @@ import com.box.l10n.mojito.mustache.MustacheTemplateEngine;
 import com.box.l10n.mojito.utils.DateTimeUtils;
 import com.box.l10n.mojito.utils.ServerConfig;
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -86,20 +86,20 @@ public class SlaCheckerEmailServiceTest {
 
   @Test
   public void testShouldResendEmailYes() {
-    DateTime now = new DateTime("2018-06-08T14:00:00.000-07:00");
+    ZonedDateTime now = ZonedDateTime.parse("2018-06-08T14:00:00.000-07:00");
     doReturn(now).when(dateTimeUtils).now();
 
-    DateTime previousEmailDateTime = new DateTime("2018-06-08T12:00:00.000-07:00");
+    ZonedDateTime previousEmailDateTime = ZonedDateTime.parse("2018-06-08T12:00:00.000-07:00");
     boolean shouldResendEmail = slaCheckerEmailService.shouldResendEmail(previousEmailDateTime);
     assertTrue(shouldResendEmail);
   }
 
   @Test
   public void testShouldResendEmailNo() {
-    DateTime now = new DateTime("2018-06-08T14:00:00.000-07:00");
+    ZonedDateTime now = ZonedDateTime.parse("2018-06-08T14:00:00.000-07:00");
     doReturn(now).when(dateTimeUtils).now();
 
-    DateTime previousEmailDateTime = new DateTime("2018-06-08T13:30:00.000-07:00");
+    ZonedDateTime previousEmailDateTime = ZonedDateTime.parse("2018-06-08T13:30:00.000-07:00");
     boolean shouldResendEmail = slaCheckerEmailService.shouldResendEmail(previousEmailDateTime);
     assertFalse(shouldResendEmail);
   }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -68,6 +68,7 @@ import com.google.common.primitives.Ints;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -77,7 +78,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.xml.parsers.ParserConfigurationException;
-import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1228,7 +1228,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
     }
 
     for (int i = 0; i < textUnits; i++) {
-      DateTime now = DateTime.now();
+      ZonedDateTime now = ZonedDateTime.now();
       String name = "plural_message" + i;
       String content = "Plural Message Test #" + i;
       String comment = "Plural Comment" + i;
@@ -1355,7 +1355,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
     int textUnits = 3;
 
     for (int i = 0; i < textUnits; i++) {
-      DateTime now = DateTime.now();
+      ZonedDateTime now = ZonedDateTime.now();
       String name = "plural_message" + i;
       String content = "Plural Message Test #" + i;
       String comment = "Plural Comment" + i;
@@ -1502,7 +1502,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
     Map<Integer, Integer> pluralSizes = ImmutableMap.of(0, 3, 1, 3, 2, 3, 3, 3, 4, 2);
 
     for (int i = 0; i < pluralUnits; i++) {
-      DateTime now = DateTime.now();
+      ZonedDateTime now = ZonedDateTime.now();
       String name = "plural_message" + i;
       String content = "Plural Message Test #" + i;
       String comment = "Plural Comment" + i;

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
@@ -47,6 +47,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -58,7 +59,6 @@ import net.sf.okapi.common.resource.TextUnit;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.proxy.HibernateProxy;
-import org.joda.time.DateTime;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1009,7 +1009,7 @@ public class TMServiceTest extends ServiceTestBase {
             null,
             TMTextUnitVariant.Status.REVIEW_NEEDED,
             true,
-            new DateTime());
+            ZonedDateTime.now());
 
     TMTextUnitVariant variant3 =
         tmService.addCurrentTMTextUnitVariant(
@@ -1409,8 +1409,8 @@ public class TMServiceTest extends ServiceTestBase {
 
   private String removeIdsAndDatesFromJson(String xliff) {
     String cleanXliff = xliff.replaceAll("\"id\":\\d+,?", "");
-    cleanXliff = cleanXliff.replaceAll("\"createdDate\":\\d+,?", "");
-    cleanXliff = cleanXliff.replaceAll("\"lastModifiedDate\":\\d+,?", "");
+    cleanXliff = cleanXliff.replaceAll("\"createdDate\":\\d+\\.\\d+,?", "");
+    cleanXliff = cleanXliff.replaceAll("\"lastModifiedDate\":\\d+\\.\\d+,?", "");
     cleanXliff = cleanXliff.replaceAll(",\\}", "}");
 
     return cleanXliff;

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMTestData.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMTestData.java
@@ -20,10 +20,10 @@ import com.box.l10n.mojito.service.repository.RepositoryLocaleRepository;
 import com.box.l10n.mojito.service.repository.RepositoryService;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import com.google.common.collect.ImmutableMap;
+import java.time.ZonedDateTime;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -183,7 +183,7 @@ public class TMTestData {
   }
 
   public ImmutableMap<String, TMTextUnit> addPluralString(String basename) {
-    DateTime date = new DateTime();
+    ZonedDateTime date = ZonedDateTime.now();
 
     ImmutableMap<String, TMTextUnit> tmTextUnitsByForm =
         Stream.of("other", "zero", "one", "two", "few", "many")
@@ -194,7 +194,7 @@ public class TMTestData {
     return tmTextUnitsByForm;
   }
 
-  TMTextUnit addPluralForm(String basename, String pluralForm, DateTime date) {
+  TMTextUnit addPluralForm(String basename, String pluralForm, ZonedDateTime date) {
     return tmService.addTMTextUnit(
         tm.getId(),
         asset.getId(),

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMTextUnitHistoryServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMTextUnitHistoryServiceTest.java
@@ -19,10 +19,10 @@ import com.box.l10n.mojito.service.repository.RepositoryLocaleCreationException;
 import com.box.l10n.mojito.service.repository.RepositoryNameAlreadyUsedException;
 import com.box.l10n.mojito.service.repository.RepositoryService;
 import com.box.l10n.mojito.test.TestIdWatcher;
+import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.List;
 import org.hibernate.proxy.HibernateProxy;
-import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -189,7 +189,7 @@ public class TMTextUnitHistoryServiceTest extends ServiceTestBase {
         frLocaleId,
         "FR[this is the content]",
         "0a30a359b20fd4095fc17fb586e8db4d");
-    DateTime now = DateTime.now();
+    ZonedDateTime now = ZonedDateTime.now();
     tmService.addTMTextUnitVariant(
         tmTextUnit.getId(),
         frLocaleId,

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticServiceTest.java
@@ -12,11 +12,12 @@ import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import com.box.l10n.mojito.service.repository.RepositoryService;
 import com.box.l10n.mojito.test.TestIdWatcher;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -52,7 +53,7 @@ public class TMTextUnitStatisticServiceTest extends ServiceTestBase {
   String tmTextComment = "comment";
   Double lastDayEstimatedVolume = 3D;
   Double lastPeriodEstimatedVolume = 42D;
-  DateTime lastSeenDate = new DateTime(2021, 11, 25, 0, 0);
+  ZonedDateTime lastSeenDate = ZonedDateTime.of(2021, 11, 25, 0, 0, 0, 0, ZoneId.systemDefault());
 
   private void createTestTextUnitData(Repository repository) {
     logger.debug("Create data for test");
@@ -132,7 +133,8 @@ public class TMTextUnitStatisticServiceTest extends ServiceTestBase {
     ImportTextUnitStatisticsBody statisticWithNameOnly = getImportTextUnitStatisticsBody();
     statisticWithNameOnly.setContent(null);
     statisticWithNameOnly.setComment(null);
-    statisticWithNameOnly.setLastSeenDate(new DateTime(2000, 1, 1, 0, 0));
+    statisticWithNameOnly.setLastSeenDate(
+        ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
     textUnitStatistics.add(statisticWithNameOnly);
 
     tmTextUnitStatisticService

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherTest.java
@@ -18,13 +18,13 @@ import com.box.l10n.mojito.service.tm.TMTestData;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitVariantRepository;
 import com.box.l10n.mojito.test.TestIdWatcher;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -501,9 +501,9 @@ public class TextUnitSearcherTest extends ServiceTestBase {
   @Test
   public void testCreatedDate() throws Exception {
 
-    DateTime now = DateTime.now();
-    DateTime secondsBefore = now.minusSeconds(2);
-    DateTime secondsAfter = now.plusSeconds(2);
+    ZonedDateTime now = ZonedDateTime.now();
+    ZonedDateTime secondsBefore = now.minusSeconds(2);
+    ZonedDateTime secondsAfter = now.plusSeconds(2);
 
     TMTestData tmTestData = new TMTestData(testIdWatcher);
     TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();


### PR DESCRIPTION
Removing completely the joda-time dependency replacing it with java-time, as part of the Mojito modernization effort