### PR TITLE
I18N-1293 - Invalid text unit info modal if browser back button used

### DIFF
--- a/webapp/src/main/resources/public/js/components/workbench/Workbench.js
+++ b/webapp/src/main/resources/public/js/components/workbench/Workbench.js
@@ -26,7 +26,12 @@ import AuthorityService from "../../utils/AuthorityService";
 
 let Workbench = createReactClass({
     displayName: 'Workbench',
-
+    componentWillUnmount() {
+        GitBlameActions.close();
+        GitBlameScreenshotViewerActions.closeScreenshotsViewer();
+        TranslationHistoryActions.close();
+        ShareSearchParamsModalActions.close();
+    },
     render: function () {
         return (
             <div>


### PR DESCRIPTION
Hid all the modals when the workbench component is unmounted