### PR TITLE
Use Java Text Block for SQL queries

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionRepository.java
@@ -17,12 +17,14 @@ public interface AssetExtractionRepository extends JpaRepository<AssetExtraction
   List<AssetExtraction> findByAsset(Asset asset);
 
   @Query(
-      "select ae.id from #{#entityName} ae "
-          + "inner join ae.asset a "
-          + "inner join ae.pollableTask pt "
-          + "left outer join ae.assetExtractionByBranches aea "
-          + "where aea.id is null "
-          + "and  ae != a.lastSuccessfulAssetExtraction "
-          + "and pt.finishedDate is not null")
+      """
+      select ae.id from #{#entityName} ae
+      inner join ae.asset a
+      inner join ae.pollableTask pt
+      left outer join ae.assetExtractionByBranches aea
+      where aea.id is null
+        and ae != a.lastSuccessfulAssetExtraction
+        and pt.finishedDate is not null
+        """)
   List<Long> findFinishedAndOldAssetExtractions(Pageable pageable);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetTextUnitToTMTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetTextUnitToTMTextUnitRepository.java
@@ -25,34 +25,44 @@ public interface AssetTextUnitToTMTextUnitRepository
   void deleteByAssetTextUnitIdIn(List<Long> assetTextUnitIds);
 
   @Query(
-      "select atuttu.tmTextUnit.id from AssetTextUnitToTMTextUnit atuttu "
-          + "inner join atuttu.assetExtraction ae "
-          + "inner join ae.assetExtractionByBranches aec "
-          + "where aec.branch = ?1")
+      """
+      select atuttu.tmTextUnit.id from AssetTextUnitToTMTextUnit atuttu
+      inner join atuttu.assetExtraction ae
+      inner join ae.assetExtractionByBranches aec
+      where aec.branch = ?1
+      """)
   List<Long> findByBranch(Branch branch);
 
   @Query(
-      "select atuttu.tmTextUnit.id from AssetTextUnitToTMTextUnit atuttu "
-          + "inner join atuttu.assetExtraction ae "
-          + "inner join ae.assetExtractionByBranches aec "
-          + "where aec.branch.name = ?1")
+      """
+      select atuttu.tmTextUnit.id from AssetTextUnitToTMTextUnit atuttu
+      inner join atuttu.assetExtraction ae
+      inner join ae.assetExtractionByBranches aec
+      where aec.branch.name = ?1
+      """)
   List<Long> findByBranchName(String branchName);
 
   @Query(
-      "select atuttu.tmTextUnit.id "
-          + "from AssetTextUnitToTMTextUnit atuttu "
-          + "where atuttu.assetExtraction.id = ?1")
+      """
+      select atuttu.tmTextUnit.id
+      from AssetTextUnitToTMTextUnit atuttu
+      where atuttu.assetExtraction.id = ?1
+      """)
   Set<Long> findTmTextUnitIdsByAssetExtractionId(Long assetExtractionId);
 
   @Query(
-      "select atuttu.tmTextUnit.id "
-          + "from AssetTextUnitToTMTextUnit atuttu "
-          + "where atuttu.assetExtraction.id = ?1 and atuttu.assetTextUnit.doNotTranslate = true")
+      """
+      select atuttu.tmTextUnit.id
+      from AssetTextUnitToTMTextUnit atuttu
+      where atuttu.assetExtraction.id = ?1 and atuttu.assetTextUnit.doNotTranslate = true
+      """)
   Set<Long> getTmTextUnitIdsOfDoNotTranslateUnitsByAssetExtractionId(Long assetExtractionId);
 
   @Query(
-      "select atuttu.tmTextUnit.id "
-          + "from AssetTextUnitToTMTextUnit atuttu "
-          + "where atuttu.assetExtraction.id = ?1 and atuttu.assetTextUnit.id = ?2")
+      """
+      select atuttu.tmTextUnit.id
+      from AssetTextUnitToTMTextUnit atuttu
+      where atuttu.assetExtraction.id = ?1 and atuttu.assetTextUnit.id = ?2
+      """)
   Optional<Long> findTmTextUnitId(long assetExtractionId, long assetTextUnitId);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetTextUnit/AssetTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetTextUnit/AssetTextUnitRepository.java
