### PR TITLE
Include non void output jobs in the skip process

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
@@ -161,9 +161,7 @@ public class QuartzPollableTaskScheduler {
         logger.debug("Job already scheduled for key: {}, reschedule", keyName);
         if (cleanupOnUniqueIdReschedule
             && dbUtils.isQuartzMysql()
-            && quartzJobInfo.getUniqueId() != null
-            && jobOutputType.equals(Void.class)) {
-          // Only done for jobs with Void output as a skipped job will have no output
+            && quartzJobInfo.getUniqueId() != null) {
           skipPendingPollablesWithMatchingId(scheduler, jobKey, trigger, pollableTask);
         }
         scheduler.rescheduleJob(triggerKey, trigger);

--- a/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableTaskSchedulerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableTaskSchedulerTest.java
@@ -2,7 +2,6 @@ package com.box.l10n.mojito.quartz;
 
 import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -151,16 +150,17 @@ public class QuartzPollableTaskSchedulerTest extends ServiceTestBase {
     PollableFuture<AQuartzPollableJobOutput> pollableFuture3 =
         quartzPollableTaskScheduler.scheduleJob(quartzJobInfo3);
 
-    // Wait jobs 1 & 3 to complete, job 2 will be a zombie due to providing non void output so it
-    // won't be skipped
-    pollableFuture.get();
     pollableFuture3.get();
 
     assertEquals("output: 10", pollableFuture.get().getOutput());
     PollableTask pollableTask =
         pollableTaskRepository.findById(pollableFuture2.getPollableTask().getId()).get();
-    assertFalse(pollableTask.isAllFinished());
-    assertNull(pollableTask.getMessage());
+    assertTrue(pollableTask.isAllFinished());
+    assertTrue(
+        pollableTask
+            .getMessage()
+            .contains(
+                "Job skipped as new job re-scheduled with the same unique id, tracked by pollable task id:"));
     assertEquals("output: 30", pollableFuture3.get().getOutput());
   }
 


### PR DESCRIPTION
Skip non void output jobs as well as void output as unskipped jobs are going to result in zombie tasks anyway