### PR TITLE
Set name column when persisting string check result

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/LLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/LLMService.java
@@ -48,6 +48,7 @@ public interface LLMService {
     aiStringCheck.setComment(textUnit.getComments());
     aiStringCheck.setPromptOutput(promptOutput);
     aiStringCheck.setCreatedDate(JSR310Migration.dateTimeNow());
+    aiStringCheck.setStringName(textUnit.getName());
     aiStringCheckRepository.save(aiStringCheck);
   }
 }


### PR DESCRIPTION
Fixes bug where the string name is not persisted in the AI string result entity