@@ -21,7 +21,11 @@ public interface AssetTextUnitRepository
   List<AssetTextUnit> findByAssetExtractionId(long assetExtractionId);
 
   @Query(
-      "select new com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitIdToMd5(atu.id, atu.md5) from #{#entityName} atu where atu.assetExtraction = ?1")
+      """
+      select new com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitIdToMd5(atu.id, atu.md5)
+      from #{#entityName} atu
+      where atu.assetExtraction = ?1
+      """)
   List<AssetTextUnitIdToMd5> findMd5ByAssetExtraction(AssetExtraction assetExtraction);
 
   /**
@@ -43,8 +47,12 @@ public interface AssetTextUnitRepository
   @Query(
       nativeQuery = true,
       value =
-          "select atu.* from asset_text_unit atu left join asset_text_unit_to_tm_text_unit map on map.asset_text_unit_id = atu.id "
-              + "where map.asset_text_unit_id is NULL and atu.asset_extraction_id = ?1")
+          """
+          select atu.*
+          from asset_text_unit atu
+          left join asset_text_unit_to_tm_text_unit map on map.asset_text_unit_id = atu.id
+          where map.asset_text_unit_id is NULL and atu.asset_extraction_id = ?1
+          """)
   List<AssetTextUnit> getUnmappedAssetTextUnits(Long assetExtractionId);
 
   @Transactional

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/database/MBlobRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/database/MBlobRepository.java
@@ -29,8 +29,10 @@ public interface MBlobRepository
    * <p>This does not show if test are running in UTC like on CI
    */
   @Query(
-      "select mb.id from #{#entityName} mb "
-          + "where (unix_timestamp(mb.createdDate) + mb.expireAfterSeconds) < unix_timestamp(:now)")
+      """
+      select mb.id from #{#entityName} mb
+      where (unix_timestamp(mb.createdDate) + mb.expireAfterSeconds) < unix_timestamp(:now)
+      """)
   List<Long> findExpiredBlobIdsWithNow(@Param("now") ZonedDateTime now, Pageable pageable);
 
   @Transactional

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticRepository.java
@@ -23,7 +23,12 @@ public interface BranchStatisticRepository
   @EntityGraph(
       value = "BranchStatisticGraphWithoutTextUnits",
       type = EntityGraph.EntityGraphType.LOAD)
-  @Query("select bs " + "from BranchStatistic bs " + "where bs.id in ?1 and bs.totalCount > ?2")
+  @Query(
+      """
+      select bs
+      from BranchStatistic bs
+      where bs.id in ?1 and bs.totalCount > ?2
+      """)
   List<BranchStatistic> findAllGreaterThanById(List<Long> branchStatisticIds, Long totalCountLte);
 
   BranchStatistic findByBranch(Branch branch);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchTextUnitStatisticRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchTextUnitStatisticRepository.java
@@ -19,19 +19,31 @@ public interface BranchTextUnitStatisticRepository
 
   BranchTextUnitStatistic getByBranchStatisticIdAndTmTextUnitId(long id, long tmTextUnitId);
 
-  @Query("select btus.tmTextUnit.id from #{#entityName} btus where btus.branchStatistic.id = ?1")
+  @Query(
+      """
+      select btus.tmTextUnit.id
+      from #{#entityName} btus
+      where btus.branchStatistic.id = ?1
+      """)
   List<Long> findTmTextUnitIds(long branchStatisticId);
 
   @Query(
-      "select count(btus.tmTextUnit.id) from #{#entityName} btus where btus.branchStatistic.branch.id = ?1")
+      """
+      select count(btus.tmTextUnit.id)
+      from #{#entityName} btus
+      where btus.branchStatistic.branch.id = ?1
+      """)
   long countTmTextUnitIds(long branchId);
 
   @Transactional
   int deleteByBranchStatisticBranchIdAndTmTextUnitIdIn(long branchId, Set<Long> ids);
 
   @Query(
-      "select new com.box.l10n.mojito.service.branch.BranchTextUnitStatisticWithCounts(btus.id, btus.branchStatistic.id, btus.tmTextUnit.id, btus.forTranslationCount, btus.totalCount) "
-          + "from #{#entityName} btus where btus.branchStatistic.id = ?1 and btus.tmTextUnit.id in ?2")
+      """
+      select new com.box.l10n.mojito.service.branch.BranchTextUnitStatisticWithCounts(btus.id, btus.branchStatistic.id, btus.tmTextUnit.id, btus.forTranslationCount, btus.totalCount)
+      from #{#entityName} btus
+      where btus.branchStatistic.id = ?1 and btus.tmTextUnit.id in ?2
+      """)
   List<BranchTextUnitStatisticWithCounts> getByBranchStatisticIdAndTmTextUnitIdIn(
       long branchStatisticId, List<Long> tmTextUnitIds);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheRepository.java
