### PR TITLE
Fix for delete screenshot if no third party config exists for repository

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/screenshot/ScreenshotService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/screenshot/ScreenshotService.java
@@ -412,10 +412,11 @@ public class ScreenshotService {
               .getRepository()
               .getName();
 
-      String projectId = thirdPartySyncJobs.get(repository).getThirdPartyProjectId();
-
-      thirdPartyService.removeImage(projectId, thirdPartyScreenshot.getThirdPartyId());
-      thirdPartyScreenshotRepository.deleteById(thirdPartyScreenshot.getId());
+      if (thirdPartySyncJobs.containsKey(repository)) {
+        String projectId = thirdPartySyncJobs.get(repository).getThirdPartyProjectId();
+        thirdPartyService.removeImage(projectId, thirdPartyScreenshot.getThirdPartyId());
+        thirdPartyScreenshotRepository.deleteById(thirdPartyScreenshot.getId());
+      }
     }
 
     screenshotTextUnitRepository.deleteAllByScreenshot_Id(id);


### PR DESCRIPTION
Fixes the issue where an error occurs if a user attempts to delete a screenshot from the Mojito UI and the relevant repository doesn't have any third party sync job configuration available. 

In this case only the screenshots will be deleted.