### PR TITLE
Additional deadlock handling for pull run text unit variants

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/retry/DeadLockLoserExceptionRetryTemplate.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/retry/DeadLockLoserExceptionRetryTemplate.java
@@ -1,0 +1,35 @@
+package com.box.l10n.mojito.retry;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeadLockLoserExceptionRetryTemplate {
+
+  RetryTemplate retryTemplate;
+
+  public DeadLockLoserExceptionRetryTemplate() {
+    SimpleRetryPolicy retryPolicy =
+        new SimpleRetryPolicy(5, ImmutableMap.of(DeadlockLoserDataAccessException.class, true));
+
+    ExponentialRandomBackOffPolicy exponentialRandomBackOffPolicy =
+        new ExponentialRandomBackOffPolicy();
+    exponentialRandomBackOffPolicy.setInitialInterval(10);
+    exponentialRandomBackOffPolicy.setMultiplier(3);
+    exponentialRandomBackOffPolicy.setMaxInterval(5000);
+
+    retryTemplate = new RetryTemplate();
+    retryTemplate.setRetryPolicy(retryPolicy);
+    retryTemplate.setBackOffPolicy(exponentialRandomBackOffPolicy);
+    retryTemplate.setThrowLastExceptionOnExhausted(true);
+  }
+
+  public <T, E extends Throwable> T execute(RetryCallback<T, E> retryCallback) throws E {
+    return retryTemplate.execute(retryCallback);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunAssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunAssetService.java
@@ -84,8 +84,15 @@ public class PullRunAssetService {
   void deleteExistingVariants(PullRunAsset pullRunAsset, Long localeId, String outputBcp47Tag) {
     // Delete and insert steps split into two transactions to avoid deadlocks occurring
 
+    // Lock the rows for deletion
+    jdbcTemplate.queryForList(
+        "SELECT * FROM pull_run_text_unit_variant WHERE pull_run_asset_id = ? AND locale_id = ? AND output_bcp47_tag = ? FOR UPDATE",
+        pullRunAsset.getId(),
+        localeId,
+        outputBcp47Tag);
+    // Delete the rows
     jdbcTemplate.update(
-        "delete from pull_run_text_unit_variant where pull_run_asset_id = ? and locale_id = ? and output_bcp47_tag = ?",
+        "DELETE FROM pull_run_text_unit_variant WHERE pull_run_asset_id = ? AND locale_id = ? AND output_bcp47_tag = ?",
         pullRunAsset.getId(),
         localeId,
         outputBcp47Tag);


### PR DESCRIPTION
Adds a deadlock loser exception retry handler that will retry transactions in the event of failure due to a deadlock.

Also introduced `SELECT...FOR UPDATE` query to lock the rows to be deleted prior to their deletion.