### PR TITLE
Adding support for jackson smile data format

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -51,6 +51,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-smile</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-blackbird</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <docker.compose.detached.mode>true</docker.compose.detached.mode>
         <docker.compose.remove.volumes>true</docker.compose.remove.volumes>
         <aspectj.version>1.9.20</aspectj.version>
+        <jackson.version>2.13.5</jackson.version>
     </properties>
 
     <dependencies>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -266,7 +266,6 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
-
         <!-- TODO(P1) to be removed? -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/webapp/src/main/java/com/box/l10n/mojito/Application.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/Application.java
@@ -76,6 +76,12 @@ public class Application {
     return objectMapper;
   }
 
+  @Bean(name = "smile_format_object_mapper")
+  public ObjectMapper getSmileFormatObjectMapper() {
+    ObjectMapper objectMapper = ObjectMapper.withSmileEnabled();
+    return objectMapper;
+  }
+
   /**
    * Configuration Jackson ObjectMapper
    *

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/StructuredBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/StructuredBlobStorage.java
@@ -18,7 +18,15 @@ public class StructuredBlobStorage {
     return blobStorage.getString(getFullName(prefix, name));
   }
 
+  public Optional<byte[]> getBytes(Prefix prefix, String name) {
+    return blobStorage.getBytes(getFullName(prefix, name));
+  }
+
   public void put(Prefix prefix, String name, String content, Retention retention) {
+    blobStorage.put(getFullName(prefix, name), content, retention);
+  }
+
+  public void putBytes(Prefix prefix, String name, byte[] content, Retention retention) {
     blobStorage.put(getFullName(prefix, name), content, retention);
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/textunitdtocache/TextUnitDTOsSmileCacheBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/textunitdtocache/TextUnitDTOsSmileCacheBlobStorage.java
@@ -1,0 +1,53 @@
+package com.box.l10n.mojito.service.tm.textunitdtocache;
+
+import static com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage.Prefix.TEXT_UNIT_DTOS_CACHE;
+
+import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.service.blobstorage.Retention;
+import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "l10n.cache.textunit.smile.enabled", havingValue = "true")
+public class TextUnitDTOsSmileCacheBlobStorage extends TextUnitDTOsCacheBlobStorage {
+
+  @Autowired
+  @Qualifier("smile_format_object_mapper")
+  ObjectMapper objectMapper;
+
+  String getName(Long assetId, Long localeId) {
+    return "asset/" + assetId + "/locale/" + localeId + ".smile";
+  }
+
+  Optional<ImmutableList<TextUnitDTO>> getTextUnitsFromCache(Long assetId, Long localeId) {
+    Optional<byte[]> bytes =
+        structuredBlobStorage.getBytes(TEXT_UNIT_DTOS_CACHE, getName(assetId, localeId));
+    return bytes.map(this::convertToListOrEmptyList);
+  }
+
+  void writeTextUnitDTOsToCache(
+      Long assetId,
+      Long localeId,
+      TextUnitDTOsCacheBlobStorageJson textUnitDTOsCacheBlobStorageJson) {
+    byte[] bytes = objectMapper.writeValueAsBytes(textUnitDTOsCacheBlobStorageJson);
+    structuredBlobStorage.putBytes(
+        TEXT_UNIT_DTOS_CACHE, getName(assetId, localeId), bytes, Retention.PERMANENT);
+  }
+
+  ImmutableList<TextUnitDTO> convertToListOrEmptyList(byte[] s) {
+    try {
+      return ImmutableList.copyOf(
+          objectMapper.readValue(s, TextUnitDTOsCacheBlobStorageJson.class).getTextUnitDTOs());
+    } catch (Exception e) {
+      logger.error(
+          "Can't convert the content into TextUnitDTOsCacheBlobStorageJson, return an empty list instead",
+          e);
+      return ImmutableList.of();
+    }
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/textunitdtocache/TextUnitDTOsSmileCacheBlobStorageTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/textunitdtocache/TextUnitDTOsSmileCacheBlobStorageTest.java
@@ -1,0 +1,75 @@
+package com.box.l10n.mojito.service.tm.textunitdtocache;
+
+import static com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage.Prefix.TEXT_UNIT_DTOS_CACHE;
+import static org.junit.Assert.assertEquals;
+
+import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.service.blobstorage.Retention;
+import com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage;
+import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TextUnitDTOsSmileCacheBlobStorageTest {
+
+  TextUnitDTOsSmileCacheBlobStorage textUnitDTOsCacheBlobStorage =
+      new TextUnitDTOsSmileCacheBlobStorage();
+
+  ObjectMapper objectMapper = ObjectMapper.withSmileEnabled();
+
+  @Before
+  public void setUp() {
+    textUnitDTOsCacheBlobStorage.objectMapper = objectMapper;
+  }
+
+  @Test
+  public void testSuffixAppendedToName() {
+    String blobName = textUnitDTOsCacheBlobStorage.getName(1234L, 56L);
+    assertEquals("asset/1234/locale/56.smile", blobName);
+  }
+
+  @Test
+  public void testBytesWrittenToCache() {
+    StructuredBlobStorage structuredBlobStorageMock = Mockito.mock(StructuredBlobStorage.class);
+    TextUnitDTOsCacheBlobStorageJson textUnitDTOsCacheBlobStorageJson =
+        new TextUnitDTOsCacheBlobStorageJson();
+    textUnitDTOsCacheBlobStorage.structuredBlobStorage = structuredBlobStorageMock;
+    byte[] expectedBytes = objectMapper.writeValueAsBytes(textUnitDTOsCacheBlobStorageJson);
+    textUnitDTOsCacheBlobStorage.writeTextUnitDTOsToCache(
+        1234L, 56L, textUnitDTOsCacheBlobStorageJson);
+    Mockito.verify(structuredBlobStorageMock)
+        .putBytes(
+            TEXT_UNIT_DTOS_CACHE, "asset/1234/locale/56.smile", expectedBytes, Retention.PERMANENT);
+  }
+
+  @Test
+  public void testGetTextUnitDTOS() throws IOException {
+    StructuredBlobStorage structuredBlobStorageMock = Mockito.mock(StructuredBlobStorage.class);
+    TextUnitDTOsCacheBlobStorageJson textUnitDTOsCacheBlobStorageJson =
+        new TextUnitDTOsCacheBlobStorageJson();
+    TextUnitDTO textUnitDTO = new TextUnitDTO();
+    textUnitDTO.setComment("testComment");
+    textUnitDTO.setTmTextUnitId(1L);
+    textUnitDTO.setName("testName");
+    textUnitDTO.setSource("testSource");
+    textUnitDTOsCacheBlobStorageJson.setTextUnitDTOs(ImmutableList.of(textUnitDTO));
+    byte[] expectedBytes = objectMapper.writeValueAsBytes(textUnitDTOsCacheBlobStorageJson);
+    Mockito.when(
+            structuredBlobStorageMock.getBytes(TEXT_UNIT_DTOS_CACHE, "asset/1234/locale/56.smile"))
+        .thenReturn(Optional.of(expectedBytes));
+    textUnitDTOsCacheBlobStorage.structuredBlobStorage = structuredBlobStorageMock;
+    Optional<ImmutableList<TextUnitDTO>> textUnitDTOS =
+        textUnitDTOsCacheBlobStorage.getTextUnitsFromCache(1234L, 56L);
+    Mockito.verify(structuredBlobStorageMock)
+        .getBytes(TEXT_UNIT_DTOS_CACHE, "asset/1234/locale/56.smile");
+    assertEquals(1, textUnitDTOS.get().size());
+    assertEquals("testComment", textUnitDTOS.get().get(0).getComment());
+    assertEquals(1L, textUnitDTOS.get().get(0).getTmTextUnitId().longValue());
+    assertEquals("testName", textUnitDTOS.get().get(0).getName());
+    assertEquals("testSource", textUnitDTOS.get().get(0).getSource());
+  }
+}


### PR DESCRIPTION
This PR adds support for the Jackson smile data format to improve JSON serialization/deserialization for the text unit cache, profiling has displayed a 58% improvement when writing bytes to the cache using the smile data format and a 65% improvement when retrieving when compared to the existing raw text JSON implementation.