### PR TITLE
AI translation updates to TMTextUnitSearcher and store uploaded file uri in mapping step

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/ThirdPartyTextUnit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/ThirdPartyTextUnit.java
@@ -41,6 +41,9 @@ public class ThirdPartyTextUnit extends AuditableEntity {
       foreignKey = @ForeignKey(name = "FK__THIRD_PARTY_TEXT_UNIT__TM_TEXT_UNIT__ID"))
   TMTextUnit tmTextUnit;
 
+  @Column(name = "uploaded_file_uri")
+  String uploadedFileUri;
+
   public String getThirdPartyId() {
     return thirdPartyId;
   }
@@ -63,5 +66,13 @@ public class ThirdPartyTextUnit extends AuditableEntity {
 
   public void setAsset(Asset asset) {
     this.asset = asset;
+  }
+
+  public String getUploadedFileUri() {
+    return uploadedFileUri;
+  }
+
+  public void setUploadedFileUri(String uploadedFileUri) {
+    this.uploadedFileUri = uploadedFileUri;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -361,6 +361,8 @@ public class ThirdPartyService {
                             thirdPartyTextUnit.setThirdPartyId(
                                 thirdPartyTextUnitForMapping.getId());
                             thirdPartyTextUnit.setAsset(asset);
+                            thirdPartyTextUnit.setUploadedFileUri(
+                                thirdPartyTextUnitForMapping.getUploadedFileUri());
                             TMTextUnit tmTextUnit = tmTextUnitRepository.getOne(tmTextUnitId);
 
                             if (tmTextUnitAlreadySaved.containsKey(tmTextUnitId)) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -12,6 +12,7 @@ import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
+import com.box.l10n.mojito.service.ai.translation.AITranslationConfiguration;
 import com.box.l10n.mojito.service.assetExtraction.AssetTextUnitToTMTextUnitRepository;
 import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.thirdparty.smartling.SmartlingFile;
@@ -42,6 +43,7 @@ import com.google.common.io.Files;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -100,6 +102,8 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
 
   private final QuartzPollableTaskScheduler quartzPollableTaskScheduler;
 
+  private final AITranslationConfiguration aiTranslationConfiguration;
+
   private final Set<String> supportedImageExtensions =
       Sets.newHashSet("png", "jpg", "jpeg", "gif", "tiff");
 
@@ -118,7 +122,8 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
       ThirdPartyTMSSmartlingGlossary thirdPartyTMSSmartlingGlossary,
       AssetTextUnitToTMTextUnitRepository assetTextUnitToTMTextUnitRepository,
       MeterRegistry meterRegistry,
-      QuartzPollableTaskScheduler quartzPollableTaskScheduler) {
+      QuartzPollableTaskScheduler quartzPollableTaskScheduler,
+      AITranslationConfiguration aiTranslationConfiguration) {
     this(
         smartlingClient,
         textUnitSearcher,
@@ -130,7 +135,8 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
         assetTextUnitToTMTextUnitRepository,
         DEFAULT_BATCH_SIZE,
         meterRegistry,
-        quartzPollableTaskScheduler);
+        quartzPollableTaskScheduler,
+        aiTranslationConfiguration);
   }
 
   public ThirdPartyTMSSmartling(
@@ -144,7 +150,8 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
       AssetTextUnitToTMTextUnitRepository assetTextUnitToTMTextUnitRepository,
       int batchSize,
       MeterRegistry meterRegistry,
-      QuartzPollableTaskScheduler quartzPollableTaskScheduler) {
+      QuartzPollableTaskScheduler quartzPollableTaskScheduler,
+      AITranslationConfiguration aiTranslationConfiguration) {
     this.smartlingClient = smartlingClient;
     this.assetPathAndTextUnitNameKeys = assetPathAndTextUnitNameKeys;
     this.textUnitBatchImporterService = textUnitBatchImporterService;
@@ -156,6 +163,7 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
     this.assetTextUnitToTMTextUnitRepository = assetTextUnitToTMTextUnitRepository;
     this.meterRegistry = meterRegistry;
     this.quartzPollableTaskScheduler = quartzPollableTaskScheduler;
+    this.aiTranslationConfiguration = aiTranslationConfiguration;
   }
 
   @Override
@@ -337,6 +345,7 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
                         thirdPartyTextUnit.setAssetPath(key.getAssetPath());
                         thirdPartyTextUnit.setName(key.getTextUnitName());
                         thirdPartyTextUnit.setNamePluralPrefix(isPluralFile(file.getFileUri()));
+                        thirdPartyTextUnit.setUploadedFileUri(file.getFileUri());
 
                         return thirdPartyTextUnit;
                       });
@@ -968,6 +977,12 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
     result.setPluralFormsExcluded(pluralFormsExcluded);
     result.setSkipTextUnitWithPattern(skipTextUnitsWithPattern);
     result.setSkipAssetPathWithPattern(skipAssetsWithPathPattern);
