### PR TITLE
Fix workbench search for many parameters

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitSearchBody.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitSearchBody.java
@@ -1,0 +1,190 @@
+package com.box.l10n.mojito.rest.textunit;
+
+import com.box.l10n.mojito.service.tm.search.SearchType;
+import com.box.l10n.mojito.service.tm.search.StatusFilter;
+import com.box.l10n.mojito.service.tm.search.UsedFilter;
+import java.util.ArrayList;
+import org.joda.time.DateTime;
+
+class TextUnitSearchBody {
+  ArrayList<Long> repositoryIds;
+  ArrayList<String> repositoryNames;
+  ArrayList<Long> tmTextUnitIds;
+  String name;
+  String source;
+  String target;
+  String assetPath;
+  String pluralFormOther;
+  boolean pluralFormFiltered = true;
+  boolean pluralFormExcluded = false;
+  SearchType searchType = SearchType.EXACT;
+  ArrayList<String> localeTags;
+  UsedFilter usedFilter;
+  StatusFilter statusFilter;
+  Boolean doNotTranslateFilter;
+  DateTime tmTextUnitCreatedBefore;
+  DateTime tmTextUnitCreatedAfter;
+  Long branchId;
+  Integer limit = 10;
+  Integer offset = 0;
+
+  public ArrayList<Long> getRepositoryIds() {
+    return repositoryIds;
+  }
+
+  public void setRepositoryIds(ArrayList<Long> repositoryIds) {
+    this.repositoryIds = repositoryIds;
+  }
+
+  public ArrayList<String> getRepositoryNames() {
+    return repositoryNames;
+  }
+
+  public void setRepositoryNames(ArrayList<String> repositoryNames) {
+    this.repositoryNames = repositoryNames;
+  }
+
+  public ArrayList<Long> getTmTextUnitIds() {
+    return tmTextUnitIds;
+  }
+
+  public void setTmTextUnitIds(ArrayList<Long> tmTextUnitIds) {
+    this.tmTextUnitIds = tmTextUnitIds;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  public void setSource(String source) {
+    this.source = source;
+  }
+
+  public String getTarget() {
+    return target;
+  }
+
+  public void setTarget(String target) {
+    this.target = target;
+  }
+
+  public String getAssetPath() {
+    return assetPath;
+  }
+
+  public void setAssetPath(String assetPath) {
+    this.assetPath = assetPath;
+  }
+
+  public String getPluralFormOther() {
+    return pluralFormOther;
+  }
+
+  public void setPluralFormOther(String pluralFormOther) {
+    this.pluralFormOther = pluralFormOther;
+  }
+
+  public boolean isPluralFormFiltered() {
+    return pluralFormFiltered;
+  }
+
+  public void setPluralFormFiltered(boolean pluralFormFiltered) {
+    this.pluralFormFiltered = pluralFormFiltered;
+  }
+
+  public boolean isPluralFormExcluded() {
+    return pluralFormExcluded;
+  }
+
+  public void setPluralFormExcluded(boolean pluralFormExcluded) {
+    this.pluralFormExcluded = pluralFormExcluded;
+  }
+
+  public SearchType getSearchType() {
+    return searchType;
+  }
+
+  public void setSearchType(SearchType searchType) {
+    this.searchType = searchType;
+  }
+
+  public ArrayList<String> getLocaleTags() {
+    return localeTags;
+  }
+
+  public void setLocaleTags(ArrayList<String> localeTags) {
+    this.localeTags = localeTags;
+  }
+
+  public UsedFilter getUsedFilter() {
+    return usedFilter;
+  }
+
+  public void setUsedFilter(UsedFilter usedFilter) {
+    this.usedFilter = usedFilter;
+  }
+
+  public StatusFilter getStatusFilter() {
+    return statusFilter;
+  }
+
+  public void setStatusFilter(StatusFilter statusFilter) {
+    this.statusFilter = statusFilter;
+  }
+
+  public Boolean getDoNotTranslateFilter() {
+    return doNotTranslateFilter;
+  }
+
+  public void setDoNotTranslateFilter(Boolean doNotTranslateFilter) {
+    this.doNotTranslateFilter = doNotTranslateFilter;
+  }
+
+  public DateTime getTmTextUnitCreatedBefore() {
+    return tmTextUnitCreatedBefore;
+  }
+
+  public void setTmTextUnitCreatedBefore(DateTime tmTextUnitCreatedBefore) {
+    this.tmTextUnitCreatedBefore = tmTextUnitCreatedBefore;
+  }
+
+  public DateTime getTmTextUnitCreatedAfter() {
+    return tmTextUnitCreatedAfter;
+  }
+
+  public void setTmTextUnitCreatedAfter(DateTime tmTextUnitCreatedAfter) {
+    this.tmTextUnitCreatedAfter = tmTextUnitCreatedAfter;
+  }
+
+  public Long getBranchId() {
+    return branchId;
+  }
+
+  public void setBranchId(Long branchId) {
+    this.branchId = branchId;
+  }
+
+  public Integer getLimit() {
+    return limit;
+  }
+
+  public void setLimit(Integer limit) {
+    this.limit = limit;
+  }
+
+  public Integer getOffset() {
+    return offset;
+  }
+
+  public void setOffset(Integer offset) {
+    this.offset = offset;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
@@ -172,6 +172,38 @@ public class TextUnitWS {
     return search;
   }
 
+  @RequestMapping(method = RequestMethod.POST, value = "/api/textunits/search")
+  @ResponseStatus(HttpStatus.OK)
+  public List<TextUnitDTO> getTextUnitsWithPost(@RequestBody TextUnitSearchBody textUnitSearchBody)
+      throws InvalidTextUnitSearchParameterException {
+
+    TextUnitSearcherParameters textUnitSearcherParameters =
+        queryParamsToTextUnitSearcherParameters(
+            textUnitSearchBody.getRepositoryIds(),
+            textUnitSearchBody.getRepositoryNames(),
+            textUnitSearchBody.getTmTextUnitIds(),
+            textUnitSearchBody.getName(),
+            textUnitSearchBody.getSource(),
+            textUnitSearchBody.getTarget(),
+            textUnitSearchBody.getAssetPath(),
+            textUnitSearchBody.getPluralFormOther(),
+            textUnitSearchBody.isPluralFormFiltered(),
+            textUnitSearchBody.isPluralFormExcluded(),
+            textUnitSearchBody.getLocaleTags(),
+            textUnitSearchBody.getUsedFilter(),
+            textUnitSearchBody.getStatusFilter(),
+            textUnitSearchBody.getDoNotTranslateFilter(),
+            textUnitSearchBody.getTmTextUnitCreatedBefore(),
+            textUnitSearchBody.getTmTextUnitCreatedAfter(),
+            textUnitSearchBody.getBranchId(),
+            textUnitSearchBody.getSearchType());
+    textUnitSearcherParameters.setLimit(textUnitSearchBody.getLimit());
+    textUnitSearcherParameters.setOffset(textUnitSearchBody.getOffset());
+    List<TextUnitDTO> search = textUnitSearcher.search(textUnitSearcherParameters);
+
+    return search;
+  }
+
   @RequestMapping(method = RequestMethod.GET, value = "/api/textunits/count")
   @ResponseStatus(HttpStatus.OK)
   public TextUnitAndWordCount getTextUnitsCount(

--- a/webapp/src/main/resources/public/js/sdk/TextUnitClient.js
+++ b/webapp/src/main/resources/public/js/sdk/TextUnitClient.js
@@ -10,13 +10,14 @@ class TextUnitClient extends BaseClient {
     /**
      * Gets the text units that matches the searcher parameters.
      *
+     * Uses an HTTP POST to suppor larger number of parameters
+     *
      * @param {TextUnitSearcherParameters} textUnitSearcherParameters
      *
      * @returns {Promise.<TextUnit[]|err>} a promise that retuns an array of text units
      */
     getTextUnits(textUnitSearcherParameters) {
-
-        let promise = this.get(this.getUrl(), textUnitSearcherParameters.getParams());
+        let promise = this.post(this.getUrl() + '/search', textUnitSearcherParameters.getParams());
 
         return promise.then(function (result) {
             return TextUnit.toTextUnits(result);


### PR DESCRIPTION
Typically, search will start failing when there are too many repositories or locales selected. The root cause is that the search is implemented using a GET request. When there are too many parameters the URL becomes too long and the request start failing.

To fix this, a new entry point is created to search using a POST request instead. The new API is "/api/textunits/search" (the original GET is on "/api/textunits" and it is not possible to just add POST support since it is already used to add text units to the system). The GET request is kept for other system that make search using that API.

The javascript client is changed to use the POST method (since there is a level of abstraction on top of the REST API, there is nothing else to change).