@@ -17,9 +17,11 @@ public interface ApplicationCacheRepository extends JpaRepository<ApplicationCac
 
   @Query(
       value =
-          "select ac from ApplicationCache ac "
-              + "where ac.applicationCacheType = :applicationCacheType and ac.keyMD5 = :keyMD5 "
-              + "and (ac.expiryDate is null or ac.expiryDate > CURRENT_TIMESTAMP)")
+          """
+          select ac from ApplicationCache ac
+          where ac.applicationCacheType = :applicationCacheType and ac.keyMD5 = :keyMD5
+          and (ac.expiryDate is null or ac.expiryDate > CURRENT_TIMESTAMP)
+          """)
   Optional<ApplicationCache> findByIdAndNotExpired(
       @Param("applicationCacheType") ApplicationCacheType applicationCacheType,
       @Param("keyMD5") String keyMD5);
@@ -34,7 +36,11 @@ public interface ApplicationCacheRepository extends JpaRepository<ApplicationCac
 
   @Modifying
   @Query(
-      value = "delete from ApplicationCache ac " + "where ac.applicationCacheType.id = :cacheId ")
+      value =
+          """
+          delete from ApplicationCache ac
+          where ac.applicationCacheType.id = :cacheId
+          """)
   void clearCache(@Param("cacheId") short cacheId);
 
   @Modifying

--- a/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitRepository.java
@@ -20,9 +20,11 @@ public interface CommitRepository
 
   @Query(
       value =
-          "select c from Commit c "
-              + "where c.name in :commitNames and c.repository.id = :repositoryId "
-              + "and c.commitToPushRun.pushRun.repository.id = :repositoryId order by c.commitToPushRun.createdDate desc ")
+          """
+          select c from Commit c
+          where c.name in :commitNames and c.repository.id = :repositoryId
+          and c.commitToPushRun.pushRun.repository.id = :repositoryId order by c.commitToPushRun.createdDate desc
+          """)
   List<Commit> findLatestPushedCommits(
       @Param("commitNames") List<String> commitNames,
       @Param("repositoryId") Long repositoryId,
@@ -30,9 +32,11 @@ public interface CommitRepository
 
   @Query(
       value =
-          "select c from Commit c "
-              + "where c.name in :commitNames and c.repository.id = :repositoryId "
-              + "and c.commitToPullRun.pullRun.repository.id = :repositoryId order by c.commitToPullRun.createdDate desc ")
+          """
+          select c from Commit c
+          where c.name in :commitNames and c.repository.id = :repositoryId
+          and c.commitToPullRun.pullRun.repository.id = :repositoryId order by c.commitToPullRun.createdDate desc
+          """)
   List<Commit> findLatestPulledCommits(
       @Param("commitNames") List<String> commitNames,
       @Param("repositoryId") Long repositoryId,

--- a/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitToPullRunRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitToPullRunRepository.java
@@ -22,9 +22,11 @@ public interface CommitToPullRunRepository extends JpaRepository<CommitToPullRun
   @Query(
       nativeQuery = true,
       value =
-          "delete ctpr "
-              + "from pull_run pr "
-              + "join commit_to_pull_run ctpr on ctpr.pull_run_id = pr.id "
-              + "where pr.created_date < :beforeDate ")
+          """
+          delete ctpr
+          from pull_run pr
+          join commit_to_pull_run ctpr on ctpr.pull_run_id = pr.id
+          where pr.created_date < :beforeDate
+          """)
   void deleteAllByPullRunWithCreatedDateBefore(@Param("beforeDate") ZonedDateTime beforeDate);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitToPushRunRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitToPushRunRepository.java
