### PR TITLE
Skip pending pollable task if rescheduling occurs for same id

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
@@ -160,6 +160,7 @@ public class QuartzPollableTaskScheduler {
             && dbUtils.isQuartzMysql()
             && quartzJobInfo.getUniqueId() != null
             && jobOutputType.equals(Void.class)) {
+          // Only done for jobs with Void output as a skipped job will have no output
           skipPendingPollablesWithMatchingId(scheduler, jobKey, trigger, pollableTask);
         }
         scheduler.rescheduleJob(triggerKey, trigger);

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
@@ -9,6 +9,7 @@ import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.pollableTask.PollableTaskBlobStorage;
 import com.box.l10n.mojito.service.pollableTask.PollableTaskService;
 import com.ibm.icu.text.MessageFormat;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,6 +39,8 @@ public class QuartzPollableTaskScheduler {
   @Autowired PollableTaskBlobStorage pollableTaskBlobStorage;
 
   @Autowired ObjectMapper objectMapper;
+
+  @Autowired MeterRegistry meterRegistry;
 
   @Autowired DBUtils dbUtils;
 
@@ -198,6 +201,7 @@ public class QuartzPollableTaskScheduler {
                   + pollableTask.getId(),
               null,
               pendingPollable.getExpectedSubTaskNumber());
+          meterRegistry.counter("QuartzPollableTaskScheduler.skippedJobs").increment();
         }
       }
     } catch (SchedulerException e) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/DBUtils.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/DBUtils.java
