### PR TITLE
Allow any authenticated user to create and retrieve deeplinks

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
@@ -167,6 +167,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 . // always accessible to serve the frontend
                 antMatchers(getHeathcheckPatterns())
                 .permitAll()
+                // allow deep link creation and retrieval
+                .antMatchers(HttpMethod.GET, "/api/clobstorage", "/api/clobstorage/**")
+                .authenticated()
+                .antMatchers(HttpMethod.POST, "/api/clobstorage", "/api/clobstorage/**")
+                .authenticated()
                 . // allow health entry points
                 antMatchers("/actuator/shutdown", "/actuator/loggers/**", "/api/rotation")
                 .hasIpAddress("127.0.0.1")


### PR DESCRIPTION
Add permissions so any authenticated user can create and retrieve links to the workbench