### PR TITLE
I18N-1292: Fix deserialization error that was obfuscating third-party sync error responses

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/Error.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/Error.java
@@ -1,9 +1,11 @@
 package com.box.l10n.mojito.smartling.response;
 
+import java.util.Map;
+
 public class Error {
   private String key;
   private String message;
-  private String details;
+  private Map<String, String> details;
 
   public void setKey(String key) {
     this.key = key;
@@ -21,11 +23,11 @@ public class Error {
     return this.message;
   }
 
-  public void setDetails(String details) {
+  public void setDetails(Map<String, String> details) {
     this.details = details;
   }
 
-  public String getDetails() {
+  public Map<String, String> getDetails() {
     return this.details;
   }
 }


### PR DESCRIPTION
This PR fixes the deserialization issue that would hide important logging information when a third-party sync would fail.