### PR TITLE
Remove label if only strings removed

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/extractiondiffnotifier/ExtractionDiffNotifierGithub.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/extractiondiffnotifier/ExtractionDiffNotifierGithub.java
@@ -67,6 +67,12 @@ public class ExtractionDiffNotifierGithub implements ExtractionDiffNotifier {
         logger.debug("Set 'translation-required' early to avoid lag in the server setting it");
         updatePRLabel(githubClient, repository, prNumber, TRANSLATIONS_REQUIRED);
       }
+    } else if (extractionDiffStatistics.getRemoved() > 0
+        && githubClient.isLabelAppliedToPR(
+            repository, prNumber, TRANSLATIONS_REQUIRED.toString())) {
+      logger.debug(
+          "Remove 'translations-required' label if it exists since there are no new strings added");
+      githubClient.removeLabelFromPR(repository, prNumber, TRANSLATIONS_REQUIRED.toString());
     }
     return message;
   }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/extractiondiffnotifier/ExtractionDiffNotifierGithubTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/extractiondiffnotifier/ExtractionDiffNotifierGithubTest.java
@@ -108,4 +108,27 @@ public class ExtractionDiffNotifierGithubTest {
     verify(mockGithubClient, times(1))
         .removeLabelFromPR(repository, prNumber, TRANSLATIONS_REQUIRED.toString());
   }
+
+  @Test
+  public void clearTranslationsRequiredLabelIfStringsOnlyRemoved() {
+    GithubClient mockGithubClient = mock(GithubClient.class);
+
+    String repository = "repository";
+    int prNumber = 1;
+    when(mockGithubClient.isLabelAppliedToPR(repository, 1, TRANSLATIONS_REQUIRED.toString()))
+        .thenReturn(true);
+    ExtractionDiffNotifierGithub extractionDiffNotifierGithub =
+        new ExtractionDiffNotifierGithub(
+            new ExtractionDiffNotifierMessageBuilder("{baseMessage}"),
+            mockGithubClient,
+            repository,
+            prNumber);
+
+    final String msg =
+        extractionDiffNotifierGithub.sendDiffStatistics(
+            ExtractionDiffStatistics.builder().removed(1).build());
+
+    verify(mockGithubClient, times(1))
+        .removeLabelFromPR(repository, prNumber, TRANSLATIONS_REQUIRED.toString());
+  }
 }


### PR DESCRIPTION
Removes the `translations-required` label from a PR if the PR only removes strings and the label already exists on the PR.