### PR TITLE
I18N-1075 Fix duplicate plurals error in Smartling push

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidPlural.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidPlural.java
@@ -1,9 +1,12 @@
 package com.box.l10n.mojito.android.strings;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -81,6 +84,37 @@ public class AndroidPlural extends AbstractAndroidString {
 
     public AndroidPlural build() {
       return new AndroidPlural(name, comment, items);
+    }
+
+    public boolean hasItemWithSameQuantityAndDifferentContent(AndroidPluralItem pluralItem) {
+      return this.items.stream()
+          .anyMatch(
+              item ->
+                  item.getQuantity().equals(pluralItem.getQuantity())
+                      && !item.getContent().equals(pluralItem.getContent()));
+    }
+
+    public Set<AndroidPluralQuantity> getMissingQuantities() {
+      Set<AndroidPluralQuantity> currentQuantities =
+          this.items.stream().map(AndroidPluralItem::getQuantity).collect(Collectors.toSet());
+      return Arrays.stream(AndroidPluralQuantity.values())
+          .filter(quantity -> !currentQuantities.contains(quantity))
+          .collect(Collectors.toSet());
+    }
+
+    public Optional<AndroidPluralItem> getItem(AndroidPluralQuantity quantity) {
+      return this.items.stream()
+          .filter(item -> item.getQuantity().equals(quantity))
+          .map(item -> new AndroidPluralItem(item.getId(), item.getQuantity(), item.getContent()))
+          .findFirst();
+    }
+
+    public int getItemsSize() {
+      return this.items.size();
+    }
+
+    public String getName() {
+      return this.name;
     }
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/android/strings/AndroidStringDocumentMapperTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/android/strings/AndroidStringDocumentMapperTest.java
@@ -9,6 +9,7 @@ import static com.box.l10n.mojito.android.strings.AndroidPluralQuantity.ZERO;
 import static com.box.l10n.mojito.android.strings.AndroidStringDocumentMapper.removeInvalidControlCharacter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.google.common.io.Resources;
@@ -781,5 +782,474 @@ public class AndroidStringDocumentMapperTest {
     }
 
     return textUnit;
+  }
+
+  @Test
+  public void testReadFromSourceTextUnitsWithDuplicatedOnePluralsWithDifferentContent() {
+    mapper = new AndroidStringDocumentMapper(" _", assetDelimiter);
+    textUnits.add(sourceTextUnitDTO(123L, "name0", "content0", "comment0", "my/path0", null, null));
+
+    textUnits.add(
+        sourceTextUnitDTO(
+            100L,
+            "name1 _other",
+            "content1_zero",
+            "comment1",
+            "my/path0.xml",
+            "zero",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            101L,
+            "name1 _other",
+            "content1_one",
+            "comment1",
+            "my/path0.xml",
+            "one",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            102L,
+            "name1 _other",
+            "content1_two",
+            "comment1",
+            "my/path0.xml",
+            "two",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            103L,
+            "name1 _other",
+            "content1_few",
+            "comment1",
+            "my/path0.xml",
+            "few",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            104L,
+            "name1 _other",
+            "content1_many",
+            "comment1",
+            "my/path0.xml",
+            "many",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            105L,
+            "name1 _other",
+            "content1_other",
+            "comment1",
+            "my/path0.xml",
+            "other",
+            "name1_other"));
+
+    textUnits.add(
+        sourceTextUnitDTO(
+            201L,
+            "name1 _other",
+            "content2_one",
+            "comment1",
+            "my/path0.xml",
+            "one",
+            "name1_other"));
+
+    document = mapper.readFromSourceTextUnits(textUnits);
+
+    assertThat(document).isNotNull();
+    assertThat(document.getSingulars()).hasSize(1);
+    AndroidSingular singular = document.getSingulars().getFirst();
+    assertThat(singular.getId()).isEqualTo(123L);
+    assertThat(singular.getName()).isEqualTo("my/path0#@#name0");
+    assertThat(singular.getContent()).isEqualTo("content0");
+    assertThat(singular.getComment()).isEqualTo("comment0");
+
+    assertThat(document.getPlurals()).hasSize(2);
+    AndroidPlural plural = document.getPlurals().getFirst();
+    assertThat(plural.getName()).isEqualTo("my/path0.xml#@#name1");
+    assertThat(plural.getComment()).isEqualTo("comment1");
+    assertThat(plural.getItems()).hasSize(6);
+
+    assertThat(plural.getName()).isEqualTo("my/path0.xml#@#name1");
+    assertThat(plural.getComment()).isEqualTo("comment1");
+    assertThat(plural.getItems()).hasSize(6);
+    assertThat(plural.getItems().get(ZERO).getId()).isEqualTo(100L);
+    assertThat(plural.getItems().get(ZERO).getContent()).isEqualTo("content1_zero");
+    assertThat(plural.getItems().get(ONE).getId()).isEqualTo(101L);
+    assertThat(plural.getItems().get(ONE).getContent()).isEqualTo("content1_one");
+    assertThat(plural.getItems().get(TWO).getId()).isEqualTo(102L);
+    assertThat(plural.getItems().get(TWO).getContent()).isEqualTo("content1_two");
+    assertThat(plural.getItems().get(FEW).getId()).isEqualTo(103L);
+    assertThat(plural.getItems().get(FEW).getContent()).isEqualTo("content1_few");
+    assertThat(plural.getItems().get(MANY).getId()).isEqualTo(104L);
+    assertThat(plural.getItems().get(MANY).getContent()).isEqualTo("content1_many");
+    assertThat(plural.getItems().get(OTHER).getId()).isEqualTo(105L);
+    assertThat(plural.getItems().get(OTHER).getContent()).isEqualTo("content1_other");
+
+    plural = document.getPlurals().get(1);
+    assertThat(plural.getName()).isEqualTo("my/path0.xml#@#name1###content2_one");
+    assertThat(plural.getComment()).isEqualTo("comment1");
+    assertThat(plural.getItems()).hasSize(6);
+    assertThat(plural.getItems().get(ZERO).getId()).isEqualTo(100L);
+    assertThat(plural.getItems().get(ZERO).getContent()).isEqualTo("content1_zero");
+    assertThat(plural.getItems().get(ONE).getId()).isEqualTo(201L);
+    assertThat(plural.getItems().get(ONE).getContent()).isEqualTo("content2_one");
+    assertThat(plural.getItems().get(TWO).getId()).isEqualTo(102L);
+    assertThat(plural.getItems().get(TWO).getContent()).isEqualTo("content1_two");
+    assertThat(plural.getItems().get(FEW).getId()).isEqualTo(103L);
+    assertThat(plural.getItems().get(FEW).getContent()).isEqualTo("content1_few");
+    assertThat(plural.getItems().get(MANY).getId()).isEqualTo(104L);
+    assertThat(plural.getItems().get(MANY).getContent()).isEqualTo("content1_many");
+    assertThat(plural.getItems().get(OTHER).getId()).isEqualTo(105L);
+    assertThat(plural.getItems().get(OTHER).getContent()).isEqualTo("content1_other");
+  }
+
+  @Test
+  public void testReadFromSourceTextUnitsWithDuplicatedOtherPluralsWithDifferentContent() {
+    mapper = new AndroidStringDocumentMapper(" _", assetDelimiter);
+    textUnits.add(sourceTextUnitDTO(123L, "name0", "content0", "comment0", "my/path0", null, null));
+
+    textUnits.add(
+        sourceTextUnitDTO(
+            100L,
+            "name1 _other",
+            "content1_zero",
+            "comment1",
+            "my/path0.xml",
+            "zero",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            101L,
+            "name1 _other",
+            "content1_one",
+            "comment1",
+            "my/path0.xml",
+            "one",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            102L,
+            "name1 _other",
+            "content1_two",
+            "comment1",
+            "my/path0.xml",
+            "two",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            103L,
+            "name1 _other",
+            "content1_few",
+            "comment1",
+            "my/path0.xml",
+            "few",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            104L,
+            "name1 _other",
+            "content1_many",
+            "comment1",
+            "my/path0.xml",
+            "many",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            105L,
+            "name1 _other",
+            "content1_other",
+            "comment1",
+            "my/path0.xml",
+            "other",
+            "name1_other"));
+
+    textUnits.add(
+        sourceTextUnitDTO(
+            200L,
+            "name1 _other",
+            "content2_zero",
+            "comment1",
+            "my/path0.xml",
+            "zero",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            202L,
+            "name1 _other",
+            "content2_two",
+            "comment1",
+            "my/path0.xml",
+            "two",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            203L,
+            "name1 _other",
+            "content2_few",
+            "comment1",
+            "my/path0.xml",
+            "few",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            204L,
+            "name1 _other",
+            "content2_many",
+            "comment1",
+            "my/path0.xml",
+            "many",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            205L,
+            "name1 _other",
+            "content2_other",
+            "comment1",
+            "my/path0.xml",
+            "other",
+            "name1_other"));
+
+    document = mapper.readFromSourceTextUnits(textUnits);
+
+    assertThat(document).isNotNull();
+    assertThat(document.getSingulars()).hasSize(1);
+    AndroidSingular singular = document.getSingulars().get(0);
+    assertThat(singular.getId()).isEqualTo(123L);
+    assertThat(singular.getName()).isEqualTo("my/path0#@#name0");
+    assertThat(singular.getContent()).isEqualTo("content0");
+    assertThat(singular.getComment()).isEqualTo("comment0");
+
+    assertThat(document.getPlurals()).hasSize(2);
+    AndroidPlural plural = document.getPlurals().getFirst();
+    assertThat(plural.getName()).isEqualTo("my/path0.xml#@#name1");
+    assertThat(plural.getComment()).isEqualTo("comment1");
+    assertThat(plural.getItems()).hasSize(6);
+
+    assertThat(plural.getName()).isEqualTo("my/path0.xml#@#name1");
+    assertThat(plural.getComment()).isEqualTo("comment1");
+    assertThat(plural.getItems()).hasSize(6);
+    assertThat(plural.getItems().get(ZERO).getId()).isEqualTo(100L);
+    assertThat(plural.getItems().get(ZERO).getContent()).isEqualTo("content1_zero");
+    assertThat(plural.getItems().get(ONE).getId()).isEqualTo(101L);
+    assertThat(plural.getItems().get(ONE).getContent()).isEqualTo("content1_one");
+    assertThat(plural.getItems().get(TWO).getId()).isEqualTo(102L);
+    assertThat(plural.getItems().get(TWO).getContent()).isEqualTo("content1_two");
+    assertThat(plural.getItems().get(FEW).getId()).isEqualTo(103L);
+    assertThat(plural.getItems().get(FEW).getContent()).isEqualTo("content1_few");
+    assertThat(plural.getItems().get(MANY).getId()).isEqualTo(104L);
+    assertThat(plural.getItems().get(MANY).getContent()).isEqualTo("content1_many");
+    assertThat(plural.getItems().get(OTHER).getId()).isEqualTo(105L);
+    assertThat(plural.getItems().get(OTHER).getContent()).isEqualTo("content1_other");
+
+    plural = document.getPlurals().get(1);
+    assertThat(plural.getName()).isEqualTo("my/path0.xml#@#name1");
+    assertThat(plural.getComment()).isEqualTo("comment1");
+    assertThat(plural.getItems()).hasSize(6);
+    assertThat(plural.getItems().get(ZERO).getId()).isEqualTo(200L);
+    assertThat(plural.getItems().get(ZERO).getContent()).isEqualTo("content2_zero");
+    assertThat(plural.getItems().get(ONE).getId()).isEqualTo(101L);
+    assertThat(plural.getItems().get(ONE).getContent()).isEqualTo("content1_one");
+    assertThat(plural.getItems().get(TWO).getId()).isEqualTo(202L);
+    assertThat(plural.getItems().get(TWO).getContent()).isEqualTo("content2_two");
+    assertThat(plural.getItems().get(FEW).getId()).isEqualTo(203L);
+    assertThat(plural.getItems().get(FEW).getContent()).isEqualTo("content2_few");
+    assertThat(plural.getItems().get(MANY).getId()).isEqualTo(204L);
+    assertThat(plural.getItems().get(MANY).getContent()).isEqualTo("content2_many");
+    assertThat(plural.getItems().get(OTHER).getId()).isEqualTo(205L);
+    assertThat(plural.getItems().get(OTHER).getContent()).isEqualTo("content2_other");
+  }
+
+  @Test
+  public void testReadFromSourceTextUnitsWithDuplicatedOnePlurals() {
+    mapper = new AndroidStringDocumentMapper(" _", assetDelimiter);
+    textUnits.add(sourceTextUnitDTO(123L, "name0", "content0", "comment0", "my/path0", null, null));
+
+    textUnits.add(
+        sourceTextUnitDTO(
+            100L,
+            "name1 _other",
+            "content1_zero",
+            "comment1",
+            "my/path0.xml",
+            "zero",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            101L,
+            "name1 _other",
+            "content1_one",
+            "comment1",
+            "my/path0.xml",
+            "one",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            102L,
+            "name1 _other",
+            "content1_two",
+            "comment1",
+            "my/path0.xml",
+            "two",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            103L,
+            "name1 _other",
+            "content1_few",
+            "comment1",
+            "my/path0.xml",
+            "few",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            104L,
+            "name1 _other",
+            "content1_many",
+            "comment1",
+            "my/path0.xml",
+            "many",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            105L,
+            "name1 _other",
+            "content1_other",
+            "comment1",
+            "my/path0.xml",
+            "other",
+            "name1_other"));
+
+    textUnits.add(
+        sourceTextUnitDTO(
+            201L,
+            "name1 _other",
+            "content1_one",
+            "comment1",
+            "my/path0.xml",
+            "one",
+            "name1_other"));
+
+    assertThrows(
+        AndroidPluralDuplicateKeyException.class, () -> mapper.readFromSourceTextUnits(textUnits));
+  }
+
+  @Test
+  public void testReadFromSourceTextUnitsWithDuplicatedOtherPlurals() {
+    mapper = new AndroidStringDocumentMapper(" _", assetDelimiter);
+    textUnits.add(sourceTextUnitDTO(123L, "name0", "content0", "comment0", "my/path0", null, null));
+
+    textUnits.add(
+        sourceTextUnitDTO(
+            100L,
+            "name1 _other",
+            "content1_zero",
+            "comment1",
+            "my/path0.xml",
+            "zero",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            101L,
+            "name1 _other",
+            "content1_one",
+            "comment1",
+            "my/path0.xml",
+            "one",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            102L,
+            "name1 _other",
+            "content1_two",
+            "comment1",
+            "my/path0.xml",
+            "two",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            103L,
+            "name1 _other",
+            "content1_few",
+            "comment1",
+            "my/path0.xml",
+            "few",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            104L,
+            "name1 _other",
+            "content1_many",
+            "comment1",
+            "my/path0.xml",
+            "many",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            105L,
+            "name1 _other",
+            "content1_other",
+            "comment1",
+            "my/path0.xml",
+            "other",
+            "name1_other"));
+
+    textUnits.add(
+        sourceTextUnitDTO(
+            200L,
+            "name1 _other",
+            "content1_zero",
+            "comment1",
+            "my/path0.xml",
+            "zero",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            201L,
+            "name1 _other",
+            "content1_one",
+            "comment1",
+            "my/path0.xml",
+            "one",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            202L,
+            "name1 _other",
+            "content1_two",
+            "comment1",
+            "my/path0.xml",
+            "two",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            203L,
+            "name1 _other",
+            "content1_few",
+            "comment1",
+            "my/path0.xml",
+            "few",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            204L,
+            "name1 _other",
+            "content1_many",
+            "comment1",
+            "my/path0.xml",
+            "many",
+            "name1_other"));
+    textUnits.add(
+        sourceTextUnitDTO(
+            205L,
+            "name1 _other",
+            "content1_other",
+            "comment1",
+            "my/path0.xml",
+            "other",
+            "name1_other"));
+
+    assertThrows(
+        AndroidPluralDuplicateKeyException.class, () -> mapper.readFromSourceTextUnits(textUnits));
   }
 }


### PR DESCRIPTION
The duplicate plurals error in Smarling push was fixed for cases where only the source string was modified