@@ -22,9 +22,11 @@ public interface CommitToPushRunRepository extends JpaRepository<CommitToPushRun
   @Query(
       nativeQuery = true,
       value =
-          "delete ctpr "
-              + "from push_run pr "
-              + "join commit_to_push_run ctpr on ctpr.push_run_id = pr.id "
-              + "where pr.created_date < :beforeDate ")
+          """
+          delete ctpr
+          from push_run pr
+          join commit_to_push_run ctpr on ctpr.push_run_id = pr.id
+          where pr.created_date < :beforeDate
+          """)
   void deleteAllByPushRunWithCreatedDateBefore(@Param("beforeDate") ZonedDateTime beforeDate);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskRepository.java
@@ -25,8 +25,10 @@ public interface PollableTaskRepository extends JpaRepository<PollableTask, Long
    * <p>This does not show if test are running in UTC like on CI
    */
   @Query(
-      "select pt from #{#entityName} pt "
-          + "where pt.finishedDate is null "
-          + "and (unix_timestamp(pt.createdDate) + pt.timeout) < unix_timestamp(:now)")
+      """
+      select pt from #{#entityName} pt
+      where pt.finishedDate is null
+      and (unix_timestamp(pt.createdDate) + pt.timeout) < unix_timestamp(:now)
+      """)
   List<PollableTask> findZombiePollableTasks(@Param("now") ZonedDateTime now, Pageable pageable);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunAssetRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunAssetRepository.java
@@ -30,9 +30,11 @@ public interface PullRunAssetRepository extends JpaRepository<PullRunAsset, Long
   @Query(
       nativeQuery = true,
       value =
-          "delete pra "
-              + "from pull_run pr "
-              + "join pull_run_asset pra on pra.pull_run_id = pr.id "
-              + "where pr.created_date < :beforeDate ")
+          """
+          delete pra
+          from pull_run pr
+          join pull_run_asset pra on pra.pull_run_id = pr.id
+          where pr.created_date < :beforeDate
+          """)
   void deleteAllByPullRunWithCreatedDateBefore(@Param("beforeDate") ZonedDateTime beforeDate);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunRepository.java
@@ -21,11 +21,13 @@ public interface PullRunRepository extends JpaRepository<PullRun, Long> {
 
   @Query(
       value =
-          "select p from PullRun p "
-              + "left join CommitToPullRun cpr on cpr.pullRun = p "
-              + "left join Commit c on c = cpr.commit "
-              + "where c.name in :commitNames and c.repository.id = :repositoryId "
-              + "and p.repository.id = :repositoryId order by p.createdDate desc ")
+          """
+          select p from PullRun p
+          left join CommitToPullRun cpr on cpr.pullRun = p
+          left join Commit c on c = cpr.commit
+          where c.name in :commitNames and c.repository.id = :repositoryId
+          and p.repository.id = :repositoryId order by p.createdDate desc
+          """)
   List<PullRun> findLatestByCommitNames(
       @Param("commitNames") List<String> commitNames,
       @Param("repositoryId") Long repositoryId,
@@ -36,17 +38,24 @@ public interface PullRunRepository extends JpaRepository<PullRun, Long> {
   @Query(
       nativeQuery = true,
       value =
-          "delete pr, pra, prattu"
-              + "from pull_run pr "
-              + "join pull_run_asset pra on pra.pull_run_id = pr.id "
-              + "join pull_run_text_unit_variant prtuv on prtuv.pull_run_asset_id = pra.id "
-              + "where DATE_ADD(pr.created_date, INTERVAL :retentionDurationInSeconds second) < NOW() ")
+          """
+          delete pr, pra, prattu
+          from pull_run pr
+          join pull_run_asset pra on pra.pull_run_id = pr.id
+          join pull_run_text_unit_variant prtuv on prtuv.pull_run_asset_id = pra.id
+          where DATE_ADD(pr.created_date, INTERVAL :retentionDurationInSeconds second) < NOW()
+          """)
   void deleteOlderThan(@Param("retentionDurationInSeconds") long retentionDurationInSeconds);
 
   @Transactional
   @Modifying
   @Query(
       nativeQuery = true,
-      value = "delete pr " + "from pull_run pr " + "where pr.created_date < :beforeDate ")
+      value =
+          """
+          delete pr
+          from pull_run pr
+          where pr.created_date < :beforeDate
+          """)
   void deleteAllByCreatedDateBefore(@Param("beforeDate") ZonedDateTime beforeDate);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunTextUnitVariantRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunTextUnitVariantRepository.java
