### PR TITLE
WIP back and forth navigation does not work anymore with this ...

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/clobstorage/ClobStorageWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/clobstorage/ClobStorageWS.java
@@ -1,0 +1,53 @@
+package com.box.l10n.mojito.rest.clobstorage;
+
+import com.box.l10n.mojito.rest.textunit.InvalidTextUnitSearchParameterException;
+import com.box.l10n.mojito.service.blobstorage.Retention;
+import com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage;
+import java.util.Objects;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ClobStorageWS {
+
+  /** logger */
+  static Logger logger = LoggerFactory.getLogger(ClobStorageWS.class);
+
+  final StructuredBlobStorage structuredBlobStorage;
+
+  public ClobStorageWS(StructuredBlobStorage structuredBlobStorage) {
+    this.structuredBlobStorage = Objects.requireNonNull(structuredBlobStorage);
+  }
+
+  @RequestMapping(method = RequestMethod.POST, value = "/api/clobstorage")
+  @ResponseStatus(HttpStatus.OK)
+  public UUID post(@RequestBody String content) throws InvalidTextUnitSearchParameterException {
+
+    final UUID uuid = UUID.randomUUID();
+
+    structuredBlobStorage.put(
+        StructuredBlobStorage.Prefix.CLOB_STORAGE_WS,
+        uuid.toString(),
+        content,
+        Retention.PERMANENT);
+
+    return uuid;
+  }
+
+  @RequestMapping(method = RequestMethod.GET, value = "/api/clobstorage/{uuid}")
+  @ResponseStatus(HttpStatus.OK)
+  public String getTextUnitsSeargetchParams(@PathVariable(value = "uuid") UUID uuid)
+      throws InvalidTextUnitSearchParameterException {
+    return structuredBlobStorage
+        .getString(StructuredBlobStorage.Prefix.CLOB_STORAGE_WS, uuid.toString())
+        .get();
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/StructuredBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/StructuredBlobStorage.java
@@ -38,6 +38,7 @@ public class StructuredBlobStorage {
     POLLABLE_TASK,
     IMAGE,
     MULTI_BRANCH_STATE,
-    TEXT_UNIT_DTOS_CACHE
+    TEXT_UNIT_DTOS_CACHE,
+    CLOB_STORAGE_WS,
   }
 }

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -285,6 +285,22 @@ workbench.toolbar.clearAllInPage=Clear all in page
 # Label displayed in the workbench toolbar dropdown to clear selection of all textunits across all pages in the search results
 workbench.toolbar.clearAll=Clear all
 
+# Title of the modal to share the workbench's search paramters
+workbench.shareSearchParamsModal.title=Share the search parameters
+
+# Button label used for copying the link in the modal to share the workbench's search paramters
+workbench.shareSearchParamsModal.copy=Copy
+
+# Error message shown when getting the search parameters from the backend webservice fails for a given link
+workbench.shareSearchParamsModal.errors.get=Can't get the search parameters for the given link
+
+# Errror message shown when saving the search parameter to the backend service fails and that it is not possible to create
+# the shared link
+workbench.shareSearchParamsModal.errors.save=Can't save the search parameters to create a shareable link
+
+# Error message shown when it is not possible to save the URL to the clipboard to share search parameters
+workbench.shareSearchParamsModal.errors.copyToClipboard=Can't copy the URL to the clipboard
+
 # Label for the Review button on the modal in the workbench
 textUnit.reviewModal.rejected=Rejected
 

--- a/webapp/src/main/resources/public/js/actions/workbench/ShareSearchParamsDataSource.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/ShareSearchParamsDataSource.js
@@ -1,0 +1,33 @@
+import ShareSearchParamsModalActions from "./ShareSearchParamsModalActions";
+import ClobStorageClient from "../../sdk/ClobStorageClient";
+
+const ShareSearchParamsDataSource = {
+
+    saveSearchParams: {
+        remote(store, searchParams) {
+            let promise = ClobStorageClient.saveClob(searchParams).then(function (uuid) {
+                return uuid;
+            });
+
+            return promise;
+        },
+        success: ShareSearchParamsModalActions.saveSearchParamsSuccess,
+        error: ShareSearchParamsModalActions.saveSearchParamsError,
+    },
+    getSearchParams: {
+        remote(store, uuid) {
+            let promise = ClobStorageClient.getClob(uuid).then(function (searchParams) {
+                return {
+                    uuid: uuid,
+                    searchParams: searchParams
+                };
+            });
+
+            return promise;
+        },
+        success: ShareSearchParamsModalActions.getSearchParamsSuccess,
+        error: ShareSearchParamsModalActions.getSearchParamsError
+    }
+};
+
+export default ShareSearchParamsDataSource;

--- a/webapp/src/main/resources/public/js/actions/workbench/ShareSearchParamsModalActions.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/ShareSearchParamsModalActions.js
@@ -1,0 +1,22 @@
+import alt from "../../alt";
+
+class ShareSearchParamsModalActions {
+
+    constructor() {
+        this.generateActions(
+            "open",
+            "close",
+
+            "saveSearchParamsSuccess",
+            "saveSearchParamsError",
+
+            "getSearchParams",
+            "getSearchParamsSuccess",
+            "getSearchParamsError",
+
+            "setErrorType"
+        );
+    }
+}
+
+export default alt.createActions(ShareSearchParamsModalActions);

--- a/webapp/src/main/resources/public/js/components/header/Header.js
+++ b/webapp/src/main/resources/public/js/components/header/Header.js
@@ -50,8 +50,7 @@ class Header extends React.Component {
      */
     updateSearchParamsForDefaultView = () => {
         WorkbenchActions.searchParamsChanged({
-            "changedParam": SearchConstants.UPDATE_ALL,
-            "doNotTranslate": true
+            "changedParam": SearchConstants.UPDATE_ALL_LOCATION_NONE
         });
     };
 

--- a/webapp/src/main/resources/public/js/components/workbench/ShareSearchParamsButton.js
+++ b/webapp/src/main/resources/public/js/components/workbench/ShareSearchParamsButton.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import React from "react";
+import {injectIntl} from 'react-intl';
+import {Button, Glyphicon} from "react-bootstrap";
+
+class StatusGlyph extends React.Component {
+    static propTypes = {
+        "onClick": PropTypes.func.isRequired
+    };
+
+    /**
+     * @return {JSX}
+     */
+    render() {
+        return (
+            <Button onClick={this.props.onClick} className="mlm">
+                <Glyphicon glyph='glyphicon glyphicon-link'/>
+            </Button>
+        );
+    }
+}
+
+export default injectIntl(StatusGlyph);

--- a/webapp/src/main/resources/public/js/components/workbench/ShareSearchParamsModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/ShareSearchParamsModal.js
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import React from "react";
+import {FormattedMessage, injectIntl} from "react-intl";
+import {Alert, Button, Modal} from "react-bootstrap";
+import ShareSearchParamsModalStore from "../../stores/workbench/ShareSearchParamsModalStore";
+
+class ShareSearchParamsModal extends React.Component {
+    static propTypes = {
+        "show": PropTypes.bool.isRequired,
+        "onCancel": PropTypes.func.isRequired,
+        "onCopy": PropTypes.func.isRequired,
+        "isLoadingParams": PropTypes.bool.isRequired,
+        "url": PropTypes.string,
+        "errorMessage": PropTypes.string,
+    }
+
+    render() {
+        return (
+            <Modal show={this.props.show} onHide={this.props.onCancel}>
+                <Modal.Header closeButton>
+                    <Modal.Title>
+                        <FormattedMessage id="workbench.shareSearchParamsModal.title"/>
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {this.props.isLoadingParams ? (<span className="glyphicon glyphicon-refresh spinning"/>) : ""}
+
+                    <a href={this.props.url}>{this.props.url}</a>
+                    {
+                        this.props.errorType != null &&
+                        <Alert bsStyle="danger">{this.getErrorMessage()}</Alert>
+                    }
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button bsStyle="primary" onClick={() => this.props.onCopy(this.props.url)}>
+                        <FormattedMessage id="workbench.shareSearchParamsModal.copy"/>
+                    </Button>
+                    <Button onClick={this.props.onCancel}>
+                        <FormattedMessage id="label.cancel"/>
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+
+    getErrorMessage() {
+        switch (this.props.errorType) {
+            case ShareSearchParamsModalStore.ERROR_TYPES.GET_SEARCH_PARAMS:
+                return this.props.intl.formatMessage({id: "workbench.shareSearchParamsModal.errors.get"});
+            case ShareSearchParamsModalStore.ERROR_TYPES.SAVE_SEARCH_PARAMS:
+                return this.props.intl.formatMessage({id: "workbench.shareSearchParamsModal.errors.save"});
+            case ShareSearchParamsModalStore.ERROR_TYPES.COPY_TO_CLIPBOARD:
+                return this.props.intl.formatMessage({id: "workbench.shareSearchParamsModal.errors.copyToClipboard"});
+        }
+    }
+}
+
+export default injectIntl(ShareSearchParamsModal);

--- a/webapp/src/main/resources/public/js/components/workbench/Workbench.js
+++ b/webapp/src/main/resources/public/js/components/workbench/Workbench.js
@@ -8,8 +8,6 @@ import RepositoryDropDown from "./RepositoryDropdown";
 import SearchResults from "./SearchResults";
 import StatusDropdown from "./StatusDropdown";
 import SearchText from "./SearchText";
-import SearchParamsStore from "../../stores/workbench/SearchParamsStore";
-import LocationHistory from "../../utils/LocationHistory";
 import AltContainer from "alt-container";
 import GitBlameStore from "../../stores/workbench/GitBlameStore";
 import GitBlameInfoModal from "./GitBlameInfoModal";
@@ -21,6 +19,10 @@ import UrlHelper from "../../utils/UrlHelper";
 import TranslationHistoryStore from "../../stores/workbench/TranslationHistoryStore";
 import TranslationHistoryModal from "./TranslationHistoryModal";
 import TranslationHistoryActions from "../../actions/workbench/TranslationHistoryActions";
+import ShareSearchParamsModalStore from "../../stores/workbench/ShareSearchParamsModalStore";
+import ShareSearchParamsModal from "./ShareSearchParamsModal";
+import ShareSearchParamsModalActions from "../../actions/workbench/ShareSearchParamsModalActions";
+import ShareSearchParamsButton from "./ShareSearchParamsButton";
 
 let Workbench = createReactClass({
     displayName: 'Workbench',
@@ -28,19 +30,9 @@ let Workbench = createReactClass({
 
     statics: {
         storeListeners: {
-            "onSearchParamsStoreChanged": SearchParamsStore,
             "onGitBlameStoreUpdated": GitBlameStore,
             "onTranslationHistoryStoreUpdated": TranslationHistoryStore
         }
-    },
-
-    /**
-     * Handler for SearchParamsStore changes
-     *
-     * @param {object} searchParams The SearchParamsStore state
-     */
-    onSearchParamsStoreChanged: function (searchParams) {
-        this.updateLocationForSearchParam(searchParams);
     },
 
     onGitBlameStoreUpdated(store) {
@@ -49,26 +41,6 @@ let Workbench = createReactClass({
 
     onTranslationHistoryStoreUpdated(store) {
         this.setState({"isShowTranslationHistoryModal": store.show});
-    },
-
-    /**
-     * Updates the browser location based to reflect search
-     *
-     * If the URL is only workbench replace the state (to reflect the search param) else if the query has changed
-     * push a new state to keep track of the change param modification.
-     *
-     * @param {object} searchParams The SearchParamsStore state
-     */
-    updateLocationForSearchParam(searchParams) {
-        LocationHistory.updateLocation(this.props.router, "/workbench", searchParams);
-    },
-
-    /**
-     * @param {string} queryString Starts with ?
-     * @return boolean
-     */
-    isCurrentQueryEqual: function (queryString) {
-        return queryString === window.location.search;
     },
 
     /**
@@ -92,7 +64,8 @@ let Workbench = createReactClass({
                 </div>
 
                 <SearchText />
-                <StatusDropdown />
+                <StatusDropdown/>
+                <ShareSearchParamsButton onClick={ShareSearchParamsModalActions.open}/>
 
                 <div className="mtl mbl">
                     <SearchResults />
@@ -123,6 +96,16 @@ let Workbench = createReactClass({
                 <AltContainer store={TranslationHistoryStore}>
                     <TranslationHistoryModal onCloseModal={TranslationHistoryActions.close}
                                              onChangeOpenTmTextUnitVariant={TranslationHistoryActions.changeOpenTmTextUnitVariant}/>
+                </AltContainer>
+
+                <AltContainer store={ShareSearchParamsModalStore}>
+                    <ShareSearchParamsModal
+                        onCancel={ShareSearchParamsModalActions.close}
+                        onCopy={(url) => {
+                            navigator.clipboard.writeText(url)
+                                .then(ShareSearchParamsModalActions.close)
+                                .catch(err => ShareSearchParamsModalActions.setError(ShareSearchParamsModalStore.ERROR_TYPES.COPY_TO_CLIPBOARD));
+                        }}/>
                 </AltContainer>
             </div>
         );

--- a/webapp/src/main/resources/public/js/sdk/ClobStorageClient.js
+++ b/webapp/src/main/resources/public/js/sdk/ClobStorageClient.js
@@ -1,0 +1,22 @@
+import BaseClient from "./BaseClient";
+
+class ClobStorageClient extends BaseClient {
+
+    getClob(uuid) {
+        return this.get(this.getUrl(uuid));
+    }
+
+    saveClob(content) {
+        return this.post(this.getUrl(), content);
+    }
+
+    getEntityName() {
+        return 'clobstorage';
+    }
+}
+;
+
+export default new ClobStorageClient();
+
+
+

--- a/webapp/src/main/resources/public/js/stores/workbench/SearchParamsStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/SearchParamsStore.js
@@ -7,6 +7,7 @@ import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
 import RepositoryActions from "../../actions/RepositoryActions";
 
 import RepositoryStore from "../RepositoryStore";
+import ShareSearchParamsModalActions from "../../actions/workbench/ShareSearchParamsModalActions";
 
 class SearchParamsStore {
 
@@ -15,6 +16,7 @@ class SearchParamsStore {
         this.setDefaultParameters();
         this.bindActions(WorkbenchActions);
         this.bindActions(RepositoryActions);
+        this.bindActions(ShareSearchParamsModalActions);
     }
 
     /**
@@ -67,7 +69,7 @@ class SearchParamsStore {
         }
 
         let converted = {
-            "changedParam": SearchConstants.UPDATE_ALL,
+            "changedParam": SearchConstants.UPDATE_ALL_LOCATION_UPDATE,
             "repoIds": typeof repoIds !== "undefined" ? repoIds : null,
             "repoNames": typeof repoNames !== "undefined" ? repoNames : null,
             "bcp47Tags": typeof bcp47Tags !== "undefined" ? bcp47Tags : null,
@@ -148,6 +150,8 @@ class SearchParamsStore {
                 break;
 
             case SearchConstants.UPDATE_ALL:
+            case SearchConstants.UPDATE_ALL_LOCATION_UPDATE:
+            case SearchConstants.UPDATE_ALL_LOCATION_NONE:
 
                 this.setDefaultParameters();
                 this.updateAllParameters(paramData);
@@ -171,6 +175,11 @@ class SearchParamsStore {
         this.updatePageOffset();
 
         this.changedParam = paramData.changedParam;
+    }
+
+    onGetSearchParamsSuccess(result) {
+        result.searchParams["changedParam"] = SearchConstants.UPDATE_ALL_LOCATION_UPDATE;
+        this.onSearchParamsChanged(result.searchParams);
     }
 
     /**

--- a/webapp/src/main/resources/public/js/stores/workbench/ShareSearchParamsModalStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/ShareSearchParamsModalStore.js
@@ -1,0 +1,91 @@
+import alt from "../../alt";
+import ShareSearchParamsModalActions from "../../actions/workbench/ShareSearchParamsModalActions";
+import ShareSearchParamsDataSource from "../../actions/workbench/ShareSearchParamsDataSource";
+import UrlHelper from "../../utils/UrlHelper";
+import SearchParamsStore from "./SearchParamsStore";
+import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
+import keymirror from "keymirror";
+
+class ShareSearchParamsModalStore {
+
+    static ERROR_TYPES = keymirror({
+        "GET_SEARCH_PARAMS": null,
+        "SAVE_SEARCH_PARAMS": null,
+        "COPY_TO_CLIPBOARD": null,
+    });
+
+    constructor() {
+        this.setDefaultState();
+        this.bindActions(ShareSearchParamsModalActions);
+        this.bindListeners({
+            onSearchParamsChanged: WorkbenchActions.SEARCH_PARAMS_CHANGED,
+        });
+        this.registerAsync(ShareSearchParamsDataSource);
+    }
+
+    setDefaultState() {
+        this.show = false;
+        this.isLoadingParams = false;
+        this.errorType = null;
+    }
+
+    open() {
+        this.show = true;
+        if (!this.isLoadingParams && this.url == null) {
+            this.waitFor(SearchParamsStore);
+            this.isLoadingParams = true;
+            this.getInstance().saveSearchParams(SearchParamsStore.getState());
+        }
+    }
+
+    close() {
+        this.show = false;
+
+        if (this.errorType != null) {
+            this.errorType = null;
+            this.url = null;
+        }
+    }
+
+    onGetSearchParams(uuid) {
+        this.getInstance().getSearchParams(uuid);
+    }
+
+    onGetSearchParamsSuccess(result) {
+        this.waitFor(SearchParamsStore);
+        this.isLoadingParams = false;
+        this.url = this.getUrlForUUID(result.uuid);
+    }
+
+    onGetSearchParamsError() {
+        this.isLoadingParams = false;
+        this.errorType = ShareSearchParamsModalStore.ERROR_TYPES.GET_SEARCH_PARAMS;
+    }
+
+    onSaveSearchParamsSuccess(uuid) {
+        this.isLoadingParams = false;
+        this.url = this.getUrlForUUID(uuid);
+    }
+
+    onSaveSearchParamsError() {
+        this.isLoadingParams = false;
+        this.errorType = ShareSearchParamsModalStore.ERROR_TYPES.SAVE_SEARCH_PARAMS;
+    }
+
+    onSearchParamsChanged(searchParams) {
+        this.isLoadingParams = false;
+        this.url = null;
+    }
+
+    onSetErrorType(errorType) {
+        this.errorType = errorType;
+    }
+
+    getUrlForUUID(uuid) {
+        return new URL(UrlHelper.getUrlWithContextPath("/workbench?") + UrlHelper.toQueryString({"link": uuid}), location.origin).href
+    }
+}
+
+
+
+export default alt.createStore(ShareSearchParamsModalStore, 'ShareSearchParamsModalStore');

--- a/webapp/src/main/resources/public/js/utils/LocationHistory.js
+++ b/webapp/src/main/resources/public/js/utils/LocationHistory.js
@@ -40,7 +40,7 @@ class LocationHistory {
      */
     buildQuery(params) {
         let cloneParam = _.clone(params);
-        delete cloneParam["changedParam"];
+        delete cloneParam["changedParam"]; // this is workbench specific
         return UrlHelper.toQueryString(cloneParam);
     }
 };

--- a/webapp/src/main/resources/public/js/utils/SearchConstants.js
+++ b/webapp/src/main/resources/public/js/utils/SearchConstants.js
@@ -6,6 +6,8 @@ let SearchConstants = keymirror({
     "SEARCHTEXT_CHANGED": null,
     "SEARCHFILTER_CHANGED": null,
     "UPDATE_ALL": null,
+    "UPDATE_ALL_LOCATION_UPDATE": null,
+    "UPDATE_ALL_LOCATION_NONE": null,
     "NEXT_PAGE_REQUESTED" : null,
     "PREVIOUS_PAGE_REQUESTED" : null
 });


### PR DESCRIPTION
New implementation for deep links to workbench search

This changes how deep links work in the product. From now on, instead of copying the browser location/url, the user will have to click a "share" button. That button will generate a URL that can be copied and shared with other users.

This relates to commit: efd27a6 which fixed the workbench search when the number of parameters is large by relying on a POST request instead of a GET. But that did not fix the deep linking feature, which relied on updating the browser location with all the search parameters and using a redirect. The URL would end up being too long and the server redirect eventually failed.

 The general flow is:
 - user performs a search in the workbench
 - user clicks the share button
 - the share modal is openned and shows spinner (invisible if fast)
 - frontend emits a request to persist the search parameters as a clob in the backend
 - the web service return a UUID for the saved parameters, that UUID used to forge the shareable URL
 - the spinner is replaced by the generated URL in the UI
 - the user can copy the link using the CTA button or just by working with the URL.
 - the user can now share the link
 - second user opens the link
 - browser makes the initial request and fetch the SPA, which redirect to the workbench page
 - on app load, the UUID is extracted from the link and the SPA initiate a query to fetch the search parameters from the web service. It also re-writes the browser location to only show "workbench", and in other words hide the "link" part
 - once the API call completes, the search parameters just fetched are used ot update the frontend search parameter store
 - this trigger a UI re-render and trigger a new text unit search
 - search results are now accessible (note that the result may have changed, this is sharing the search parameters and not the search results)
 - if clicking the share button, the link must be the same as what the user paste

 Implementation details:
 - Create a new web service API: /api/clobstorage, a very simple API to store clobs. The POST returns a UUID that can be used by the GET method to retreive the clob later
 - ClobStorageClient is simple javascript client to access the API
 - app.js takes care of extracting the UUID and triggering the search parameters fetch
 - 2 new UI components are added: ShareSearchParamsButton (shared button that will be shown next to the "filter" dropdown in the workbench), and ShareSearchParamsModal (to show/copy the shareable URL)
 - ShareSearchParamsModalStore is the store that maintains the state for this process.
 - Update the Workbench to wire the different elements together ShareSearchParamsModalActions
 - Update the SearchParamsStore to react to new parameters being fetched and update the store state.
 - basic error will be shown in the modal there are issue saving/getting or copying to clipboard
 - this removes the logic that updates the browser location when search parameters are changed
 - but it keeps the logic to initialize the store from URL with parameters as it is used by other platform currently
 
 https://github.com/pinterest/mojito/assets/9702182/b32a631f-fdb2-494a-9247-41602f183b38