### PR TITLE
DB V65 migration refactor & re-introduce

### DIFF
--- a/docker/Dockerfile-bk17
+++ b/docker/Dockerfile-bk17
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:experimental
+
+FROM maven:3.8.4-openjdk-17 as build
+VOLUME ["/tmp"]
+
+WORKDIR /mnt/mojito
+
+# copy source and make sure node* are not present (Mac version may conflict with Linux)
+COPY . /mnt/mojito
+
+ENV PATH="/mnt/mojito/webapp/node/:${PATH}"
+RUN --mount=type=cache,target=/root/.m2 --mount=type=cache,target=/mnt/mojito/node --mount=type=cache,target=/mnt/mojito/node_module mvn clean install -DskipTests
+
+
+FROM amazoncorretto:17-alpine
+VOLUME /tmp
+
+ENV MOJITO_BIN=/usr/local/mojito/bin
+ENV PATH $PATH:${MOJITO_BIN}
+ENV MOJITO_HOST=localhost
+ENV MOJITO_SCHEME=http
+ENV MOJITO_PORT=8080
+
+COPY --from=build /mnt/mojito/webapp/target/mojito-webapp-*-exec.jar ${MOJITO_BIN}/mojito-webapp.jar
+COPY --from=build /mnt/mojito/cli/target/mojito-cli-*-exec.jar ${MOJITO_BIN}/mojito-cli.jar
+RUN sh -c 'touch ${MOJITO_BIN}/mojito-webapp.jar'
+RUN sh -c 'touch ${MOJITO_BIN}/mojito-cli.jar'
+
+# Create the shell wrapper for the jar
+RUN /bin/echo -e "#!/bin/sh \n\
+java -Dl10n.resttemplate.host=\${MOJITO_HOST} \\\\\n \
+     -Dl10n.resttemplate.scheme=\${MOJITO_SCHEME} \\\\\n \
+     -Dl10n.resttemplate.port=\${MOJITO_PORT} \\\\\n \
+     -jar $MOJITO_BIN/mojito-cli.jar \"\${@}\"" \
+    >> /usr/local/mojito/bin/mojito && chmod +x $MOJITO_BIN/mojito
+
+# starting with "exec doesn't seem to be needed with openjdk:8-alpine. As per docker documentation, it is required in general
+ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar $MOJITO_BIN/mojito-webapp.jar

--- a/docker/docker-compose-api-worker.yml
+++ b/docker/docker-compose-api-worker.yml
@@ -19,28 +19,26 @@ services:
       - --collation-server=utf8mb4_bin
       - --max-connections=1000
       - --log_error_verbosity=2
+    volumes:
+        - mysql-data:/var/lib/mysql
+
   api:
     deploy:
       mode: replicated
       replicas: 1
       endpoint_mode: vip
       resources:
-        limits:
-          cpus: '2'
-          memory: 1G
+#        limits:
+#          cpus: '2'
+#          memory: 1G
         reservations:
           cpus: '1'
           memory: 200M
-    healthcheck:
-      test: [ "CMD", "curl", "localhost:8080/" ]
-      interval: 5s
-      timeout: 10s
-      retries: 50
     depends_on:
       db:
         condition: service_healthy
     build:
-      dockerfile: docker/Dockerfile-bk8
+      dockerfile: docker/Dockerfile-bk17
       context: ../
     image: mojito:latest
     pull_policy: never
@@ -103,21 +101,14 @@ services:
       replicas: 2
       endpoint_mode: vip
       resources:
-        limits:
-          cpus: '2'
-          memory: 1G
+#        limits:
+#          cpus: '2'
+#          memory: 1G
         reservations:
           cpus: '1'
           memory: 200M
-    healthcheck:
-      test: [ "CMD", "curl", "localhost:8080/" ]
-      interval: 5s
-      timeout: 10s
-      retries: 50
     depends_on:
       db:
-        condition: service_healthy
-      api:
         condition: service_healthy
     image: mojito:latest
     pull_policy: never
@@ -173,3 +164,6 @@ services:
         "logging.level.com.box.l10n.mojito.service.repository.statistics.RepositoryStatisticsJob" : "DEBUG",
         "logging.level.com.box.l10n.mojito.service.thirdparty.smartling.quartz" : "DEBUG"
         }'
+
+volumes:
+  mysql-data:

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/PullRunTextUnitVariant.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/PullRunTextUnitVariant.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.entity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import javax.persistence.Basic;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
 import javax.persistence.Index;
@@ -25,8 +26,8 @@ import org.hibernate.annotations.BatchSize;
     name = "pull_run_text_unit_variant",
     indexes = {
       @Index(
-          name = "UK__PULL_RUN_TEXT_UNIT_VARIANT__PRA_ID__TUV_ID__LOCALE_ID",
-          columnList = "pull_run_asset_id, tm_text_unit_variant_id, locale_id",
+          name = "UK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE_ID__PRA_ID__TUV_ID__TAG",
+          columnList = "pull_run_asset_id, locale_id, output_bcp47_tag, tm_text_unit_variant_id",
           unique = true)
     })
 @BatchSize(size = 1000)
