### PR TITLE
Ignore local/ in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ release.properties
 /.java-version
 /node_modules/
 /tmp/
+/local/

--- a/idea.md
+++ b/idea.md
@@ -1,3 +1,13 @@
+# Add private config, deployment code, etc. for easy access
+
+The local/ is excluded from Git. It can be used to seem like to private config, deployment code, etc.
+
+```shell
+cd local/
+ln -s ~/.l10n/config
+ln -s ~/code/mojito-deploy/
+```
+
 ## Simplest way to get everything to work quickly (but slower that intellij incremental update)
 
 https://www.jetbrains.com/help/idea/delegate-build-and-run-actions-to-maven.html


### PR DESCRIPTION
This can be used to symlink private config, deployment code, etc. to have quick access in Intellij without having to modify the project settings.