@@ -9,11 +9,18 @@ public class DBUtils {
   @Value("${spring.datasource.url}")
   String url;
 
+  @Value("${l10n.org.quartz.dataSource.myDS.driver:RAMJobStore}")
+  String quartzDatasourceDriver;
+
   public boolean isMysql() {
     return url.contains("mysql");
   }
 
   public boolean isHsql() {
     return url.contains("hsqldb");
+  }
+
+  public boolean isQuartzMysql() {
+    return quartzDatasourceDriver.contains("mysql");
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskBlobStorage.java
@@ -50,13 +50,8 @@ public class PollableTaskBlobStorage {
     String outputJson =
         structuredBlobStorage
             .getString(POLLABLE_TASK, outputName)
-            .orElseGet(
-                () -> {
-                  logger.warn(
-                      "Can't get the output json for pollable id {}, assuming task has been skipped, returning empty object.",
-                      pollableTaskId);
-                  return "{}";
-                });
+            .orElseThrow(
+                () -> new RuntimeException("Can't get the output json for: " + pollableTaskId));
     return outputJson;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskBlobStorage.java
@@ -5,12 +5,16 @@ import static com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage.Pref
 import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.service.blobstorage.Retention;
 import com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PollableTaskBlobStorage {
+
+  static Logger logger = LoggerFactory.getLogger(PollableTaskBlobStorage.class);
 
   @Autowired StructuredBlobStorage structuredBlobStorage;
 
@@ -46,8 +50,13 @@ public class PollableTaskBlobStorage {
     String outputJson =
         structuredBlobStorage
             .getString(POLLABLE_TASK, outputName)
-            .orElseThrow(
-                () -> new RuntimeException("Can't get the output json for: " + pollableTaskId));
+            .orElseGet(
+                () -> {
+                  logger.warn(
+                      "Can't get the output json for pollable id {}, assuming task has been skipped, returning empty object.",
+                      pollableTaskId);
+                  return "{}";
+                });
     return outputJson;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/PollableTaskBlobStorage.java
@@ -5,16 +5,12 @@ import static com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage.Pref
 import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.service.blobstorage.Retention;
 import com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PollableTaskBlobStorage {
-
-  static Logger logger = LoggerFactory.getLogger(PollableTaskBlobStorage.class);
 
   @Autowired StructuredBlobStorage structuredBlobStorage;
 

--- a/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableTaskSchedulerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableTaskSchedulerTest.java
@@ -3,8 +3,6 @@ package com.box.l10n.mojito.quartz;
 import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.box.l10n.mojito.service.DBUtils;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
@@ -46,13 +44,8 @@ public class QuartzPollableTaskSchedulerTest extends ServiceTestBase {
             VoidQuartzPollableJob.class, 10L, DEFAULT_SCHEDULER_NAME);
     Void aVoid = pollableFuture.get();
     assertEquals(null, aVoid);
-    try {
-      Object output =
-          pollableTaskBlobStorage.getOutputJson(pollableFuture.getPollableTask().getId());
-      fail();
-    } catch (RuntimeException re) {
-      assertTrue(re.getMessage().startsWith("Can't get the output json for:"));
-    }
+    assertEquals(
+        "{}", pollableTaskBlobStorage.getOutputJson(pollableFuture.getPollableTask().getId()));
   }
 
   @Test

--- a/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableTaskSchedulerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableTaskSchedulerTest.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.quartz;
 
 import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -72,11 +73,12 @@ public class QuartzPollableTaskSchedulerTest extends ServiceTestBase {
   }
 
   @Test
-  public void testRescheduleNonConcurrentJobs() throws ExecutionException, InterruptedException {
+  public void testRescheduleJobsWithUniqueIdAndVoidOutput()
+      throws ExecutionException, InterruptedException {
     /**
-     * This test verifies that in the event of a rescheduling of a job that disallows concurrent
-     * execution, the pollable task associated with the Quartz Trigger in a BLOCKED state is
-     * returned for multiple calls to scheduleJob with the same uniqueId set.
+     * This test verifies that in the event of a rescheduling of a job that has void output, the
+     * pollable task associated with the Quartz Trigger in a BLOCKED state is marked as finished
+     * with a message stating it has been skipped.
      *
      * <p>This ensures that no more than 2 pollable tasks (the executing tasks and the task waiting
      * to execute) are present at the same time for the same uniqueId.
@@ -90,11 +92,11 @@ public class QuartzPollableTaskSchedulerTest extends ServiceTestBase {
      */
     Assume.assumeTrue(dbUtils.isQuartzMysql());
     QuartzJobInfo<Long, Void> quartzJobInfo =
-        QuartzJobInfo.newBuilder(AQuartzPollableJob3.class).withUniqueId("test1").build();
+        QuartzJobInfo.newBuilder(AQuartzPollableJobVoidOutput.class).withUniqueId("test1").build();
     QuartzJobInfo<Long, Void> quartzJobInfo2 =
-        QuartzJobInfo.newBuilder(AQuartzPollableJob3.class).withUniqueId("test1").build();
+        QuartzJobInfo.newBuilder(AQuartzPollableJobVoidOutput.class).withUniqueId("test1").build();
     QuartzJobInfo<Long, Void> quartzJobInfo3 =
-        QuartzJobInfo.newBuilder(AQuartzPollableJob3.class).withUniqueId("test1").build();
+        QuartzJobInfo.newBuilder(AQuartzPollableJobVoidOutput.class).withUniqueId("test1").build();
     quartzPollableTaskScheduler.cleanupOnUniqueIdReschedule = true;
     PollableFuture<Void> pollableFuture = quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
     PollableFuture<Void> pollableFuture2 = quartzPollableTaskScheduler.scheduleJob(quartzJobInfo2);
@@ -111,18 +113,68 @@ public class QuartzPollableTaskSchedulerTest extends ServiceTestBase {
 
     pollableTask = pollableTaskRepository.findById(pollableFuture2.getPollableTask().getId()).get();
     assertTrue(pollableTask.isAllFinished());
-    assertEquals(
-        "Job skipped as new job re-scheduled with the same unique id, tracked by pollable task id: 3",
-        pollableTask.getMessage());
+    assertTrue(
+        pollableTask
+            .getMessage()
+            .contains(
+                "Job skipped as new job re-scheduled with the same unique id, tracked by pollable task id:"));
 
     pollableTask = pollableTaskRepository.findById(pollableFuture3.getPollableTask().getId()).get();
     assertTrue(pollableTask.isAllFinished());
     assertNull(pollableTask.getMessage());
   }
 
+  @Test
+  public void testRescheduleJobsWithUniqueIdAndNonVoidOutput()
+      throws ExecutionException, InterruptedException {
+    Assume.assumeTrue(dbUtils.isQuartzMysql());
+    QuartzJobInfo<Long, AQuartzPollableJobOutput> quartzJobInfo =
+        QuartzJobInfo.newBuilder(AQuartzPollableJobNonVoidOutput.class)
+            .withUniqueId("test1")
+            .withInput(10L)
+            .build();
+    QuartzJobInfo<Long, AQuartzPollableJobOutput> quartzJobInfo2 =
+        QuartzJobInfo.newBuilder(AQuartzPollableJobNonVoidOutput.class)
+            .withUniqueId("test1")
+            .withInput(20L)
+            .build();
+    QuartzJobInfo<Long, AQuartzPollableJobOutput> quartzJobInfo3 =
+        QuartzJobInfo.newBuilder(AQuartzPollableJobNonVoidOutput.class)
+            .withUniqueId("test1")
+            .withInput(30L)
+            .build();
+    quartzPollableTaskScheduler.cleanupOnUniqueIdReschedule = true;
+    PollableFuture<AQuartzPollableJobOutput> pollableFuture =
+        quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
+    PollableFuture<AQuartzPollableJobOutput> pollableFuture2 =
+        quartzPollableTaskScheduler.scheduleJob(quartzJobInfo2);
+    PollableFuture<AQuartzPollableJobOutput> pollableFuture3 =
+        quartzPollableTaskScheduler.scheduleJob(quartzJobInfo3);
+
+    // Wait jobs 1 & 3 to complete, job 2 will be a zombie due to providing non void output so it
+    // won't be skipped
+    pollableFuture.get();
+    pollableFuture3.get();
+
+    assertEquals("output: 10", pollableFuture.get().getOutput());
+    PollableTask pollableTask =
+        pollableTaskRepository.findById(pollableFuture2.getPollableTask().getId()).get();
+    assertFalse(pollableTask.isAllFinished());
+    assertNull(pollableTask.getMessage());
+    assertEquals("output: 30", pollableFuture3.get().getOutput());
+  }
+
   @DisallowConcurrentExecution
-  public static class AQuartzPollableJob3 extends VoidQuartzPollableJob {
+  public static class AQuartzPollableJobVoidOutput extends VoidQuartzPollableJob {
     public Void call(Long input) throws Exception {
+      Thread.sleep(2000);
+      return super.call(input);
+    }
+  }
+
+  @DisallowConcurrentExecution
+  public static class AQuartzPollableJobNonVoidOutput extends AQuartzPollableJob2 {
+    public AQuartzPollableJobOutput call(Long input) throws Exception {
       Thread.sleep(2000);
       return super.call(input);
     }


### PR DESCRIPTION
Alternative approach to #84. 

This approach marks pending pollable tasks associated with a blocked trigger as finished if a re-scheduling occurs for the same id.