### PR TITLE
Fetch createdByUser in entity graph, remove @JsonBackReference annotation

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Branch.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Branch.java
@@ -2,7 +2,6 @@ package com.box.l10n.mojito.entity;
 
 import com.box.l10n.mojito.entity.security.user.User;
 import com.box.l10n.mojito.rest.View;
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import jakarta.persistence.*;
@@ -49,7 +48,6 @@ public class Branch extends SettableAuditableEntity {
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "repository_id", foreignKey = @ForeignKey(name = "FK__BRANCH__REPOSITORY__ID"))
   @JsonView(View.BranchSummary.class)
-  @JsonBackReference
   Repository repository;
 
   @JsonView(View.BranchSummary.class)

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Branch.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Branch.java
@@ -41,7 +41,14 @@ import org.springframework.data.annotation.CreatedBy;
     subgraphs = {
       @NamedSubgraph(
           name = "Branch.legacy.screenshots",
-          attributeNodes = {@NamedAttributeNode("screenshotTextUnits")})
+          attributeNodes = {
+            @NamedAttributeNode(
+                value = "screenshotTextUnits",
+                subgraph = "Branch.legacy.screenshots.screenshotTextUnits")
+          }),
+      @NamedSubgraph(
+          name = "Branch.legacy.screenshots.screenshotTextUnits",
+          attributeNodes = {@NamedAttributeNode("tmTextUnit")})
     })
 public class Branch extends SettableAuditableEntity {
 

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/BranchStatistic.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/BranchStatistic.java
@@ -30,6 +30,7 @@ import java.util.Set;
           attributeNodes = {
             @NamedAttributeNode(value = "screenshots", subgraph = "branchGraph.screenshots"),
             @NamedAttributeNode(value = "repository", subgraph = "branchGraph.repository"),
+            @NamedAttributeNode(value = "createdByUser"),
           }),
       @NamedSubgraph(
           name = "branchGraph.branchTextUnitStatistics",
@@ -46,7 +47,7 @@ import java.util.Set;
           name = "branchGraph.screenshots",
           attributeNodes = {
             @NamedAttributeNode(value = "screenshotTextUnits"),
-          })
+          }),
     })
 @NamedEntityGraph(
     name = "BranchStatisticGraphWithoutTextUnits",
@@ -59,7 +60,7 @@ import java.util.Set;
           attributeNodes = {
             @NamedAttributeNode(value = "screenshots"),
             @NamedAttributeNode(value = "repository"),
-          })
+          }),
     })
 public class BranchStatistic extends AuditableEntity {
 


### PR DESCRIPTION
Added `createdByUser` to `BranchStatistic` entity graph.

Removed `@JsonBackReference` to fix screenshot upload.

Retrieve `tmTextUnit` fields for a `ScreenshotTextUnit` via a sub entity graph for branches.