### PR TITLE
Added command to allow reusing a prompt across repositories

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/AddPromptToRepositoryCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/AddPromptToRepositoryCommand.java
@@ -1,0 +1,52 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.rest.client.AIServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope("prototype")
+@Parameters(
+    commandNames = {"add-ai-prompt-to-repository"},
+    commandDescription = "Add an AI prompt for a given repository")
+public class AddPromptToRepositoryCommand extends Command {
+
+  static Logger logger = LoggerFactory.getLogger(AddPromptToRepositoryCommand.class);
+
+  @Autowired AIServiceClient aiServiceClient;
+
+  @Parameter(
+      names = {"--repository-name", "-r"},
+      required = true,
+      description = "Repository name")
+  String repository;
+
+  @Parameter(
+      names = {"--prompt-id", "-pid"},
+      required = true,
+      description = "The prompt id")
+  Long promptId;
+
+  @Parameter(
+      names = {"--prompt-type", "-pty"},
+      required = true,
+      description = "The type of prompt to create")
+  String promptType;
+
+  @Autowired ConsoleWriter consoleWriter;
+
+  public void execute() {
+    logger.debug("Add prompt to {} repository with id: {}", repository, promptId);
+    aiServiceClient.addPromptToRepository(promptId, repository, promptType);
+    consoleWriter
+        .newLine()
+        .a("Prompt with id: " + promptId + ", added to repository: " + repository)
+        .println();
+  }
+}

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/AIServiceClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/AIServiceClient.java
@@ -56,4 +56,12 @@ public class AIServiceClient extends BaseClient {
     authenticatedRestTemplate.delete(
         getBasePathForEntity() + "/prompts/contextMessage/" + contextMessageId);
   }
+
+  public void addPromptToRepository(Long promptId, String repositoryName, String promptType) {
+    logger.debug("Received request to add prompt id {} to {} repository", promptId, repositoryName);
+    authenticatedRestTemplate.postForObject(
+        getBasePathForEntity() + "/prompts/" + promptId + "/" + repositoryName + "/" + promptType,
+        null,
+        Void.class);
+  }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AIPromptWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AIPromptWS.java
@@ -29,6 +29,18 @@ public class AIPromptWS {
     return promptService.createPrompt(AIPromptCreateRequest);
   }
 
+  @RequestMapping(
+      value = "/api/ai/prompts/{prompt_id}/{repository_name}/{prompt_type}",
+      method = RequestMethod.POST)
+  @Timed("AIWS.addPromptToRepository")
+  public void addPromptToRepository(
+      @PathVariable("prompt_id") Long promptId,
+      @PathVariable("repository_name") String repositoryName,
+      @PathVariable("prompt_type") String promptType) {
+    logger.debug("Received request to add prompt id {} to {} repository", promptId, repositoryName);
+    promptService.addPromptToRepository(promptId, repositoryName, promptType);
+  }
+
   @RequestMapping(value = "/api/ai/prompts/{prompt_id}", method = RequestMethod.DELETE)
   @Timed("AIWS.deletePrompt")
   public void deletePrompt(@PathVariable("prompt_id") Long promptId) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/PromptService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/PromptService.java
@@ -21,4 +21,6 @@ public interface PromptService {
       AIPromptContextMessageCreateRequest aiPromptContextMessageCreateRequest);
 
   void deletePromptContextMessage(Long promptContextMessageId);
+
+  void addPromptToRepository(Long promptId, String repositoryName, String promptType);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/LLMPromptService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/LLMPromptService.java
@@ -82,6 +82,34 @@ public class LLMPromptService implements PromptService {
     return aiPrompt.getId();
   }
 
+  @Timed("LLMPromptService.addPromptToRepository")
+  public void addPromptToRepository(Long promptId, String repositoryName, String promptType) {
+    Repository repository = repositoryRepository.findByName(repositoryName);
+
+    if (repository == null) {
+      logger.error("Repository not found: {}", repositoryName);
+      throw new AIException("Repository not found: " + repositoryName);
+    }
+
+    AIPromptType aiPromptType = aiPromptTypeRepository.findByName(promptType);
+    if (aiPromptType == null) {
+      logger.error("Prompt type not found: {}", promptType);
+      throw new AIException("Prompt type not found: " + promptType);
+    }
+
+    AIPrompt aiPrompt =
+        aiPromptRepository
+            .findById(promptId)
+            .orElseThrow(() -> new AIException("Prompt not found: " + promptId));
+
+    RepositoryAIPrompt repositoryAIPrompt = new RepositoryAIPrompt();
+    repositoryAIPrompt.setRepositoryId(repository.getId());
+    repositoryAIPrompt.setAiPromptId(aiPrompt.getId());
+    repositoryAIPrompt.setPromptTypeId(aiPromptType.getId());
+    repositoryAIPromptRepository.save(repositoryAIPrompt);
+    logger.debug("Created repository prompt with id: {}", repositoryAIPrompt.getId());
+  }
+
   @Timed("LLMPromptService.getPromptsByRepositoryAndPromptType")
   public List<AIPrompt> getPromptsByRepositoryAndPromptType(
       Repository repository, PromptType promptType) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
