### PR TITLE
URL decode passed image string

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/images/ImageWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/images/ImageWS.java
@@ -5,6 +5,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import com.box.l10n.mojito.entity.Image;
 import com.box.l10n.mojito.service.image.ImageService;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.io.FilenameUtils;
@@ -70,7 +71,22 @@ public class ImageWS {
         (String)
             httpServletRequest.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
 
-    return path.substring(PATH_PREFIX.length());
+    return urlDecode(path.substring(PATH_PREFIX.length()));
+  }
+
+  /**
+   * Best effort approach to url decode a string. If it fails, the original string is returned.
+   *
+   * @param encodedString
+   * @return url decoded string (or original string if it fails)
+   */
+  private String urlDecode(String encodedString) {
+    try {
+      return URLDecoder.decode(encodedString, "UTF-8");
+    } catch (Exception e) {
+      logger.warn("Could not decode string: {}, returning encoded string", encodedString, e);
+      return encodedString;
+    }
   }
 
   /**

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/images/ImageWSIntegrationTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/images/ImageWSIntegrationTest.java
@@ -1,0 +1,35 @@
+package com.box.l10n.mojito.rest.images;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.box.l10n.mojito.entity.Image;
+import com.box.l10n.mojito.rest.WSTestBase;
+import com.box.l10n.mojito.service.image.ImageService;
+import java.util.Optional;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+public class ImageWSIntegrationTest extends WSTestBase {
+
+  private static final String imageName = "1234-5678-9101-1121Some file name with gaps.png";
+
+  private static final String PATH_PREFIX = "/api/images/";
+
+  @Autowired ImageService imageService;
+
+  @Test
+  public void testUploadImage() {
+    byte[] imageBytes = "test".getBytes();
+    authenticatedRestTemplate.put(PATH_PREFIX + imageName, imageBytes);
+    ResponseEntity<byte[]> response =
+        authenticatedRestTemplate.getForEntity(PATH_PREFIX + imageName, byte[].class);
+    assertThat(response.getStatusCode().is2xxSuccessful());
+    assertThat(response.getBody()).isEqualTo(imageBytes);
+
+    // Verify the stored image uses the HTTP decoded name
+    Optional<Image> imageOpt = imageService.getImage(imageName);
+    assertThat(imageOpt).isPresent();
+    assertThat(imageOpt.get().getName()).isEqualTo(imageName);
+  }
+}


### PR DESCRIPTION
Resolves issue where images names were being stored with HTTP encoded names and the associated screenshot entities were not. Issue was introduced after upgrading Spring to 2.7.15 (https://github.com/pinterest/mojito/commit/7d44ec0eefb2409ad8bccdb9e9161fa7ef83ba98)

Added unit test to catch this issue reoccurring in future.