### PR TITLE
Add tiered cache for AI checks web service

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/okapi/extractor/AssetExtractorTextUnit.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/extractor/AssetExtractorTextUnit.java
@@ -1,8 +1,9 @@
 package com.box.l10n.mojito.okapi.extractor;
 
+import java.io.Serializable;
 import java.util.Set;
 
-public class AssetExtractorTextUnit {
+public class AssetExtractorTextUnit implements Serializable {
   String name;
   String source;
   String comments;

--- a/webapp/src/main/java/com/box/l10n/mojito/CacheType.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/CacheType.java
@@ -5,13 +5,15 @@ public enum CacheType {
   DEFAULT(Names.DEFAULT),
   LOCALES(Names.LOCALES),
   PLURAL_FORMS(Names.PLURAL_FORMS),
-  MACHINE_TRANSLATION(Names.MACHINE_TRANSLATION);
+  MACHINE_TRANSLATION(Names.MACHINE_TRANSLATION),
+  AI_CHECKS(Names.AI_CHECKS);
 
   public static class Names {
     public static final String DEFAULT = "default";
     public static final String LOCALES = "locales";
     public static final String PLURAL_FORMS = "pluralForms";
     public static final String MACHINE_TRANSLATION = "machineTranslation";
+    public static final String AI_CHECKS = "aiChecks";
   }
 
   CacheType(String cacheName) {

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AICheckRequest.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AICheckRequest.java
@@ -2,10 +2,11 @@ package com.box.l10n.mojito.rest.ai;
 
 import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AICheckRequest {
+public class AICheckRequest implements Serializable {
 
   private List<AssetExtractorTextUnit> textUnits;
   private String repositoryName;

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AICheckResponse.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AICheckResponse.java
@@ -1,11 +1,12 @@
 package com.box.l10n.mojito.rest.ai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AICheckResponse {
+public class AICheckResponse implements Serializable {
 
   boolean error;
 

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AICheckResult.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AICheckResult.java
@@ -1,9 +1,10 @@
 package com.box.l10n.mojito.rest.ai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AICheckResult {
+public class AICheckResult implements Serializable {
 
   boolean success;
   String suggestedFix;

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AIChecksWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/ai/AIChecksWS.java
@@ -1,11 +1,14 @@
 package com.box.l10n.mojito.rest.ai;
 
+import static com.box.l10n.mojito.CacheType.Names.AI_CHECKS;
+
 import com.box.l10n.mojito.service.ai.LLMService;
 import io.micrometer.core.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -21,6 +24,7 @@ public class AIChecksWS {
 
   @RequestMapping(value = "/api/ai/checks", method = RequestMethod.POST)
   @Timed("AIWS.executeAIChecks")
+  @Cacheable(AI_CHECKS)
   public AICheckResponse executeAIChecks(@RequestBody AICheckRequest AICheckRequest) {
     logger.debug("Received request to execute AI checks");
     AICheckResponse response;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/AIChecksCacheConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/AIChecksCacheConfiguration.java
@@ -1,0 +1,92 @@
+package com.box.l10n.mojito.service.ai;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for the tiered cache for the AI Checks service. The second tier cache (database) is
+ * optional and can be enabled/disabled. By default, the TTL is 0 (disabled).
+ *
+ * @author maallen
+ */
+@Configuration
+@ConfigurationProperties(prefix = "l10n.ai.checks.cache")
+public class AIChecksCacheConfiguration {
+
+  Database database = new Database();
+  InMemory inMemory = new InMemory();
+
+  public static class Database {
+    boolean enabled = false;
+    private boolean evictEntryOnDeserializationFailure;
+
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration ttl = Duration.ZERO;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public Duration getTtl() {
+      return ttl;
+    }
+
+    public void setTtl(Duration ttl) {
+      this.ttl = ttl;
+    }
+
+    public boolean isEvictEntryOnDeserializationFailure() {
+      return evictEntryOnDeserializationFailure;
+    }
+
+    public void setEvictEntryOnDeserializationFailure(boolean evictEntryOnDeserializationFailure) {
+      this.evictEntryOnDeserializationFailure = evictEntryOnDeserializationFailure;
+    }
+  }
+
+  public static class InMemory {
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration ttl = Duration.ZERO;
+
+    private long maximumSize = Long.MAX_VALUE;
+
+    public long getMaximumSize() {
+      return maximumSize;
+    }
+
+    public void setMaximumSize(long maximumSize) {
+      this.maximumSize = maximumSize;
+    }
+
+    public Duration getTtl() {
+      return ttl;
+    }
+
+    public void setTtl(Duration ttl) {
+      this.ttl = ttl;
+    }
+  }
+
+  public Database getDatabase() {
+    return database;
+  }
+
+  public void setDatabase(Database database) {
+    this.database = database;
+  }
+
+  public InMemory getInMemory() {
+    return inMemory;
+  }
+
+  public void setInMemory(InMemory inMemory) {
+    this.inMemory = inMemory;
+  }
+}


### PR DESCRIPTION
Adds a tiered cache to avoid duplicate checks for AI check requests. If the source string hasn't changed since the last request, return the cached response.