### PR TITLE
Added counter metrics for AI checks

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/ai/openai/OpenAIConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/ai/openai/OpenAIConfig.java
@@ -45,6 +45,12 @@ public class OpenAIConfig {
        * Allow modification of a restricted header prior to sending the request.
        *
        * <p>Provided list here is a list of header names which are set as unrestricted in the JRE.
+       *
+       * <p>Note that depending on when libraries are loaded and the order in which the loading
+       * occurs, this property setting may not be in effect before the httpClient library is loaded.
+       *
+       * <p>In those cases you should set the system property directly via the command line prior to
+       * application startup.
        */
       System.setProperty(
           "jdk.httpclient.allowRestrictedHeaders",

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/LLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/LLMService.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.service.ai;
 import com.box.l10n.mojito.JSR310Migration;
 import com.box.l10n.mojito.entity.AIPrompt;
 import com.box.l10n.mojito.entity.AIStringCheck;
+import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
 import com.box.l10n.mojito.rest.ai.AICheckRequest;
 import com.box.l10n.mojito.rest.ai.AICheckResponse;
@@ -36,12 +37,12 @@ public interface LLMService {
 
   default void persistCheckResult(
       AssetExtractorTextUnit textUnit,
-      long repositoryId,
+      Repository repository,
       AIPrompt prompt,
       String promptOutput,
       AIStringCheckRepository aiStringCheckRepository) {
     AIStringCheck aiStringCheck = new AIStringCheck();
-    aiStringCheck.setRepositoryId(repositoryId);
+    aiStringCheck.setRepositoryId(repository.getId());
     aiStringCheck.setAiPromptId(prompt.getId());
     aiStringCheck.setContent(textUnit.getSource());
     aiStringCheck.setComment(textUnit.getComments());


### PR DESCRIPTION
Added metrics to count the number of success/failed/error results of AI string checks, tagged with repository name and check outcome.