@@ -52,6 +53,9 @@ public class PullRunTextUnitVariant extends SettableAuditableEntity {
       foreignKey = @ForeignKey(name = "FK__PULL_RUN_TEXT_UNIT_VARIANT__TM_TEXT_UNIT_VARIANT_ID"))
   private TMTextUnitVariant tmTextUnitVariant;
 
+  @Column(name = "output_bcp47_tag", length = 10)
+  private String outputBcp47Tag;
+
   public PullRunAsset getPullRunAsset() {
     return pullRunAsset;
   }
@@ -66,5 +70,13 @@ public class PullRunTextUnitVariant extends SettableAuditableEntity {
 
   public void setTmTextUnitVariant(TMTextUnitVariant tmTextUnitVariant) {
     this.tmTextUnitVariant = tmTextUnitVariant;
+  }
+
+  public String getOutputBcp47Tag() {
+    return outputBcp47Tag;
+  }
+
+  public void setOutputBcp47Tag(String outputBcp47Tag) {
+    this.outputBcp47Tag = outputBcp47Tag;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -43,6 +43,7 @@ import com.box.l10n.mojito.okapi.steps.CheckForDoNotTranslateStep;
 import com.box.l10n.mojito.okapi.steps.FilterEventsToInMemoryRawDocumentStep;
 import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
+import com.box.l10n.mojito.retry.DataIntegrityViolationExceptionRetryTemplate;
 import com.box.l10n.mojito.security.AuditorAwareImpl;
 import com.box.l10n.mojito.service.WordCountService;
 import com.box.l10n.mojito.service.asset.AssetRepository;
@@ -143,6 +144,9 @@ public class TMService {
   @Autowired PullRunService pullRunService;
 
   @Autowired PullRunAssetService pullRunAssetService;
+
+  @Autowired
+  DataIntegrityViolationExceptionRetryTemplate dataIntegrityViolationExceptionRetryTemplate;
 
   @Value("${l10n.tmService.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
   String schedulerName;
@@ -1045,18 +1049,27 @@ public class TMService {
             asset, content, filterConfigIdOverride, filterOptions, translateStep, bcp47Tag);
 
     if (replaceUsedTmTextUnitVariantIds) {
-      replaceUsedTmTextUnitVariantIds(
-          asset,
-          pullRunName,
-          repositoryLocale.getLocale(),
-          translateStep.getUsedTmTextUnitVariantIds());
+      dataIntegrityViolationExceptionRetryTemplate.execute(
+          context -> {
+            replaceUsedTmTextUnitVariantIds(
+                asset,
+                pullRunName,
+                repositoryLocale.getLocale(),
+                translateStep.getUsedTmTextUnitVariantIds(),
+                outputBcp47tag);
+            return null;
+          });
     }
 
     return generateLocalizedBase;
   }
 
   void replaceUsedTmTextUnitVariantIds(
-      Asset asset, String pullRunName, Locale locale, List<Long> usedTmTextUnitVariantIds) {
+      Asset asset,
+      String pullRunName,
+      Locale locale,
+      List<Long> usedTmTextUnitVariantIds,
+      String outputBcp47tag) {
     logger.debug(
         "Replace used TmTextUnitVariantIds for pull run name: {} and locale: {}",
         pullRunName,
@@ -1066,7 +1079,7 @@ public class TMService {
     List<Long> uniqueUsedTmTextUnitVariantIds =
         usedTmTextUnitVariantIds.stream().distinct().collect(Collectors.toList());
     pullRunAssetService.replaceTextUnitVariants(
-        pullRunAsset, locale.getId(), uniqueUsedTmTextUnitVariantIds);
+        pullRunAsset, locale.getId(), uniqueUsedTmTextUnitVariantIds, outputBcp47tag);
   }
 
   /**

--- a/webapp/src/main/resources/db/migration/V65__Alter_pull_run_text_variants.sql
+++ b/webapp/src/main/resources/db/migration/V65__Alter_pull_run_text_variants.sql
@@ -1,0 +1,21 @@
+ALTER TABLE pull_run_text_unit_variant
+DROP FOREIGN KEY FK__PULL_RUN_TEXT_UNIT_VARIANT__PULL_RUN_ASSET_ID;
+
+ALTER TABLE pull_run_text_unit_variant
+DROP FOREIGN KEY FK__PULL_RUN_TEXT_UNIT_VARIANT__TM_TEXT_UNIT_VARIANT_ID;
+
+ALTER TABLE pull_run_text_unit_variant
+DROP FOREIGN KEY FK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE__ID;
+
+ALTER TABLE pull_run_text_unit_variant DROP INDEX UK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE_ID__PRA_ID__TUV_ID;
+
+ALTER TABLE pull_run_text_unit_variant
+    ADD CONSTRAINT FK__PULL_RUN_TEXT_UNIT_VARIANT__PULL_RUN_ASSET_ID FOREIGN KEY (pull_run_asset_id) REFERENCES pull_run_asset (id);
+
+ALTER TABLE pull_run_text_unit_variant
+    ADD CONSTRAINT FK__PULL_RUN_TEXT_UNIT_VARIANT__TM_TEXT_UNIT_VARIANT_ID FOREIGN KEY (tm_text_unit_variant_id) REFERENCES tm_text_unit_variant (id);
+
+ALTER TABLE pull_run_text_unit_variant ADD COLUMN output_bcp47_tag VARCHAR(20);
+
+ALTER TABLE pull_run_text_unit_variant ADD CONSTRAINT UK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE_ID__PRA_ID__TUV_ID__TAG UNIQUE (pull_run_asset_id, locale_id, tm_text_unit_variant_id, output_bcp47_tag);
+alter table pull_run_text_unit_variant add constraint FK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE__ID foreign key (locale_id) references locale (id);

--- a/webapp/src/main/resources/db/migration/V65__Alter_pull_run_text_variants.sql
+++ b/webapp/src/main/resources/db/migration/V65__Alter_pull_run_text_variants.sql
@@ -1,21 +1,3 @@
-ALTER TABLE pull_run_text_unit_variant
-DROP FOREIGN KEY FK__PULL_RUN_TEXT_UNIT_VARIANT__PULL_RUN_ASSET_ID;
-
-ALTER TABLE pull_run_text_unit_variant
-DROP FOREIGN KEY FK__PULL_RUN_TEXT_UNIT_VARIANT__TM_TEXT_UNIT_VARIANT_ID;
-
-ALTER TABLE pull_run_text_unit_variant
-DROP FOREIGN KEY FK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE__ID;
-
-ALTER TABLE pull_run_text_unit_variant DROP INDEX UK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE_ID__PRA_ID__TUV_ID;
-
-ALTER TABLE pull_run_text_unit_variant
-    ADD CONSTRAINT FK__PULL_RUN_TEXT_UNIT_VARIANT__PULL_RUN_ASSET_ID FOREIGN KEY (pull_run_asset_id) REFERENCES pull_run_asset (id);
-
-ALTER TABLE pull_run_text_unit_variant
-    ADD CONSTRAINT FK__PULL_RUN_TEXT_UNIT_VARIANT__TM_TEXT_UNIT_VARIANT_ID FOREIGN KEY (tm_text_unit_variant_id) REFERENCES tm_text_unit_variant (id);
-
 ALTER TABLE pull_run_text_unit_variant ADD COLUMN output_bcp47_tag VARCHAR(20);
-
 ALTER TABLE pull_run_text_unit_variant ADD CONSTRAINT UK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE_ID__PRA_ID__TUV_ID__TAG UNIQUE (pull_run_asset_id, locale_id, tm_text_unit_variant_id, output_bcp47_tag);
-alter table pull_run_text_unit_variant add constraint FK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE__ID foreign key (locale_id) references locale (id);
+ALTER TABLE pull_run_text_unit_variant DROP INDEX UK__PULL_RUN_TEXT_UNIT_VARIANT__LOCALE_ID__PRA_ID__TUV_ID;

--- a/webapp/src/test/java/com/box/l10n/mojito/service/delta/DeltaServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/delta/DeltaServiceTest.java
@@ -647,6 +647,7 @@ public class DeltaServiceTest extends ServiceTestBase {
                 Collectors.mapping(TMTextUnitVariant::getId, Collectors.toList())))
         .forEach(
             (localeId, perLocale) ->
-                pullRunAssetService.replaceTextUnitVariants(pullRunAsset, localeId, perLocale));
+                pullRunAssetService.replaceTextUnitVariants(
+                    pullRunAsset, localeId, perLocale, "test"));
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/delta/PushPullRunCleanupServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/delta/PushPullRunCleanupServiceTest.java
@@ -144,7 +144,7 @@ public class PushPullRunCleanupServiceTest extends ServiceTestBase {
             tmTextUnit1.getId(), frFR.getId(), "le hello_world 2");
 
     pullRunAssetService.replaceTextUnitVariants(
-        pullRunAsset, frFR.getId(), Arrays.asList(tuv1.getId(), tuv2.getId()));
+        pullRunAsset, frFR.getId(), Arrays.asList(tuv1.getId(), tuv2.getId()), "fr-FR");
     List<TMTextUnitVariant> recordedVariants =
         pullRunTextUnitVariantRepository.findByPullRun(pullRun, Pageable.unpaged());
     Assert.assertEquals(2, recordedVariants.size());


### PR DESCRIPTION
Refactors the v65 DB migration script to avoid dropping and recreating the existing foreign keys, also re-introduces the updated pull run handling implementation for avoiding deadlocks when running with `--parallel` enabled.