### PR TITLE
Run branch statistic calculations in parallel

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/AsyncBranchStatisticUpdater.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/AsyncBranchStatisticUpdater.java
@@ -1,0 +1,45 @@
+package com.box.l10n.mojito.service.branch;
+
+import com.box.l10n.mojito.entity.Branch;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AsyncBranchStatisticUpdater {
+
+  @Autowired @Lazy BranchStatisticService branchStatisticService;
+
+  public void updateBranchStatistics(
+      List<Branch> branches,
+      Map<String, ImmutableMap<Long, ForTranslationCountForTmTextUnitId>>
+          mapBranchNameToTranslationCountForTextUnitId) {
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    branches.stream()
+        .forEach(
+            branch ->
+                futures.add(
+                    updateBranchStatisticsAsync(
+                        branch, mapBranchNameToTranslationCountForTextUnitId)));
+    // wait for all the updates to complete
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+  }
+
+  @Async("statisticsTaskExecutor")
+  public CompletableFuture<Void> updateBranchStatisticsAsync(
+      Branch branch,
+      Map<String, ImmutableMap<Long, ForTranslationCountForTmTextUnitId>>
+          mapBranchNameToTranslationCountForTextUnitId) {
+    branchStatisticService.updateBranchStatisticInTx(
+        branch,
+        mapBranchNameToTranslationCountForTextUnitId.getOrDefault(
+            branch.getName(), ImmutableMap.of()));
+    return CompletableFuture.completedFuture(null);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/AsyncBranchStatisticUpdater.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/AsyncBranchStatisticUpdater.java
@@ -1,11 +1,13 @@
 package com.box.l10n.mojito.service.branch;
 
+import static com.box.l10n.mojito.utils.TaskExecutorUtils.waitForAllFutures;
+
 import com.box.l10n.mojito.entity.Branch;
 import com.google.common.collect.ImmutableMap;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
@@ -14,21 +16,27 @@ import org.springframework.stereotype.Component;
 @Component
 public class AsyncBranchStatisticUpdater {
 
+  // Lazy annotation is used to resolve the circular dependency between AsyncBranchStatisticUpdater
+  // and BranchStatisticService,
+  // this is needed because by re-using the Spring proxy to call the update Branch stats method, we
+  // ensure a transaction is in place.
+  // If we combine @Async and @Transactional on the same method then 2 proxies are created by Spring
+  // and the transactional proxy
+  // is not used when the method is called asynchronously.
   @Autowired @Lazy BranchStatisticService branchStatisticService;
 
   public void updateBranchStatistics(
       List<Branch> branches,
       Map<String, ImmutableMap<Long, ForTranslationCountForTmTextUnitId>>
           mapBranchNameToTranslationCountForTextUnitId) {
-    List<CompletableFuture<Void>> futures = new ArrayList<>();
-    branches.stream()
-        .forEach(
-            branch ->
-                futures.add(
+    List<CompletableFuture<Void>> futures =
+        branches.stream()
+            .map(
+                branch ->
                     updateBranchStatisticsAsync(
-                        branch, mapBranchNameToTranslationCountForTextUnitId)));
-    // wait for all the updates to complete
-    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+                        branch, mapBranchNameToTranslationCountForTextUnitId))
+            .collect(Collectors.toList());
+    waitForAllFutures(futures);
   }
 
   @Async("statisticsTaskExecutor")

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticService.java
@@ -4,6 +4,7 @@ import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULE
 import static com.box.l10n.mojito.service.assetExtraction.AssetExtractionService.PRIMARY_BRANCH;
 import static com.box.l10n.mojito.service.tm.search.StatusFilter.FOR_TRANSLATION;
 import static com.box.l10n.mojito.utils.Predicates.not;
+import static com.box.l10n.mojito.utils.TaskExecutorUtils.waitForAllFutures;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.box.l10n.mojito.entity.AssetExtraction;
@@ -35,7 +36,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -117,10 +117,10 @@ public class BranchStatisticService {
   }
 
   private void sendBranchNotifications(List<Branch> branchesToCheck) {
-    List<CompletableFuture<PollableFuture<Void>>> futures = new ArrayList<>();
-    branchesToCheck.stream().forEach(branch -> futures.add(scheduleBranchNotification(branch)));
-    // wait for all notifications to be scheduled
-    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    waitForAllFutures(
+        branchesToCheck.stream()
+            .map(branch -> scheduleBranchNotification(branch))
+            .collect(Collectors.toList()));
   }
 
   /**

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticService.java
@@ -20,6 +20,7 @@ import com.box.l10n.mojito.service.assetExtraction.AssetTextUnitToTMTextUnitRepo
 import com.box.l10n.mojito.service.assetExtraction.MultiBranchStateService;
 import com.box.l10n.mojito.service.branch.notification.job.BranchNotificationJob;
 import com.box.l10n.mojito.service.branch.notification.job.BranchNotificationJobInput;
+import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
@@ -34,12 +35,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -49,6 +52,7 @@ import javax.persistence.EntityManager;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,6 +91,8 @@ public class BranchStatisticService {
 
   @Autowired RepositoryRepository repositoryRepository;
 
+  @Autowired AsyncBranchStatisticUpdater asyncBranchStatisticUpdater;
+
   @Value("${l10n.branchStatistic.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
   String schedulerName;
 
@@ -106,10 +112,15 @@ public class BranchStatisticService {
 
       List<Branch> branchesToCheck = getBranchesToProcess(repositoryId);
       computeAndSaveBranchStatistics(repositoryId, updateType, branchesToCheck);
-      for (Branch branch : branchesToCheck) {
-        scheduleBranchNotification(branch);
-      }
+      sendBranchNotifications(branchesToCheck);
     }
+  }
+
+  private void sendBranchNotifications(List<Branch> branchesToCheck) {
+    List<CompletableFuture<PollableFuture<Void>>> futures = new ArrayList<>();
+    branchesToCheck.stream().forEach(branch -> futures.add(scheduleBranchNotification(branch)));
+    // wait for all notifications to be scheduled
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
   }
 
   /**
@@ -135,9 +146,10 @@ public class BranchStatisticService {
           branches.stream().map(Branch::getName).collect(ImmutableSet.toImmutableSet());
 
       logger.info("Computing branch stastistics");
+
       Map<String, ImmutableMap<Long, ForTranslationCountForTmTextUnitId>>
           mapBranchNameToTranslationCountForTextUnitId =
-              assetRepository.findIdByRepositoryIdAndDeleted(repositoryId, false).stream()
+              assetRepository.findIdByRepositoryIdAndDeleted(repositoryId, false).parallelStream()
                   .flatMap(
                       assetId -> {
                         AssetExtraction lastSuccessfulAssetExtraction =
@@ -154,7 +166,7 @@ public class BranchStatisticService {
                             .getAsset()
                             .getRepository()
                             .getRepositoryLocales()
-                            .stream()
+                            .parallelStream()
                             .filter(
                                 rl -> rl.getParentLocale() != null && rl.isToBeFullyTranslated())
                             .flatMap(
@@ -173,7 +185,7 @@ public class BranchStatisticService {
                                                       TextUnitDTO::getTmTextUnitId,
                                                       Function.identity()));
 
-                                  return multiBranchState.getBranches().stream()
+                                  return multiBranchState.getBranches().parallelStream()
                                       .filter(
                                           branch -> branchNamesToCheck.contains(branch.getName()))
                                       .flatMap(
@@ -197,12 +209,8 @@ public class BranchStatisticService {
                   .collect(toMapBranchNameToTranslationCountForTextUnitId());
 
       logger.debug("Updating branch statistics");
-      for (Branch branch : branches) {
-        updateBranchStatisticInTx(
-            branch,
-            mapBranchNameToTranslationCountForTextUnitId.getOrDefault(
-                branch.getName(), ImmutableMap.of()));
-      }
+      asyncBranchStatisticUpdater.updateBranchStatistics(
+          branches, mapBranchNameToTranslationCountForTextUnitId);
       logger.debug("Finished computing statistics");
     }
   }
@@ -435,7 +443,8 @@ public class BranchStatisticService {
             }));
   }
 
-  void scheduleBranchNotification(Branch branch) {
+  @Async("statisticsTaskExecutor")
+  CompletableFuture<PollableFuture<Void>> scheduleBranchNotification(Branch branch) {
     BranchNotificationJobInput branchNotificationJobInput = new BranchNotificationJobInput();
     branchNotificationJobInput.setBranchId(branch.getId());
 
@@ -445,7 +454,8 @@ public class BranchStatisticService {
             .withInput(branchNotificationJobInput)
             .withScheduler(schedulerName)
             .build();
-    quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
+    return CompletableFuture.completedFuture(
+        quartzPollableTaskScheduler.scheduleJob(quartzJobInfo));
   }
 
   /**

--- a/webapp/src/main/java/com/box/l10n/mojito/utils/TaskExecutorUtils.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/utils/TaskExecutorUtils.java
@@ -1,0 +1,11 @@
+package com.box.l10n.mojito.utils;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class TaskExecutorUtils {
+
+  public static <T> void waitForAllFutures(List<CompletableFuture<T>> futures) {
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+  }
+}


### PR DESCRIPTION
Adds parallel processing to the branch statistics calculations, when combined with locale stats parallel processing in #94 the Repository statistic calculations latency for a repository with a small number of assets is improved by ~82%.