### PR TITLE
Stop running spotless during compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,14 +127,6 @@
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>2.24.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>apply</goal>
-                        </goals>
-                        <phase>compile</phase>
-                    </execution>
-                </executions>
                 <configuration>
                     <java>
                         <excludes>


### PR DESCRIPTION
It is probably better to just run spotless explicilty or before commiting using github hooks, see docs: .githooks/README.md

On the CI there is a check to make sure PR are properly indented before merge