### PR TITLE
Fix regression in ImageWS name encoding

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/images/ImageWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/images/ImageWS.java
@@ -5,6 +5,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import com.box.l10n.mojito.entity.Image;
 import com.box.l10n.mojito.service.image.ImageService;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.io.FilenameUtils;
@@ -70,7 +71,9 @@ public class ImageWS {
         (String)
             httpServletRequest.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
 
-    return path.substring(PATH_PREFIX.length());
+    String imageName = path.substring(PATH_PREFIX.length());
+    imageName = URLDecoder.decode(imageName);
+    return imageName;
   }
 
   /**

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/images/ImageWSITest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/images/ImageWSITest.java
@@ -1,0 +1,57 @@
+package com.box.l10n.mojito.rest.images;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.box.l10n.mojito.entity.Image;
+import com.box.l10n.mojito.rest.WSTestBase;
+import com.box.l10n.mojito.rest.client.ImageClient;
+import com.box.l10n.mojito.service.image.ImageService;
+import com.box.l10n.mojito.test.category.IntegrationTest;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ImageWSITest extends WSTestBase {
+
+  @Autowired ImageClient imageClient;
+
+  @Autowired ImageService imageService;
+
+  @Test
+  @Category({IntegrationTest.class})
+  public void testImageNameOneWord() {
+    final String imageName = "oneword.jpg";
+    imageClient.uploadImage(imageName, "some test".getBytes(StandardCharsets.UTF_8));
+    final Optional<Image> image = imageService.getImage(imageName);
+    assertThat(image.get().getName()).isEqualTo(imageName);
+  }
+
+  @Test
+  @Category({IntegrationTest.class})
+  public void testImageNameWithSpace() {
+    final String imageName = "some image.jpg";
+    imageClient.uploadImage(imageName, "some test".getBytes(StandardCharsets.UTF_8));
+
+    final Optional<Image> withWrongName = imageService.getImage("some%20image.jpg");
+    assertThat(withWrongName.isPresent()).isFalse();
+
+    final Optional<Image> image = imageService.getImage(imageName);
+    assertThat(image.get().getName()).isEqualTo(imageName);
+  }
+
+  @Test
+  @Category({IntegrationTest.class})
+  public void testImageNameWithUTF8() {
+    final String imageName = "こんにちは.jpg";
+    imageClient.uploadImage(imageName, "some test".getBytes(StandardCharsets.UTF_8));
+
+    final Optional<Image> withWrongName =
+        imageService.getImage("%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF.jpg");
+    assertThat(withWrongName.isPresent()).isFalse();
+
+    final Optional<Image> image = imageService.getImage(imageName);
+    assertThat(image.get().getName()).isEqualTo(imageName);
+  }
+}


### PR DESCRIPTION
There is regression (probably introduced by Spring upgradei, to be investigated more) in what is returned by httpServletRequest.getAttribute(). The content is now URL encoded causing issue as Mojito expect it to be decoded.

This applies URLDecoder.decode() to fix the regression and adds integration tests to catch future change/regression