### PR TITLE
Don't run multiple times for duplicate strings

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
@@ -25,8 +25,10 @@ import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,31 +58,38 @@ public class OpenAILLMService implements LLMService {
   boolean persistResults;
 
   @Timed("OpenAILLMService.executeAIChecks")
-  public AICheckResponse executeAIChecks(AICheckRequest AICheckRequest) {
+  public AICheckResponse executeAIChecks(AICheckRequest aiCheckRequest) {
 
     logger.debug("Executing OpenAI string checks.");
-    Repository repository = repositoryRepository.findByName(AICheckRequest.getRepositoryName());
+    Repository repository = repositoryRepository.findByName(aiCheckRequest.getRepositoryName());
 
     if (repository == null) {
-      logger.error("Repository not found: {}", AICheckRequest.getRepositoryName());
-      throw new AIException("Repository not found: " + AICheckRequest.getRepositoryName());
+      logger.error("Repository not found: {}", aiCheckRequest.getRepositoryName());
+      throw new AIException("Repository not found: " + aiCheckRequest.getRepositoryName());
     }
 
     List<AIPrompt> prompts =
         LLMPromptService.getPromptsByRepositoryAndPromptType(repository, SOURCE_STRING_CHECKER);
 
+    Set<String> sourceStrings = new HashSet<>();
     Map<String, List<AICheckResult>> results = new HashMap<>();
-    AICheckRequest.getTextUnits()
+    aiCheckRequest
+        .getTextUnits()
         .forEach(
             textUnit -> {
-              List<AICheckResult> AICheckResults = checkString(textUnit, prompts, repository);
-              results.put(textUnit.getSource(), AICheckResults);
+              // Only check each source string once, this prevents duplicate checks for the same
+              // source content i.e. plurals
+              if (!sourceStrings.contains(textUnit.getSource())) {
+                List<AICheckResult> aiCheckResults = checkString(textUnit, prompts, repository);
+                results.put(textUnit.getSource(), aiCheckResults);
+                sourceStrings.add(textUnit.getSource());
+              }
             });
 
-    AICheckResponse AICheckResponse = new AICheckResponse();
-    AICheckResponse.setResults(results);
+    AICheckResponse aiCheckResponse = new AICheckResponse();
+    aiCheckResponse.setResults(results);
 
-    return AICheckResponse;
+    return aiCheckResponse;
   }
 
   @Timed("OpenAILLMService.checkString")


### PR DESCRIPTION
Avoids running identical AI checks for text units with duplicate content in a request e.g. running a check for every plural form.