### PR TITLE
Changed logic of Span Translate Integrity Checker

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/SpanTranslateTagIntegrityChecker.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/SpanTranslateTagIntegrityChecker.java
@@ -17,11 +17,14 @@ public class SpanTranslateTagIntegrityChecker extends RegexIntegrityChecker {
 
   @Override
   public String getRegex() {
-    return "<.*span translate[^>]*>";
+    return "<span[^>]*translate[^>]*>";
   }
 
   @Override
   public void check(String sourceContent, String targetContent) throws IntegrityCheckException {
+    // Source and target both have span tag, return
+    if (matchesRegex(sourceContent) && matchesRegex(targetContent)) return;
+    // Target doesn't have span tag, return
     if (!matchesRegex(targetContent)) return;
 
     SpanTranslateTagIntegrityCheckerException spanTranslateException =

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/SpanTranslateTagIntegrityCheckerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/SpanTranslateTagIntegrityCheckerTest.java
@@ -14,7 +14,7 @@ public class SpanTranslateTagIntegrityCheckerTest {
   SpanTranslateTagIntegrityChecker checker = new SpanTranslateTagIntegrityChecker();
 
   @Test
-  public void testWorksWithNoTag() {
+  public void testWithNoTags() {
     String source = "This is testing the translate tag checker.";
     String target = "Ceci teste le vérificateur de balises de traduction";
 
@@ -22,7 +22,7 @@ public class SpanTranslateTagIntegrityCheckerTest {
   }
 
   @Test
-  public void testWorksNormalTag() {
+  public void testNormalTag() {
     String source = "This is testing the <span>translate</span> tag checker.";
     String target = "Ceci teste le vérificateur de balises de <span>traduction</span>";
 
@@ -30,10 +30,59 @@ public class SpanTranslateTagIntegrityCheckerTest {
   }
 
   @Test
+  public void testBothTag() {
+    String source = "This is testing the <span translate=\"no\">translate</span> tag checker.";
+    String target =
+        "Ceci teste le vérificateur de balises de <span translate=\"no\">traduction</span>";
+
+    try {
+      checker.check(source, target);
+    } catch (IntegrityCheckException e) {
+      fail("Check shouldn't fail with span translate tag in both tags.");
+    }
+  }
+
+  @Test
+  public void testOneTag() {
+    String source = "This is testing the <span translate=\"no\">translate</span> tag checker.";
+    String target = "Ceci teste le vérificateur de balises de traduction";
+
+    try {
+      checker.check(source, target);
+    } catch (IntegrityCheckException e) {
+      fail("Check shouldn't fail with span translate tag only in source text.");
+    }
+  }
+
+  @Test
   public void testThrowsWithTag() {
     String source = "This is testing the translate tag checker.";
     String target =
-        "Ceci teste le <span translate=\"no\">vérificateur</span> de balises de traduction";
+        "Ceci teste le vérificateur de balises de <span translate=\"no\">traduction</span>";
+
+    try {
+      checker.check(source, target);
+      fail("Check should fail if span tag is in target but not source.");
+    } catch (IntegrityCheckException e) {
+    }
+  }
+
+  @Test
+  public void testThrowsWithNoClosingTag() {
+    String source = "This is testing the translate tag checker.";
+    String target = "Ceci teste le <span translate=\"no\">vérificateur de balises de traduction";
+
+    try {
+      checker.check(source, target);
+      fail("Check should fail with span translate opening tag in target string.");
+    } catch (IntegrityCheckException e) {
+    }
+  }
+
+  @Test
+  public void testRightToLeftTag() {
+    String source = "This is testing the translate tag checker.";
+    String target = "يتم الآن اختبار <span translate=\"no\">مدقق</span> علامات الترجمة.";
 
     try {
       checker.check(source, target);
@@ -43,14 +92,26 @@ public class SpanTranslateTagIntegrityCheckerTest {
   }
 
   @Test
-  public void testBackwardsTag() {
-    String source = "This is testing the translate tag checker.";
+  public void testRightToLeftTagOne() {
+    String source = "This is testing the <span translate=\"no\">translate</span> tag checker.";
+    String target = "يتم الآن اختبار مدقق علامات الترجمة.";
+
+    try {
+      checker.check(source, target);
+    } catch (IntegrityCheckException e) {
+      fail("Check shouldn't fail with span translate tag in just the source tag.");
+    }
+  }
+
+  @Test
+  public void testRightToLeftTagBoth() {
+    String source = "This is testing the <span translate=\"no\">translate</span> tag checker.";
     String target = "يتم الآن اختبار <span translate=\"no\">مدقق</span> علامات الترجمة.";
 
     try {
       checker.check(source, target);
-      fail("Check should fail with span translate tag in target string.");
     } catch (IntegrityCheckException e) {
+      fail("Check shouldn't fail with span translate tag in both target and source.");
     }
   }
 }


### PR DESCRIPTION
If the target and source both have translate instructions the checker will not throw an error.

Cleaned up the regex. The Arabic text units (right to left unit tests) match correctly even if it appears the quote is at the start of the span tag.

Added unit tests to test that no error will be thrown if the target and source have the span tags.