### PR TITLE
Fix bug with pagination in user management page

### DIFF
--- a/webapp/src/main/resources/public/js/components/users/UserMainPage.js
+++ b/webapp/src/main/resources/public/js/components/users/UserMainPage.js
@@ -37,7 +37,7 @@ class UserMainPage extends React.Component {
     }
 
     currentPage() {
-        return this.props.userPage == null ? 0 : this.props.userPage.totalPages;
+        return this.props.userPage == null ? 1 : this.props.userPage.number + 1;
     }
 
     renderPageBar() {


### PR DESCRIPTION
Fixes issue where the pagination in the user management page is broken as `totalPages` is used as the `currentPage` value, meaning that you couldn't page through a list of users.