@@ -30,9 +30,11 @@ public interface PullRunTextUnitVariantRepository
       Long pullRunAssetId, Long localeId, String outputBcp47Tag);
 
   @Query(
-      "select prtuv.tmTextUnitVariant from PullRunTextUnitVariant prtuv "
-          + "inner join prtuv.pullRunAsset pra "
-          + "inner join pra.pullRun pr where pr = :pullRun")
+      """
+      select prtuv.tmTextUnitVariant from PullRunTextUnitVariant prtuv
+      inner join prtuv.pullRunAsset pra
+      inner join pra.pullRun pr where pr = :pullRun
+      """)
   List<TMTextUnitVariant> findByPullRun(@Param("pullRun") PullRun pullRun, Pageable pageable);
 
   @Transactional
@@ -43,15 +45,17 @@ public interface PullRunTextUnitVariantRepository
   @Query(
       nativeQuery = true,
       value =
-          "delete pull_run_text_unit_variant "
-              + "from pull_run_text_unit_variant "
-              + "join (select prtuv.id as id "
-              + "  from pull_run pr "
-              + "  join pull_run_asset pra on pra.pull_run_id = pr.id "
-              + "  join pull_run_text_unit_variant prtuv on prtuv.pull_run_asset_id = pra.id "
-              + "  where pr.created_date < :beforeDate "
-              + "  limit :batchSize "
-              + ") todelete on todelete.id = pull_run_text_unit_variant.id")
+          """
+          delete pull_run_text_unit_variant
+          from pull_run_text_unit_variant
+          join (select prtuv.id as id
+            from pull_run pr
+            join pull_run_asset pra on pra.pull_run_id = pr.id
+            join pull_run_text_unit_variant prtuv on prtuv.pull_run_asset_id = pra.id
+            where pr.created_date < :beforeDate
+            limit :batchSize
+          ) todelete on todelete.id = pull_run_text_unit_variant.id
+          """)
   int deleteAllByPullRunWithCreatedDateBefore(
       @Param("beforeDate") ZonedDateTime beforeDate, @Param("batchSize") int batchSize);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunAssetRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunAssetRepository.java
@@ -30,9 +30,11 @@ public interface PushRunAssetRepository extends JpaRepository<PushRunAsset, Long
   @Query(
       nativeQuery = true,
       value =
-          "delete pra "
-              + "from push_run pr "
-              + "join push_run_asset pra on pra.push_run_id = pr.id "
-              + "where pr.created_date < :beforeDate ")
+          """
+          delete pra
+          from push_run pr
+          join push_run_asset pra on pra.push_run_id = pr.id
+          where pr.created_date < :beforeDate
+          """)
   void deleteAllByPushRunWithCreatedDateBefore(@Param("beforeDate") ZonedDateTime beforeDate);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunAssetTmTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunAssetTmTextUnitRepository.java
@@ -27,9 +27,11 @@ public interface PushRunAssetTmTextUnitRepository
   List<PushRunAssetTmTextUnit> findByPushRunAsset(PushRunAsset pushRunAsset, Pageable pageable);
 
   @Query(
-      "select prattu.tmTextUnit from PushRunAssetTmTextUnit prattu "
-          + "inner join prattu.pushRunAsset pra "
-          + "inner join pra.pushRun pr where pr = :pushRun")
+      """
+      select prattu.tmTextUnit from PushRunAssetTmTextUnit prattu
+      inner join prattu.pushRunAsset pra
+      inner join pra.pushRun pr where pr = :pushRun
+      """)
   List<TMTextUnit> findByPushRun(@Param("pushRun") PushRun pushRun, Pageable pageable);
 
   @Transactional
