### PR TITLE
Reduce metric cardinality for importTextUnits

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
@@ -158,8 +158,7 @@ public class TextUnitBatchImporterService {
                                       meterRegistry,
                                       "TextUnitBatchImporterService.importTextUnits.batch")
                                   .tag("repository", asset.getRepository().getName())
-                                  .tag("asset", asset.getPath())
-                                  .tag("locale", locale.getBcp47Tag())) {
+                                  .tag("asset", asset.getPath())) {
 
                             mapTextUnitsToImportWithExistingTextUnits(
                                 locale, asset, textUnitsForBatchImport);
@@ -169,8 +168,7 @@ public class TextUnitBatchImporterService {
                                           meterRegistry,
                                           "TextUnitBatchImporterService.importTextUnits.integrityChecks")
                                       .tag("repository", asset.getRepository().getName())
-                                      .tag("asset", asset.getPath())
-                                      .tag("locale", locale.getBcp47Tag())) {
+                                      .tag("asset", asset.getPath())) {
 
                                 applyIntegrityChecks(
                                     asset,


### PR DESCRIPTION
The metric cardinality for importTextUnits was too high, this reduces it be removing the BCP47 dimension/tag.