### PR TITLE
Check if deletes required first to avoid sending locking delete requests

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/retry/DeadLockLoserExceptionRetryListener.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/retry/DeadLockLoserExceptionRetryListener.java
@@ -1,0 +1,35 @@
+package com.box.l10n.mojito.retry;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.listener.RetryListenerSupport;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeadLockLoserExceptionRetryListener extends RetryListenerSupport {
+
+  static Logger logger = LoggerFactory.getLogger(DeadLockLoserExceptionRetryListener.class);
+
+  MeterRegistry meterRegistry;
+
+  public DeadLockLoserExceptionRetryListener(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  @Override
+  public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
+    logger.debug("Attempting initial retry");
+    meterRegistry.counter("DeadLockLoserExceptionRetryCounter").increment();
+    return true;
+  }
+
+  @Override
+  public <T, E extends Throwable> void onError(
+      RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+    logger.debug("Retry attempt failed, retrying again");
+    meterRegistry.counter("DeadLockLoserExceptionRetryCounter").increment();
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/retry/DeadLockLoserExceptionRetryTemplate.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/retry/DeadLockLoserExceptionRetryTemplate.java
@@ -13,7 +13,8 @@ public class DeadLockLoserExceptionRetryTemplate {
 
   RetryTemplate retryTemplate;
 
-  public DeadLockLoserExceptionRetryTemplate() {
+  public DeadLockLoserExceptionRetryTemplate(
+      DeadLockLoserExceptionRetryListener deadLockLoserExceptionRetryListener) {
     SimpleRetryPolicy retryPolicy =
         new SimpleRetryPolicy(5, ImmutableMap.of(DeadlockLoserDataAccessException.class, true));
 
@@ -27,6 +28,7 @@ public class DeadLockLoserExceptionRetryTemplate {
     retryTemplate.setRetryPolicy(retryPolicy);
     retryTemplate.setBackOffPolicy(exponentialRandomBackOffPolicy);
     retryTemplate.setThrowLastExceptionOnExhausted(true);
+    retryTemplate.registerListener(deadLockLoserExceptionRetryListener);
   }
 
   public <T, E extends Throwable> T execute(RetryCallback<T, E> retryCallback) throws E {

--- a/webapp/src/main/java/com/box/l10n/mojito/retry/DeadLockLoserExceptionRetryTemplate.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/retry/DeadLockLoserExceptionRetryTemplate.java
@@ -1,0 +1,35 @@
+package com.box.l10n.mojito.retry;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeadLockLoserExceptionRetryTemplate {
+
+  RetryTemplate retryTemplate;
+
+  public DeadLockLoserExceptionRetryTemplate() {
+    SimpleRetryPolicy retryPolicy =
+        new SimpleRetryPolicy(5, ImmutableMap.of(DeadlockLoserDataAccessException.class, true));
+
+    ExponentialRandomBackOffPolicy exponentialRandomBackOffPolicy =
+        new ExponentialRandomBackOffPolicy();
+    exponentialRandomBackOffPolicy.setInitialInterval(10);
+    exponentialRandomBackOffPolicy.setMultiplier(3);
+    exponentialRandomBackOffPolicy.setMaxInterval(5000);
+
+    retryTemplate = new RetryTemplate();
+    retryTemplate.setRetryPolicy(retryPolicy);
+    retryTemplate.setBackOffPolicy(exponentialRandomBackOffPolicy);
+    retryTemplate.setThrowLastExceptionOnExhausted(true);
+  }
+
+  public <T, E extends Throwable> T execute(RetryCallback<T, E> retryCallback) throws E {
+    return retryTemplate.execute(retryCallback);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunAssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunAssetService.java
@@ -84,8 +84,15 @@ public class PullRunAssetService {
   void deleteExistingVariants(PullRunAsset pullRunAsset, Long localeId, String outputBcp47Tag) {
     // Delete and insert steps split into two transactions to avoid deadlocks occurring
 
+    // Lock the rows for deletion
+    jdbcTemplate.queryForList(
+        "SELECT * FROM pull_run_text_unit_variant WHERE pull_run_asset_id = ? AND locale_id = ? AND output_bcp47_tag = ? FOR UPDATE",
+        pullRunAsset.getId(),
+        localeId,
+        outputBcp47Tag);
+    // Delete the rows
     jdbcTemplate.update(
-        "delete from pull_run_text_unit_variant where pull_run_asset_id = ? and locale_id = ? and output_bcp47_tag = ?",
+        "DELETE FROM pull_run_text_unit_variant WHERE pull_run_asset_id = ? AND locale_id = ? AND output_bcp47_tag = ?",
         pullRunAsset.getId(),
         localeId,
         outputBcp47Tag);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunTextUnitVariantRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunTextUnitVariantRepository.java
@@ -24,6 +24,9 @@ public interface PullRunTextUnitVariantRepository
   List<PullRunTextUnitVariant> findByTmTextUnitVariant_TmTextUnitIdAndLocaleId(
       Long tmTextUnitId, Long localeId);
 
+  List<PullRunTextUnitVariant> findByPullRunAssetIdAndLocaleIdAndOutputBcp47Tag(
+      Long pullRunAssetId, Long localeId, String outputBcp47Tag);
+
   @Query(
       "select prtuv.tmTextUnitVariant from PullRunTextUnitVariant prtuv "
           + "inner join prtuv.pullRunAsset pra "

--- a/webapp/src/test/java/com/box/l10n/mojito/service/delta/DeltaServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/delta/DeltaServiceTest.java
@@ -14,7 +14,6 @@ import com.box.l10n.mojito.entity.RepositoryLocale;
 import com.box.l10n.mojito.entity.TM;
 import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
-import com.box.l10n.mojito.retry.DeadLockLoserExceptionRetryListener;
 import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
@@ -88,8 +87,6 @@ public class DeltaServiceTest extends ServiceTestBase {
   @Autowired AssetExtractionService assetExtractionService;
 
   @Autowired AssetTextUnitToTMTextUnitRepository assetTextUnitToTMTextUnitRepository;
-
-  @Autowired DeadLockLoserExceptionRetryListener deadLockLoserExceptionRetryListener;
 
   @Test
   public void testGetDeltasFromDateWorks() {

--- a/webapp/src/test/java/com/box/l10n/mojito/service/delta/DeltaServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/delta/DeltaServiceTest.java
@@ -14,6 +14,7 @@ import com.box.l10n.mojito.entity.RepositoryLocale;
 import com.box.l10n.mojito.entity.TM;
 import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
+import com.box.l10n.mojito.retry.DeadLockLoserExceptionRetryListener;
 import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
@@ -87,6 +88,8 @@ public class DeltaServiceTest extends ServiceTestBase {
   @Autowired AssetExtractionService assetExtractionService;
 
   @Autowired AssetTextUnitToTMTextUnitRepository assetTextUnitToTMTextUnitRepository;
+
+  @Autowired DeadLockLoserExceptionRetryListener deadLockLoserExceptionRetryListener;
 
   @Test
   public void testGetDeltasFromDateWorks() {


### PR DESCRIPTION
Alternative approach to #75, in this case we check if there are any entities to be deleted before sending the delete requests that will require gap locks to be available. If no entities then don't send the delete, if entities do exist delete in batches of 1000.

Deadlock retry logic will catch any deadlocks that do occur and retry the transaction.