### PR TITLE
I18N-1292: Fix serialization issue of Smartling errors

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
@@ -346,6 +346,9 @@ public class SmartlingClient {
 
       try (CloseableHttpResponse response = httpclient.execute(uploadFileMethod)) {
         String responseBody = EntityUtils.toString(response.getEntity());
+        if (response.getCode() != 200 && response.getCode() != 202) {
+          logger.error("Error uploading file with code '{}': {}", response.getCode(), responseBody);
+        }
         FileUploadResponse fileUploadResponse =
             objectMapper.readValue(responseBody, FileUploadResponse.class);
 

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/Error.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/Error.java
@@ -1,6 +1,6 @@
 package com.box.l10n.mojito.smartling.response;
 
-public class Errors {
+public class Error {
   private String key;
   private String message;
   private String details;

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/Response.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/Response.java
@@ -1,13 +1,14 @@
 package com.box.l10n.mojito.smartling.response;
 
 import com.fasterxml.jackson.annotation.JsonRootName;
+import java.util.List;
 
 @JsonRootName("response")
 public class Response<T> {
 
   String code;
   T data;
-  Errors[] errors;
+  List<Error> errors;
 
   public String getCode() {
     return code;
@@ -25,11 +26,11 @@ public class Response<T> {
     this.data = data;
   }
 
-  public Errors[] getErrors() {
+  public List<Error> getErrors() {
     return errors;
   }
 
-  public void setErrors(Errors[] errors) {
+  public void setErrors(List<Error> errors) {
     this.errors = errors;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/Response.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/Response.java
@@ -7,7 +7,7 @@ public class Response<T> {
 
   String code;
   T data;
-  Errors errors;
+  Errors[] errors;
 
   public String getCode() {
     return code;
@@ -25,11 +25,11 @@ public class Response<T> {
     this.data = data;
   }
 
-  public Errors getErrors() {
+  public Errors[] getErrors() {
     return errors;
   }
 
-  public void setErrors(Errors errors) {
+  public void setErrors(Errors[] errors) {
     this.errors = errors;
   }
 }


### PR DESCRIPTION
Smartling errors are actually an array of `Errors` and not a single object. See [smartling docs](https://help.smartling.com/hc/en-us/articles/1260805481410-Error-Codes)

Additionally, update code to log all Smartling errors so that they are not swallowed (if the serialization does fail)