### PR TITLE
Upgraded JCommander dependency from 1.48 to 1.58

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.48</version>
+            <version>1.58</version>
         </dependency>
 
         <dependency>

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
@@ -209,6 +209,7 @@ public class L10nJCommander {
   public void createJCommanderForRun() {
     logger.debug("Create JCommander instance");
     jCommander = new JCommander();
+    jCommander.setExpandAtSign(false);
 
     jCommander.setAcceptUnknownOptions(true);
 


### PR DESCRIPTION
This version supports ability to disable ampersat (@) parsing
https://github.com/cbeust/jcommander/pull/156