@@ -37,15 +39,17 @@ public interface PushRunAssetTmTextUnitRepository
   @Query(
       nativeQuery = true,
       value =
-          "delete push_run_asset_tm_text_unit "
-              + "from push_run_asset_tm_text_unit "
-              + "join (select prattu.id as id "
-              + "  from push_run pr "
-              + "  join push_run_asset pra on pra.push_run_id = pr.id "
-              + "  join push_run_asset_tm_text_unit prattu on prattu.push_run_asset_id = pra.id "
-              + "  where pr.created_date < :beforeDate "
-              + "  limit :batchSize "
-              + ") todelete on todelete.id = push_run_asset_tm_text_unit.id")
+          """
+          delete push_run_asset_tm_text_unit
+          from push_run_asset_tm_text_unit
+            join (select prattu.id as id
+              from push_run pr
+                join push_run_asset pra on pra.push_run_id = pr.id
+                join push_run_asset_tm_text_unit prattu on prattu.push_run_asset_id = pra.id
+              where pr.created_date < :beforeDate
+              limit :batchSize
+            ) todelete on todelete.id = push_run_asset_tm_text_unit.id
+          """)
   int deleteAllByPushRunWithCreatedDateBefore(
       @Param("beforeDate") ZonedDateTime beforeDate, @Param("batchSize") int batchSize);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunRepository.java
@@ -22,11 +22,13 @@ public interface PushRunRepository extends JpaRepository<PushRun, Long> {
 
   @Query(
       value =
-          "select p from PushRun p "
-              + "join CommitToPushRun cpr on cpr.pushRun = p "
-              + "join Commit c on c = cpr.commit "
-              + "where c.name in :commitNames and c.repository.id = :repositoryId "
-              + "and p.repository.id = :repositoryId order by p.createdDate desc ")
+          """
+          select p from PushRun p
+          join CommitToPushRun cpr on cpr.pushRun = p
+          join Commit c on c = cpr.commit
+          where c.name in :commitNames and c.repository.id = :repositoryId
+          and p.repository.id = :repositoryId order by p.createdDate desc
+          """)
   List<PushRun> findLatestByCommitNames(
       @Param("commitNames") List<String> commitNames,
       @Param("repositoryId") Long repositoryId,
@@ -36,6 +38,11 @@ public interface PushRunRepository extends JpaRepository<PushRun, Long> {
   @Modifying
   @Query(
       nativeQuery = true,
-      value = "delete pr " + "from push_run pr " + "where pr.created_date < :beforeDate ")
+      value =
+          """
+          delete pr
+          from push_run pr
+          where pr.created_date < :beforeDate
+          """)
   void deleteAllByCreatedDateBefore(@Param("beforeDate") ZonedDateTime beforeDate);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/screenshot/ScreenshotRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/screenshot/ScreenshotRepository.java
@@ -22,11 +22,13 @@ public interface ScreenshotRepository
 
   @Query(
       value =
-          "select s from #{#entityName} s "
-              + "inner join s.screenshotRun sr "
-              + "inner join sr.repository r "
-              + "left join  s.thirdPartyScreenshots tps "
-              + "where r = ?1 and r.manualScreenshotRun = sr and tps is null")
+          """
+          select s from #{#entityName} s
+          inner join s.screenshotRun sr
+          inner join sr.repository r
+          left join  s.thirdPartyScreenshots tps
+          where r = ?1 and r.manualScreenshotRun = sr and tps is null
+          """)
   List<Screenshot> findUnmappedScreenshots(Repository repository);
 
   void deleteById(Long screenshotId);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitCurrentVariantRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitCurrentVariantRepository.java
@@ -20,7 +20,10 @@ public interface TMTextUnitCurrentVariantRepository
   List<TMTextUnitCurrentVariant> findByTmTextUnit_Tm_IdAndLocale_Id(Long tmId, Long localeId);
 
   @Query(
-      "select new com.box.l10n.mojito.service.tm.TMTextUnitCurrentVariantDTO(ttucv.tmTextUnit.id, ttucv.tmTextUnitVariant.id) "
-          + "from #{#entityName} ttucv where ttucv.asset.id = ?1 and ttucv.locale.id = ?2")
+      """
+      select new com.box.l10n.mojito.service.tm.TMTextUnitCurrentVariantDTO(ttucv.tmTextUnit.id, ttucv.tmTextUnitVariant.id)
+      from #{#entityName} ttucv
+      where ttucv.asset.id = ?1 and ttucv.locale.id = ?2
+      """)
   List<TMTextUnitCurrentVariantDTO> findByAsset_idAndLocale_Id(Long assetId, Long localeId);
 }


### PR DESCRIPTION
We can now use Java Text Block since the migration to Java 17. Migrate SQL queries to using it for better readability