### PR TITLE
Set the pullRunId parameters in PullCommandParallel

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommandParallel.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommandParallel.java
@@ -46,6 +46,9 @@ public class PullCommandParallel extends PullCommand {
     this.sourceDirectoryParam = pullCommand.sourceDirectoryParam;
     this.targetDirectoryParam = pullCommand.targetDirectoryParam;
     this.onlyIfFullyTranslated = pullCommand.onlyIfFullyTranslated;
+    this.pullRunName = pullCommand.pullRunName;
+    this.recordPullRun = pullCommand.recordPullRun;
+    this.isParallel = pullCommand.isParallel;
   }
 
   public void pull() throws CommandException {


### PR DESCRIPTION
Fixes bug where the pull run id isn't created in the mojito DB