+    result.setExcludeUnexpiredPendingMT(
+        aiTranslationConfiguration != null && aiTranslationConfiguration.isEnabled());
+    result.setAiTranslationExpiryDuration(
+        aiTranslationConfiguration != null
+            ? aiTranslationConfiguration.getExpiryDuration()
+            : Duration.ofHours(3));
     if (!Strings.isNullOrEmpty(pluralFormOther)) {
       result.setPluralFormOther(pluralFormOther);
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -43,7 +43,6 @@ import com.google.common.io.Files;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -977,12 +976,8 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
     result.setPluralFormsExcluded(pluralFormsExcluded);
     result.setSkipTextUnitWithPattern(skipTextUnitsWithPattern);
     result.setSkipAssetPathWithPattern(skipAssetsWithPathPattern);
-    result.setExcludeUnexpiredPendingMT(
-        aiTranslationConfiguration != null && aiTranslationConfiguration.isEnabled());
-    result.setAiTranslationExpiryDuration(
-        aiTranslationConfiguration != null
-            ? aiTranslationConfiguration.getExpiryDuration()
-            : Duration.ofHours(3));
+    result.setExcludeUnexpiredPendingMT(aiTranslationConfiguration.isEnabled());
+    result.setAiTranslationExpiryDuration(aiTranslationConfiguration.getExpiryDuration());
     if (!Strings.isNullOrEmpty(pluralFormOther)) {
       result.setPluralFormOther(pluralFormOther);
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTextUnit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTextUnit.java
@@ -30,6 +30,8 @@ public class ThirdPartyTextUnit implements TextUnitForBatchMatcher {
    */
   boolean namePluralPrefix;
 
+  String uploadedFileUri;
+
   public String getId() {
     return id;
   }
@@ -79,5 +81,13 @@ public class ThirdPartyTextUnit implements TextUnitForBatchMatcher {
 
   public void setNamePluralPrefix(boolean namePluralPrefix) {
     this.namePluralPrefix = namePluralPrefix;
+  }
+
+  public String getUploadedFileUri() {
+    return uploadedFileUri;
+  }
+
+  public void setUploadedFileUri(String uploadedFileUri) {
+    this.uploadedFileUri = uploadedFileUri;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.service.tm.search;
 
 import com.box.l10n.mojito.service.NormalizationUtils;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -50,6 +51,8 @@ public class TextUnitSearcherParameters {
   String skipTextUnitWithPattern;
   String includeTextUnitsWithPattern;
   String skipAssetPathWithPattern;
+  boolean isExcludeUnexpiredPendingMT = false;
+  Duration aiTranslationExpiryDuration;
 
   public String getName() {
     return name;
@@ -326,5 +329,21 @@ public class TextUnitSearcherParameters {
 
   public void setOrderByTextUnitID(boolean ordered) {
     isOrderedByTextUnitID = ordered;
+  }
+
+  public boolean isExcludeUnexpiredPendingMT() {
+    return isExcludeUnexpiredPendingMT;
+  }
+
+  public void setExcludeUnexpiredPendingMT(boolean excludeUnexpiredPendingMT) {
+    isExcludeUnexpiredPendingMT = excludeUnexpiredPendingMT;
+  }
+
+  public Duration getAiTranslationExpiryDuration() {
+    return aiTranslationExpiryDuration;
+  }
+
+  public void setAiTranslationExpiryDuration(Duration aiTranslationExpiryDuration) {
+    this.aiTranslationExpiryDuration = aiTranslationExpiryDuration;
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
@@ -197,34 +197,49 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         .extracting(
             t -> t.getAsset().getId(),
             com.box.l10n.mojito.entity.ThirdPartyTextUnit::getThirdPartyId,
-            t -> t.getTmTextUnit().getId())
+            t -> t.getTmTextUnit().getId(),
+            com.box.l10n.mojito.entity.ThirdPartyTextUnit::getUploadedFileUri)
         .containsExactly(
-            tuple(asset.getId(), "3rd-hello", thirdPartyServiceTestData.tmTextUnitHello.getId()),
-            tuple(asset.getId(), "3rd-bye", thirdPartyServiceTestData.tmTextUnitBye.getId()),
+            tuple(
+                asset.getId(),
+                "3rd-hello",
+                thirdPartyServiceTestData.tmTextUnitHello.getId(),
+                "testFileUri"),
+            tuple(
+                asset.getId(),
+                "3rd-bye",
+                thirdPartyServiceTestData.tmTextUnitBye.getId(),
+                "testFileUri"),
             tuple(
                 asset.getId(),
                 "3rd-plural_things",
-                thirdPartyServiceTestData.tmTextUnitPluralThingsZero.getId()),
+                thirdPartyServiceTestData.tmTextUnitPluralThingsZero.getId(),
+                "testFileUri"),
             tuple(
                 asset.getId(),
                 "3rd-plural_things",
-                thirdPartyServiceTestData.tmTextUnitPluralThingsOne.getId()),
+                thirdPartyServiceTestData.tmTextUnitPluralThingsOne.getId(),
+                "testFileUri"),
             tuple(
                 asset.getId(),
                 "3rd-plural_things",
-                thirdPartyServiceTestData.tmTextUnitPluralThingsTwo.getId()),
+                thirdPartyServiceTestData.tmTextUnitPluralThingsTwo.getId(),
+                "testFileUri"),
             tuple(
                 asset.getId(),
                 "3rd-plural_things",
-                thirdPartyServiceTestData.tmTextUnitPluralThingsFew.getId()),
+                thirdPartyServiceTestData.tmTextUnitPluralThingsFew.getId(),
+                "testFileUri"),
             tuple(
                 asset.getId(),
                 "3rd-plural_things",
-                thirdPartyServiceTestData.tmTextUnitPluralThingsMany.getId()),
+                thirdPartyServiceTestData.tmTextUnitPluralThingsMany.getId(),
+                "testFileUri"),
             tuple(
                 asset.getId(),
                 "3rd-plural_things",
-                thirdPartyServiceTestData.tmTextUnitPluralThingsOther.getId()));
+                thirdPartyServiceTestData.tmTextUnitPluralThingsOther.getId(),
+                "testFileUri"));
 
     logger.debug("Verify behavior");
     verify(thirdPartyTMSMock, times(3))
@@ -741,6 +756,7 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
     thirdPartyTextUnit.setId(id);
     thirdPartyTextUnit.setName(name);
     thirdPartyTextUnit.setNamePluralPrefix(isNamePluralPrefix);
+    thirdPartyTextUnit.setUploadedFileUri("testFileUri");
     return thirdPartyTextUnit;
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -34,6 +34,7 @@ import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.quartz.QuartzSchedulerManager;
+import com.box.l10n.mojito.service.ai.translation.AITranslationConfiguration;
 import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
@@ -161,6 +162,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
   @Mock TextUnitBatchImporterService mockTextUnitBatchImporterService;
 
+  @Mock AITranslationConfiguration aiTranslationConfiguration;
+
   @Captor ArgumentCaptor<List<TextUnitDTO>> textUnitListCaptor;
 
   @Captor
@@ -216,7 +219,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             mockThirdPartyTMSSmartlingGlossary,
             assetTextUnitToTMTextUnitRepository,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
 
     mapper = new AndroidStringDocumentMapper(pluralSep, null);
     RetryBackoffSpec retryConfiguration =
@@ -292,7 +296,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             batchSize,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
 
     TM tm = repository.getTm();
     Asset asset =
@@ -346,7 +351,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             batchSize,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
     // throw timeout exception for first request, following request should be successful
     when(smartlingClient.uploadFile(any(), any(), any(), any(), any(), any(), any()))
         .thenThrow(
@@ -412,7 +418,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             batchSize,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
 
     TM tm = repository.getTm();
     Asset asset =
@@ -463,7 +470,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             batchSize,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
 
     TM tm = repository.getTm();
     Asset asset =
@@ -522,7 +530,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             batchSize,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
 
     TM tm = repository.getTm();
     Asset asset =
@@ -737,7 +746,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             mockThirdPartyTMSSmartlingGlossary,
             assetTextUnitToTMTextUnitRepository,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
     tmsSmartling.pull(
         repository,
         "projectId",
@@ -809,7 +819,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             mockThirdPartyTMSSmartlingGlossary,
             assetTextUnitToTMTextUnitRepository,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
     tmsSmartling.pull(
         repository,
         "projectId",
@@ -872,7 +883,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             mockThirdPartyTMSSmartlingGlossary,
             assetTextUnitToTMTextUnitRepository,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
     tmsSmartling.pull(
         repository,
         "projectId",
@@ -1461,7 +1473,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             batchSize,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
     Repository repository =
         repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
     Locale frCA = localeService.findByBcp47Tag("fr-CA");
@@ -1615,7 +1628,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             3,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
 
     assertThat(tmsSmartling.batchesFor(0)).isEqualTo(0);
     assertThat(tmsSmartling.batchesFor(1)).isEqualTo(1);
@@ -1638,7 +1652,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             35,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
 
     assertThat(tmsSmartling.batchesFor(0)).isEqualTo(0);
     assertThat(tmsSmartling.batchesFor(1)).isEqualTo(1);
@@ -1659,7 +1674,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             4231,
             meterRegistry,
-            mockQuartzPollableTaskScheduler);
+            mockQuartzPollableTaskScheduler,
+            aiTranslationConfiguration);
 
     assertThat(tmsSmartling.batchesFor(0)).isEqualTo(0);
     assertThat(tmsSmartling.batchesFor(1)).isEqualTo(1);


### PR DESCRIPTION
Updates to support the introduction of AI translations to the Smartling sync.

This updates introduces the functionality in the text unit searcher to omit TMTextUnits to be returned in the search if the have an entry in the `tm_text_unit_pending_mt` table that has not yet expired.

Also added support to set the new `uploadedFileUri` as part of the mapping step of the sync