@@ -88,7 +88,7 @@ public class OpenAILLMService implements LLMService {
       AssetExtractorTextUnit textUnit, List<AIPrompt> prompts, Repository repository) {
     List<AICheckResult> results = new ArrayList<>();
     String sourceString = textUnit.getSource();
-    String comment = textUnit.getComments();
+    String comment = textUnit.getComments() != null ? textUnit.getComments() : "";
     String[] nameSplit = textUnit.getName().split(" --- ");
 
     if (!prompts.isEmpty()) {

--- a/webapp/src/main/resources/db/migration/V67__update_repo_ai_prompt_constraint.sql
+++ b/webapp/src/main/resources/db/migration/V67__update_repo_ai_prompt_constraint.sql
@@ -1,0 +1,23 @@
+ALTER TABLE repository_ai_prompt
+DROP FOREIGN KEY repository_ai_prompt_ibfk_1;
+
+ALTER TABLE repository_ai_prompt
+DROP FOREIGN KEY repository_ai_prompt_ibfk_2;
+
+ALTER TABLE repository_ai_prompt
+DROP FOREIGN KEY repository_ai_prompt_ibfk_3;
+
+ALTER TABLE repository_ai_prompt
+DROP CONSTRAINT UQ__REPOSITORY_AI_PROMPT__AI_PROMPT_ID_PROMPT_TYPE_ID;
+
+ALTER TABLE repository_ai_prompt
+ADD CONSTRAINT UQ__REPOSITORY_AI_PROMPT__ALL UNIQUE (repository_id, ai_prompt_id, prompt_type_id);
+
+ALTER TABLE repository_ai_prompt
+ADD CONSTRAINT FK__REPOSITORY_AI_PROMPT__PROMPT_TYPE_ID FOREIGN KEY (prompt_type_id) REFERENCES ai_prompt_type(id);
+
+ALTER TABLE repository_ai_prompt
+ADD CONSTRAINT FK__REPOSITORY_AI_PROMPT__AI_PROMPT_ID FOREIGN KEY (ai_prompt_id) REFERENCES ai_prompt(id);
+
+ALTER TABLE repository_ai_prompt
+ADD CONSTRAINT FK__REPOSITORY_AI_PROMPT__REPOSITORY_ID FOREIGN KEY (repository_id) REFERENCES repository(id);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/LLMPromptServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/LLMPromptServiceTest.java
@@ -22,6 +22,8 @@ import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -35,6 +37,8 @@ public class LLMPromptServiceTest {
   @Mock RepositoryAIPromptRepository repositoryAIPromptRepository;
 
   @Mock RepositoryRepository repositoryRepository;
+
+  @Captor ArgumentCaptor<RepositoryAIPrompt> repositoryAIPromptCaptor;
 
   @InjectMocks LLMPromptService LLMPromptService;
 
@@ -134,5 +138,24 @@ public class LLMPromptServiceTest {
     assertEquals("Check strings for spelling", openAIPrompt.getUserPrompt());
     assertEquals("gtp-3.5-turbo", openAIPrompt.getModelName());
     assertEquals(0.0F, openAIPrompt.getPromptTemperature());
+  }
+
+  @Test
+  void testAddPromptToRepository() {
+    AIPrompt aiPrompt = new AIPrompt();
+    aiPrompt.setId(1L);
+    Repository repository = new Repository();
+    repository.setId(2L);
+    AIPromptType promptType = new AIPromptType();
+    promptType.setId(3L);
+    when(repositoryRepository.findByName("testRepo")).thenReturn(repository);
+    when(aiPromptTypeRepository.findByName("SOURCE_STRING_CHECKER")).thenReturn(promptType);
+    when(aiPromptRepository.findById(1L)).thenReturn(Optional.of(aiPrompt));
+    LLMPromptService.addPromptToRepository(1L, "testRepo", "SOURCE_STRING_CHECKER");
+    verify(aiPromptTypeRepository, times(1)).findByName("SOURCE_STRING_CHECKER");
+    verify(repositoryAIPromptRepository, times(1)).save(repositoryAIPromptCaptor.capture());
+    assertEquals(1L, repositoryAIPromptCaptor.getValue().getAiPromptId());
+    assertEquals(2L, repositoryAIPromptCaptor.getValue().getRepositoryId());
+    assertEquals(3L, repositoryAIPromptCaptor.getValue().getPromptTypeId());
   }
 }


### PR DESCRIPTION
Added `add-ai-prompt-to-repository` cli command which allows a single AI prompt to be reused for multiple mojito repositories.

Updates were required to the database schema constraints to allow this as previously we were restricting uniqueness via prompt id and checker type.