### PR TITLE
If 401 is returned to Smartling refresh token request, request a new token

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingOAuthAccessResponse.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingOAuthAccessResponse.java
@@ -30,24 +30,12 @@ public class SmartlingOAuthAccessResponse {
       return code;
     }
 
-    public void setCode(String code) {
-      this.code = code;
-    }
-
     public TokenData getData() {
       return data;
     }
 
-    public void setData(TokenData data) {
-      this.data = data;
-    }
-
     public ErrorDetails getError() {
       return error;
-    }
-
-    public void setError(ErrorDetails error) {
-      this.error = error;
     }
   }
 
@@ -75,40 +63,16 @@ public class SmartlingOAuthAccessResponse {
       return accessToken;
     }
 
-    public void setAccessToken(String accessToken) {
-      this.accessToken = accessToken;
-    }
-
     public String getRefreshToken() {
       return refreshToken;
-    }
-
-    public void setRefreshToken(String refreshToken) {
-      this.refreshToken = refreshToken;
     }
 
     public int getExpiresIn() {
       return expiresIn;
     }
 
-    public void setExpiresIn(int expiresIn) {
-      this.expiresIn = expiresIn;
-    }
-
     public int getRefreshExpiresIn() {
       return refreshExpiresIn;
-    }
-
-    public void setRefreshExpiresIn(int refreshExpiresIn) {
-      this.refreshExpiresIn = refreshExpiresIn;
-    }
-
-    public String getTokenType() {
-      return tokenType;
-    }
-
-    public void setTokenType(String tokenType) {
-      this.tokenType = tokenType;
     }
 
     public long getRefreshExpiryTime() {
@@ -137,29 +101,5 @@ public class SmartlingOAuthAccessResponse {
 
     @JsonProperty("message")
     private String message;
-
-    public Object getDetails() {
-      return details;
-    }
-
-    public void setDetails(Object details) {
-      this.details = details;
-    }
-
-    public String getKey() {
-      return key;
-    }
-
-    public void setKey(String key) {
-      this.key = key;
-    }
-
-    public String getMessage() {
-      return message;
-    }
-
-    public void setMessage(String message) {
-      this.message = message;
-    }
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingOAuthAccessResponse.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingOAuthAccessResponse.java
@@ -23,6 +23,9 @@ public class SmartlingOAuthAccessResponse {
     @JsonProperty("data")
     private TokenData data;
 
+    @JsonProperty("errors")
+    private ErrorDetails error;
+
     public String getCode() {
       return code;
     }
@@ -37,6 +40,14 @@ public class SmartlingOAuthAccessResponse {
 
     public void setData(TokenData data) {
       this.data = data;
+    }
+
+    public ErrorDetails getError() {
+      return error;
+    }
+
+    public void setError(ErrorDetails error) {
+      this.error = error;
     }
   }
 
@@ -114,6 +125,41 @@ public class SmartlingOAuthAccessResponse {
 
     public void setTokenExpiryTime(long tokenExpiryTime) {
       this.tokenExpiryTime = tokenExpiryTime;
+    }
+  }
+
+  static class ErrorDetails {
+    @JsonProperty("details")
+    private Object details;
+
+    @JsonProperty("key")
+    private String key;
+
+    @JsonProperty("message")
+    private String message;
+
+    public Object getDetails() {
+      return details;
+    }
+
+    public void setDetails(Object details) {
+      this.details = details;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public void setKey(String key) {
+      this.key = key;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public void setMessage(String message) {
+      this.message = message;
     }
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingOAuth2TokenServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingOAuth2TokenServiceTest.java
@@ -101,8 +101,6 @@ public class SmartlingOAuth2TokenServiceTest {
 
     assertEquals("newToken", accessToken);
 
-    Thread.sleep(1000);
-
     when(mockResponse.statusCode()).thenReturn(401).thenReturn(401).thenReturn(200);
     when(mockResponse.body())
         .thenReturn(

--- a/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingOAuth2TokenServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingOAuth2TokenServiceTest.java
@@ -38,6 +38,7 @@ public class SmartlingOAuth2TokenServiceTest {
   public void getAccessTokenRequestsNewTokenWhenRefreshTokenExpired() throws Exception {
     when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
         .thenReturn(mockResponse);
+    when(mockResponse.statusCode()).thenReturn(200);
     when(mockResponse.body())
         .thenReturn(
             "{\"response\": {\"data\": {\"accessToken\": \"newToken\", \"expiresIn\": 3600, \"refreshToken\": \"refreshToken\", \"refreshExpiresIn\": 1}}}");
@@ -54,6 +55,7 @@ public class SmartlingOAuth2TokenServiceTest {
   public void getAccessTokenRequestsNewTokenWhenNoTokenExists() throws Exception {
     when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
         .thenReturn(mockResponse);
+    when(mockResponse.statusCode()).thenReturn(200);
     when(mockResponse.body())
         .thenReturn(
             "{\"response\": {\"data\": {\"accessToken\": \"newToken\", \"expiresIn\": 3600, \"refreshToken\": \"refreshToken\", \"refreshExpiresIn\": 7200}}}");
@@ -68,6 +70,7 @@ public class SmartlingOAuth2TokenServiceTest {
   public void getRefreshedAccessTokenTokenWhenAccessTokenExpired() throws Exception {
     when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
         .thenReturn(mockResponse);
+    when(mockResponse.statusCode()).thenReturn(200);
     when(mockResponse.body())
         .thenReturn(
             "{\"response\": {\"data\": {\"accessToken\": \"newToken\", \"expiresIn\": 1, \"refreshToken\": \"refreshToken\", \"refreshExpiresIn\": 7200}}}");
@@ -83,5 +86,46 @@ public class SmartlingOAuth2TokenServiceTest {
 
     assertEquals("refreshedToken", accessToken);
     verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+  }
+
+  @Test
+  public void testRefreshTokenRequestResponse401TriggersNewTokenRequest() throws Exception {
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(mockResponse);
+    when(mockResponse.statusCode()).thenReturn(200);
+    when(mockResponse.body())
+        .thenReturn(
+            "{\"response\": {\"data\": {\"accessToken\": \"newToken\", \"expiresIn\": 1, \"refreshToken\": \"refreshToken\", \"refreshExpiresIn\": 7200}}}");
+
+    String accessToken = smartlingOAuth2TokenService.getAccessToken();
+
+    assertEquals("newToken", accessToken);
+
+    Thread.sleep(1000);
+
+    when(mockResponse.statusCode()).thenReturn(401).thenReturn(401).thenReturn(200);
+    when(mockResponse.body())
+        .thenReturn(
+            "{\"response\": {\"code\": \"AUTHENTICATION_ERROR\", \"errors\": {\"details\": {}, \"key\": \"invalid_token\", \"message\": \"Invalid token\"}}}")
+        .thenReturn(
+            "{\"response\": {\"data\": {\"accessToken\": \"evenNewerToken\", \"expiresIn\": 1, \"refreshToken\": \"refreshToken\", \"refreshExpiresIn\": 7200}}}");
+
+    accessToken = smartlingOAuth2TokenService.getAccessToken();
+
+    assertEquals("evenNewerToken", accessToken);
+
+    verify(httpClient, times(3)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+  }
+
+  @Test(expected = SmartlingOAuthTokenException.class)
+  public void testNewTokenRequestResponse401TriggersException() throws Exception {
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(mockResponse);
+    when(mockResponse.statusCode()).thenReturn(401);
+    when(mockResponse.body())
+        .thenReturn(
+            "{\"response\": {\"code\": \"AUTHENTICATION_ERROR\", \"errors\": {\"details\": {}, \"key\": \"invalid_token\", \"message\": \"Invalid token\"}}}");
+
+    smartlingOAuth2TokenService.getAccessToken();
   }
 }


### PR DESCRIPTION
Updated the Smartling OAuth exception handling to request a new token in the event of a 401 returned during a refresh token request.

Moved synchronized block to public `getAccessToken` method to avoid the possibility of some threads getting an expired token while a token retrieval is in progress.

Increased the expiry window from 3 to 30 seconds, if a token will expire within the next 30 seconds we'll refresh/recreate a token.