### PR TITLE
I18N-1305: Added block list for Slack usernames that shouldn't receive branch notifications

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSender.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSender.java
@@ -17,4 +17,6 @@ public interface BranchNotificationMessageSender {
       throws BranchNotificationMessageSenderException;
 
   String getId();
+
+  boolean isUserAllowed(String username);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenders.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenders.java
@@ -160,7 +160,8 @@ public class BranchNotificationMessageSenders {
                           branchNotificationMessageBuilderSlack,
                           slackConfigurationProperties.getUserEmailPattern(),
                           slackConfigurationProperties.isUseDirectMessage(),
-                          slackConfigurationProperties.isGithubPR());
+                          slackConfigurationProperties.isGithubPR(),
+                          slackConfigurationProperties.getBlockedUsernames());
 
                   return new SimpleEntry<String, BranchNotificationMessageSenderSlack>(
                       id, branchNotificationMessageSenderSlack);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenders.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenders.java
@@ -22,8 +22,11 @@ import com.box.l10n.mojito.slack.SlackClients;
 import com.box.l10n.mojito.thirdpartynotification.slack.SlackChannels;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
@@ -128,12 +131,31 @@ public class BranchNotificationMessageSenders {
           branchNotificationMessageSendersConfigurationProperties,
       SlackClients slackClients,
       BranchUrlBuilder branchUrlBuilder) {
+
     Map<String, BranchNotificationMessageSenderSlack> slack =
         branchNotificationMessageSendersConfigurationProperties.getSlack().entrySet().stream()
             .map(
                 e -> {
                   String id = e.getKey();
                   SlackConfigurationProperties slackConfigurationProperties = e.getValue();
+
+                  List<Pattern> blockedUserPatterns =
+                      slackConfigurationProperties.getBlockedUsernames().stream()
+                          .map(
+                              regex -> {
+                                try {
+                                  return Pattern.compile(regex);
+                                } catch (PatternSyntaxException ex) {
+                                  throw new IllegalStateException(
+                                      "Invalid regex: '"
+                                          + regex
+                                          + "' in blocked usernames list for Slack client '"
+                                          + slackConfigurationProperties.getSlackClientId()
+                                          + "'",
+                                      ex);
+                                }
+                              })
+                          .collect(Collectors.toList());
 
                   SlackClient slackClient =
                       slackClients.getById(slackConfigurationProperties.getSlackClientId());
@@ -161,7 +183,7 @@ public class BranchNotificationMessageSenders {
                           slackConfigurationProperties.getUserEmailPattern(),
                           slackConfigurationProperties.isUseDirectMessage(),
                           slackConfigurationProperties.isGithubPR(),
-                          slackConfigurationProperties.getBlockedUsernames());
+                          blockedUserPatterns);
 
                   return new SimpleEntry<String, BranchNotificationMessageSenderSlack>(
                       id, branchNotificationMessageSenderSlack);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersConfigurationProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersConfigurationProperties.java
@@ -1,6 +1,8 @@
 package com.box.l10n.mojito.service.branch.notification;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -73,6 +75,8 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
     boolean githubPR = false;
 
+    List<String> blockedUsernames = new ArrayList<>();
+
     public String getSlackClientId() {
       return slackClientId;
     }
@@ -111,6 +115,14 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
     public void setGithubPR(boolean githubPR) {
       this.githubPR = githubPR;
+    }
+
+    public List<String> getBlockedUsernames() {
+      return blockedUsernames;
+    }
+
+    public void setBlockedUsernames(List<String> blockedUsernames) {
+      this.blockedUsernames = blockedUsernames;
     }
 
     public static class MessageBuilderConfigurationProperties {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
@@ -16,10 +16,12 @@ import com.box.l10n.mojito.service.branch.BranchStatisticService;
 import com.box.l10n.mojito.service.branch.BranchTextUnitStatisticRepository;
 import com.box.l10n.mojito.service.branch.notification.job.BranchNotificationMissingScreenshotsJob;
 import com.box.l10n.mojito.service.branch.notification.job.BranchNotificationMissingScreenshotsJobInput;
+import com.box.l10n.mojito.service.branch.notification.slack.BranchNotificationMessageSenderSlack;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.utils.DateTimeUtils;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -153,6 +155,15 @@ public class BranchNotificationService {
         branch.getName(),
         notifierId);
     BranchNotification branchNotification = getOrCreateBranchNotification(branch, notifierId);
+
+    if (branchNotificationMessageSender
+        instanceof BranchNotificationMessageSenderSlack branchNotificationMessageSenderSlack) {
+      String userName = getUsername(branch);
+      if (Strings.isNullOrEmpty(userName)
+          || branchNotificationMessageSenderSlack.isUsernameBlocked(userName)) {
+        return;
+      }
+    }
 
     if (shouldSendNewMessage(branchNotification, branchNotificationInfo)) {
       sendNewMessage(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
@@ -156,6 +156,7 @@ public class BranchNotificationService {
         notifierId);
     BranchNotification branchNotification = getOrCreateBranchNotification(branch, notifierId);
 
+    // Check if the username for the Slack notification is in the block list
     if (branchNotificationMessageSender
         instanceof BranchNotificationMessageSenderSlack branchNotificationMessageSenderSlack) {
       String userName = getUsername(branch);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
@@ -16,7 +16,6 @@ import com.box.l10n.mojito.service.branch.BranchStatisticService;
 import com.box.l10n.mojito.service.branch.BranchTextUnitStatisticRepository;
 import com.box.l10n.mojito.service.branch.notification.job.BranchNotificationMissingScreenshotsJob;
 import com.box.l10n.mojito.service.branch.notification.job.BranchNotificationMissingScreenshotsJobInput;
-import com.box.l10n.mojito.service.branch.notification.slack.BranchNotificationMessageSenderSlack;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.utils.DateTimeUtils;
 import com.google.common.base.Joiner;
@@ -148,13 +147,11 @@ public class BranchNotificationService {
       Branch branch,
       BranchNotificationInfo branchNotificationInfo) {
     // Check if the username for the Slack notification is in the block list
-    if (branchNotificationMessageSender
-        instanceof BranchNotificationMessageSenderSlack branchNotificationMessageSenderSlack) {
-      String userName = getUsername(branch);
-      if (Strings.isNullOrEmpty(userName)
-          || branchNotificationMessageSenderSlack.isUsernameBlocked(userName)) {
-        return;
-      }
+
+    String username = getUsername(branch);
+    if (Strings.isNullOrEmpty(username)
+        || !branchNotificationMessageSender.isUserAllowed(username)) {
+      return;
     }
 
     String notifierId = branchNotificationMessageSender.getId();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
@@ -147,15 +147,6 @@ public class BranchNotificationService {
       BranchNotificationMessageSender branchNotificationMessageSender,
       Branch branch,
       BranchNotificationInfo branchNotificationInfo) {
-    String notifierId = branchNotificationMessageSender.getId();
-
-    logger.debug(
-        "sendNotificationsForBranch: {} ({} with sender: {})",
-        branch.getId(),
-        branch.getName(),
-        notifierId);
-    BranchNotification branchNotification = getOrCreateBranchNotification(branch, notifierId);
-
     // Check if the username for the Slack notification is in the block list
     if (branchNotificationMessageSender
         instanceof BranchNotificationMessageSenderSlack branchNotificationMessageSenderSlack) {
@@ -165,6 +156,15 @@ public class BranchNotificationService {
         return;
       }
     }
+
+    String notifierId = branchNotificationMessageSender.getId();
+
+    logger.debug(
+        "sendNotificationsForBranch: {} ({} with sender: {})",
+        branch.getId(),
+        branch.getName(),
+        notifierId);
+    BranchNotification branchNotification = getOrCreateBranchNotification(branch, notifierId);
 
     if (shouldSendNewMessage(branchNotification, branchNotificationInfo)) {
       sendNewMessage(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageSenderGithub.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageSenderGithub.java
@@ -134,4 +134,9 @@ public class BranchNotificationMessageSenderGithub implements BranchNotification
   public String getId() {
     return id;
   }
+
+  @Override
+  public boolean isUserAllowed(String username) {
+    return true;
+  }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/noop/BranchNotificationMessageSenderNoop.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/noop/BranchNotificationMessageSenderNoop.java
@@ -49,4 +49,9 @@ public class BranchNotificationMessageSenderNoop implements BranchNotificationMe
   public String getId() {
     return id;
   }
+
+  @Override
+  public boolean isUserAllowed(String username) {
+    return true;
+  }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationMessageSenderPhabricator.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationMessageSenderPhabricator.java
@@ -104,4 +104,9 @@ public class BranchNotificationMessageSenderPhabricator implements BranchNotific
   public String getId() {
     return id;
   }
+
+  @Override
+  public boolean isUserAllowed(String username) {
+    return true;
+  }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageSenderSlack.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageSenderSlack.java
@@ -30,7 +30,7 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
   boolean useDirectMessage;
   boolean githubPR;
 
-  List<String> blockedUsernames;
+  List<Pattern> blockedUserPatterns;
 
   public BranchNotificationMessageSenderSlack(
       String id,
@@ -40,7 +40,7 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
       String userEmailPattern,
       boolean useDirectMessage,
       boolean isGithubPR,
-      List<String> blockedUsernames) {
+      List<Pattern> blockedUserPatterns) {
     this.id = id;
     this.slackClient = Preconditions.checkNotNull(slackClient);
     this.slackChannels = Preconditions.checkNotNull(slackChannels);
@@ -49,7 +49,7 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
     this.userEmailPattern = Preconditions.checkNotNull(userEmailPattern);
     this.useDirectMessage = useDirectMessage;
     this.githubPR = isGithubPR;
-    this.blockedUsernames = blockedUsernames;
+    this.blockedUserPatterns = blockedUserPatterns;
   }
 
   @Override
@@ -131,19 +131,18 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
     }
   }
 
-  public boolean isUsernameBlocked(String username) {
-    for (String blockedUsernameRegex : blockedUsernames) {
-      if (Pattern.compile(blockedUsernameRegex, Pattern.CASE_INSENSITIVE)
-          .matcher(username)
-          .matches()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   @Override
   public String getId() {
     return id;
+  }
+
+  @Override
+  public boolean isUserAllowed(String username) {
+    for (Pattern blockedUserPattern : blockedUserPatterns) {
+      if (blockedUserPattern.matcher(username).matches()) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageSenderSlack.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageSenderSlack.java
@@ -11,6 +11,7 @@ import com.box.l10n.mojito.slack.response.ChatPostMessageResponse;
 import com.box.l10n.mojito.thirdpartynotification.slack.SlackChannels;
 import com.google.common.base.Preconditions;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 
 public class BranchNotificationMessageSenderSlack implements BranchNotificationMessageSender {
@@ -29,6 +30,8 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
   boolean useDirectMessage;
   boolean githubPR;
 
+  List<String> blockedUsernames;
+
   public BranchNotificationMessageSenderSlack(
       String id,
       SlackClient slackClient,
@@ -36,7 +39,8 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
       BranchNotificationMessageBuilderSlack branchNotificationMessageBuilderSlack,
       String userEmailPattern,
       boolean useDirectMessage,
-      boolean isGithubPR) {
+      boolean isGithubPR,
+      List<String> blockedUsernames) {
     this.id = id;
     this.slackClient = Preconditions.checkNotNull(slackClient);
     this.slackChannels = Preconditions.checkNotNull(slackChannels);
@@ -45,6 +49,7 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
     this.userEmailPattern = Preconditions.checkNotNull(userEmailPattern);
     this.useDirectMessage = useDirectMessage;
     this.githubPR = isGithubPR;
+    this.blockedUsernames = blockedUsernames;
   }
 
   @Override
@@ -124,6 +129,17 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
     } catch (SlackClientException sce) {
       throw new BranchNotificationMessageSenderException(sce);
     }
+  }
+
+  public boolean isUsernameBlocked(String username) {
+    for (String blockedUsernameRegex : blockedUsernames) {
+      if (Pattern.compile(blockedUsernameRegex, Pattern.CASE_INSENSITIVE)
+          .matcher(username)
+          .matches()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -206,6 +206,9 @@ spring.session.jdbc.table-name=SPRING_SESSION_V2
 # Notification for branch activity
 #l10n.branchNotification.slack.enabled=true
 #l10n.branchNotification.slack.userEmailPattern={0}@test.com
+# Blocked usernames to not send Slack messages to (Regex works here and usernames can be seperated by commas)
+#l10n.branchNotification.slack.blockedUsernames=bot-number-001,jenkins-bot,.*\\[bot\\]$
+
 #l10n.branchNotification.phabricator.enabled=true
 #l10n.branchNotification.phabricator.reviewer=PHID-PROJ-xyz
 #l10n.branchNotification.phabricator.blockingReview=true
@@ -262,5 +265,4 @@ spring.session.jdbc.table-name=SPRING_SESSION_V2
 # l10n.pagerduty.retry.minBackOffDelay=500
 # Maximum back off delay in milliseconds
 # l10n.pagerduty.retry.maxBackOffDelay=5000
-
 

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -207,7 +207,7 @@ spring.session.jdbc.table-name=SPRING_SESSION_V2
 #l10n.branchNotification.slack.enabled=true
 #l10n.branchNotification.slack.userEmailPattern={0}@test.com
 # Blocked usernames to not send Slack messages to (Regex works here and usernames can be seperated by commas)
-#l10n.branchNotification.slack.blockedUsernames=bot-number-001,jenkins-bot,.*\\[bot\\]$
+#l10n.branchNotification.slack.blockedUsernames=bot-number-001,jenkins-bot,.*\\\[bot\\\]$
 
 #l10n.branchNotification.phabricator.enabled=true
 #l10n.branchNotification.phabricator.reviewer=PHID-PROJ-xyz


### PR DESCRIPTION
This PR adds a block list to the application.properties that stops the Slack branch notifier from attempting to send messages to usernames in that list. Usernames are separated by commas and regex can be used in the block list to match names.
This is useful for ensuring bot accounts on GH can be excluded when attempting to send a Slack message.