### PR TITLE
Added PUSH_AI_TRANSLATION to third party sync

### DIFF
--- a/restclient/src/main/java/com/box/l10n/mojito/rest/ThirdPartySyncAction.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/ThirdPartySyncAction.java
@@ -6,5 +6,6 @@ public enum ThirdPartySyncAction {
   PULL,
   PULL_SOURCE,
   MAP_TEXTUNIT,
-  PUSH_SCREENSHOT
+  PUSH_SCREENSHOT,
+  PUSH_MT_TRANSLATION,
 }

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/ThirdPartySyncAction.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/ThirdPartySyncAction.java
@@ -7,5 +7,5 @@ public enum ThirdPartySyncAction {
   PULL_SOURCE,
   MAP_TEXTUNIT,
   PUSH_SCREENSHOT,
-  PUSH_MT_TRANSLATION,
+  PUSH_AI_TRANSLATION,
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnitVariant.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnitVariant.java
@@ -69,8 +69,13 @@ public class TMTextUnitVariant extends SettableAuditableEntity {
      */
     REVIEW_NEEDED,
 
+    /** Indicates that the text unit has been machine translated in Mojito automatically. */
     MT_TRANSLATED,
 
+    /**
+     * Indicates that the text unit has been machine translated in Mojito automatically and has been
+     * sent for third party review.
+     */
     MT_REVIEW_NEEDED,
     /** A string that doesn't need any work to be performed on it. */
     APPROVED,

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnitVariant.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnitVariant.java
@@ -71,7 +71,7 @@ public class TMTextUnitVariant extends SettableAuditableEntity {
 
     MT_TRANSLATED,
 
-    MT_REVIEW,
+    MT_REVIEW_NEEDED,
     /** A string that doesn't need any work to be performed on it. */
     APPROVED,
     /** It was overridden in Mojito, so it won't be updated during third-party sync */

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySyncAction.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySyncAction.java
@@ -6,5 +6,6 @@ public enum ThirdPartySyncAction {
   PULL,
   PULL_SOURCE,
   MAP_TEXTUNIT,
-  PUSH_SCREENSHOT
+  PUSH_SCREENSHOT,
+  PUSH_AI_TRANSLATION
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -352,22 +352,4 @@ public class AITranslateCronJob implements Job {
     trigger.setCronExpression(aiTranslationConfiguration.getCron());
     return trigger;
   }
-
-  private void deleteBatch(List<TmTextUnitPendingMT> batch) {
-    if (batch.isEmpty()) {
-      logger.debug("No pending MTs to delete");
-      return;
-    }
-
-    String sql =
-        "DELETE FROM tm_text_unit_pending_mt WHERE id IN ("
-            + batch.stream()
-                .map(tmTextUnitPendingMT -> tmTextUnitPendingMT.getId().toString())
-                .collect(Collectors.joining(","))
-            + ")";
-    logger.debug(
-        "Executing batch delete for IDs: {}",
-        batch.stream().map(TmTextUnitPendingMT::getId).collect(Collectors.toList()));
-    jdbcTemplate.update(sql);
-  }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.service.ai.translation;
 
+import static com.box.l10n.mojito.entity.TMTextUnitVariant.Status.MT_REVIEW_NEEDED;
+
 import com.box.l10n.mojito.JSR310Migration;
 import com.box.l10n.mojito.entity.PromptType;
 import com.box.l10n.mojito.entity.TmTextUnitPendingMT;
@@ -94,7 +96,7 @@ public class AITranslationService {
         new BatchPreparedStatementSetter() {
           @Override
           public void setValues(PreparedStatement ps, int i) throws SQLException {
-            ps.setString(1, "MT_REVIEW");
+            ps.setString(1, MT_REVIEW_NEEDED.name());
             ps.setLong(2, updateBatch.get(i));
           }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -180,6 +180,18 @@ public class ThirdPartyService {
     if (actions.contains(ThirdPartySyncAction.PUSH_SCREENSHOT)) {
       uploadScreenshotsAndCreateMappings(repository, thirdPartyProjectId, currentTask);
     }
+    if (actions.contains(ThirdPartySyncAction.PUSH_AI_TRANSLATION)) {
+      pushAITranslations(
+          thirdPartyProjectId,
+          pluralSeparator,
+          localeMapping,
+          skipTextUnitsWithPattern,
+          skipAssetsWithPathPattern,
+          includeTextUnitsWithPattern,
+          options,
+          repository,
+          currentTask);
+    }
   }
 
   @Pollable(message = "Push source strings to third party service.")
@@ -288,6 +300,28 @@ public class ThirdPartyService {
         .filter(e -> e.getKey() != null)
         .forEach(
             e -> mapThirdPartyTextUnitsToTextUnitDTOs(e.getKey(), e.getValue(), pluralSeparator));
+  }
+
+  @Pollable(message = "Push AI translations to third party service.")
+  void pushAITranslations(
+      String thirdPartyProjectId,
+      String pluralSeparator,
+      String localeMapping,
+      String skipTextUnitsWithPattern,
+      String skipAssetsWithPathPattern,
+      String includeTextUnitsWithPattern,
+      List<String> options,
+      Repository repository,
+      @ParentTask PollableTask currentTask) {
+    thirdPartyTMS.pushAITranslations(
+        repository,
+        thirdPartyProjectId,
+        pluralSeparator,
+        parseLocaleMapping(localeMapping),
+        skipTextUnitsWithPattern,
+        skipAssetsWithPathPattern,
+        includeTextUnitsWithPattern,
+        options);
   }
 
   void mapThirdPartyTextUnitsToTextUnitDTOs(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMS.java
@@ -96,4 +96,14 @@ interface ThirdPartyTMS {
       String projectId,
       List<String> optionList,
       Map<String, String> localeMapping);
+
+  void pushAITranslations(
+      Repository repository,
+      String projectId,
+      String pluralSeparator,
+      Map<String, String> localeMapping,
+      String skipTextUnitsWithPattern,
+      String skipAssetsWithPathPattern,
+      String includeTextUnitsWithPattern,
+      List<String> optionList);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
@@ -117,4 +117,15 @@ public class ThirdPartyTMSInMemory implements ThirdPartyTMS {
       String projectId,
       List<String> optionList,
       Map<String, String> localeMapping) {}
+
+  @Override
+  public void pushAITranslations(
+      Repository repository,
+      String projectId,
+      String pluralSeparator,
+      Map<String, String> localeMapping,
+      String skipTextUnitsWithPattern,
+      String skipAssetsWithPathPattern,
+      String includeTextUnitsWithPattern,
+      List<String> optionList) {}
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -419,7 +419,6 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
       SmartlingOptions options = SmartlingOptions.parseList(optionList);
 
       if (options.isJsonSync()) {
-        // TODO(mallen) Need to update json sync push to handle AI translations
         thirdPartyTMSSmartlingWithJson.push(
             repository,
             projectId,
@@ -760,8 +759,13 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
             .tag("repository", repository.getName())) {
       SmartlingOptions options = SmartlingOptions.parseList(optionList);
       if (options.isJsonSync()) {
-        // TODO: Add json sync implementation
-        throw new RuntimeException("Not yet implemented");
+        thirdPartyTMSSmartlingWithJson.pushAiTranslations(
+            repository,
+            projectId,
+            localeMapping,
+            skipTextUnitsWithPattern,
+            skipAssetsWithPathPattern,
+            includeTextUnitsWithPattern);
       }
 
       AndroidStringDocumentMapper mapper = new AndroidStringDocumentMapper(pluralSeparator, null);
@@ -861,6 +865,14 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
             filterTmTextUnitIds);
     aiTranslationService.updateVariantStatusToMTReview(
         batch.stream().map(TextUnitDTO::getTmTextUnitCurrentVariantId).toList());
+    meterRegistry
+        .counter(
+            "SmartlingSync.uploadAiTranslationsBatch",
+            "repository",
+            repository.getName(),
+            "jsonSync",
+            "false")
+        .increment(batch.size());
     return file;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -984,7 +984,7 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
       logger.debug("Process translation batch for file: {}", fileName);
       List<TextUnitDTO> fileBatch = batch;
       SmartlingFile file = new SmartlingFile();
-      file.setFileName(fileName);
+      file.setFileName(fileName + "_" + localeTag);
 
       try {
         logger.debug("Save target file to: {}", file.getFileName());

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingResultProcessor.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingResultProcessor.java
@@ -37,6 +37,10 @@ public class SmartlingResultProcessor {
     return processAction(files, options, "push_translations");
   }
 
+  public String processPushAiTranslations(List<SmartlingFile> files, SmartlingOptions options) {
+    return processAction(files, options, "push_ai_translations");
+  }
+
   private String processAction(List<SmartlingFile> files, SmartlingOptions options, String action) {
     String result = null;
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitVariantRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitVariantRepository.java
@@ -162,13 +162,4 @@ public interface TMTextUnitVariantRepository extends JpaRepository<TMTextUnitVar
               """)
   List<LocaleVariantDTO> findLocaleVariantDTOsByTmTextUnitId(
       @Param("tmTextUnitId") Long tmTextUnitId);
-
-  @Query(
-      """
-        select tuv from TMTextUnitVariant tuv
-        join TMTextUnitCurrentVariant tucv ON tuv.id = tucv.tmTextUnitVariant.id
-        where tucv.id = :tmTextUnitCurrentVariantId
-    """)
-  TMTextUnitVariant findByCurrentVariantId(
-      @Param("tmTextUnitCurrentVariantId") Long tmTextUnitCurrentVariantId);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitVariantRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitVariantRepository.java
@@ -162,4 +162,13 @@ public interface TMTextUnitVariantRepository extends JpaRepository<TMTextUnitVar
               """)
   List<LocaleVariantDTO> findLocaleVariantDTOsByTmTextUnitId(
       @Param("tmTextUnitId") Long tmTextUnitId);
+
+  @Query(
+      """
+        select tuv from TMTextUnitVariant tuv
+        join TMTextUnitCurrentVariant tucv ON tuv.id = tucv.tmTextUnitVariant.id
+        where tucv.id = :tmTextUnitCurrentVariantId
+    """)
+  TMTextUnitVariant findByCurrentVariantId(
+      @Param("tmTextUnitCurrentVariantId") Long tmTextUnitCurrentVariantId);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/StatusFilter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/StatusFilter.java
@@ -54,4 +54,6 @@ public enum StatusFilter {
   NOT_REJECTED,
   /** TextUnits with status ({@link TMTextUnitVariant.Status#OVERRIDDEN}). */
   OVERRIDDEN,
+  /** TextUnits with status (@link TMTextUnitVariant.Status#MT_TRANSLATED}). */
+  MT_TRANSLATED
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
@@ -34,6 +34,7 @@ public class TextUnitDTO {
   private Long assetTextUnitId;
   private ZonedDateTime tmTextUnitCreatedDate;
   private boolean doNotTranslate;
+  private String uploadedFileUri;
 
   public Long getTmTextUnitId() {
     return tmTextUnitId;
@@ -241,5 +242,13 @@ public class TextUnitDTO {
 
   public void setDoNotTranslate(boolean doNotTranslate) {
     this.doNotTranslate = doNotTranslate;
+  }
+
+  public String getUploadedFileUri() {
+    return uploadedFileUri;
+  }
+
+  public void setUploadedFileUri(String uploadedFileUri) {
+    this.uploadedFileUri = uploadedFileUri;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTONativeObjectMapper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTONativeObjectMapper.java
@@ -56,6 +56,10 @@ public class TextUnitDTONativeObjectMapper implements NativeObjectMapper<TextUni
     String doNotTranslate = cr.getString(idx++);
     t.setDoNotTranslate(Boolean.valueOf(doNotTranslate));
 
+    if (cr.hasProperty("uploadedFileUri")) {
+      t.setUploadedFileUri(cr.getString(idx++));
+    }
+
     return t;
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
@@ -408,6 +408,10 @@ public class TextUnitSearcher {
               new NativeEqExpFix(
                   "tuv.status", TMTextUnitVariant.Status.TRANSLATION_NEEDED.toString()));
           break;
+        case MT_TRANSLATED:
+          conjunction.add(
+              new NativeEqExpFix("tuv.status", TMTextUnitVariant.Status.MT_TRANSLATED.toString()));
+          break;
         case TRANSLATED:
           conjunction.add(NativeExps.isNotNull("tuv.id"));
           break;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
@@ -165,10 +165,9 @@ public class TextUnitSearcher {
               "tm_text_unit_pending_mt", "tmtupmt", "tmtupmt.tm_text_unit_id", "tu.id"));
     }
 
-    if (searchParameters.getStatusFilter() != null
-        && searchParameters.getStatusFilter().equals(StatusFilter.MT_TRANSLATED)) {
-      // Pushing AI translations, need to retrieve the uploadedFileUri from the ThirdPartyTextUnit
-      // table
+    if (searchParameters.isRetrieveUploadedFileUri()) {
+      // Retrieve the uploadedFileUri from the ThirdPartyTextUnit table (used when pushing AI
+      // translations to third party)
       c.addJoin(
           NativeExps.innerJoin("third_party_text_unit", "tptu", "tptu.tm_text_unit_id", "tu.id"));
     }
@@ -248,8 +247,7 @@ public class TextUnitSearcher {
             .addProjection("tu.created_date", "tmTextUnitCreatedDate")
             .addProjection("atu.do_not_translate", "doNotTranslate");
 
-    if (searchParameters.getStatusFilter() != null
-        && searchParameters.getStatusFilter().equals(StatusFilter.MT_TRANSLATED)) {
+    if (searchParameters.isRetrieveUploadedFileUri()) {
       projection.addProjection("tptu.uploaded_file_uri", "uploadedFileUri");
     }
     c.setProjection(projection);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
@@ -165,7 +165,7 @@ public class TextUnitSearcher {
               "tm_text_unit_pending_mt", "tmtupmt", "tmtupmt.tm_text_unit_id", "tu.id"));
     }
 
-    if (searchParameters.isRetrieveUploadedFileUri()) {
+    if (searchParameters.shouldRetrieveUploadedFileUri()) {
       // Retrieve the uploadedFileUri from the ThirdPartyTextUnit table (used when pushing AI
       // translations to third party)
       c.addJoin(
@@ -247,7 +247,7 @@ public class TextUnitSearcher {
             .addProjection("tu.created_date", "tmTextUnitCreatedDate")
             .addProjection("atu.do_not_translate", "doNotTranslate");
 
-    if (searchParameters.isRetrieveUploadedFileUri()) {
+    if (searchParameters.shouldRetrieveUploadedFileUri()) {
       projection.addProjection("tptu.uploaded_file_uri", "uploadedFileUri");
     }
     c.setProjection(projection);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
@@ -165,6 +165,14 @@ public class TextUnitSearcher {
               "tm_text_unit_pending_mt", "tmtupmt", "tmtupmt.tm_text_unit_id", "tu.id"));
     }
 
+    if (searchParameters.getStatusFilter() != null
+        && searchParameters.getStatusFilter().equals(StatusFilter.MT_TRANSLATED)) {
+      // Pushing AI translations, need to retrieve the uploadedFileUri from the ThirdPartyTextUnit
+      // table
+      c.addJoin(
+          NativeExps.innerJoin("third_party_text_unit", "tptu", "tptu.tm_text_unit_id", "tu.id"));
+    }
+
     NativeJunctionExp onClauseRepositoryLocale = NativeExps.conjunction();
     onClauseRepositoryLocale.add(new NativeColumnEqExp("rl.locale_id", "l.id"));
     onClauseRepositoryLocale.add(new NativeColumnEqExp("rl.repository_id", "r.id"));
@@ -212,15 +220,11 @@ public class TextUnitSearcher {
             "plural_form_for_locale", "pffl", NativeJoin.JoinType.LEFT_OUTER, onClausePluralForm));
 
     logger.debug("Set projections");
-
-    // TODO(P1) Might want to some of those projection as optional for perf reason
-    c.setProjection(
+    NativeProjection projection =
         NativeExps.projection()
             .addProjection("tu.id", "tmTextUnitId")
             .addProjection("tuv.id", "tmTextUnitVariantId")
-            .
-            // TODO(PO) THIS NOT CONSISTANT !! chooose
-            addProjection("l.id", "localeId")
+            .addProjection("l.id", "localeId")
             .addProjection("l.bcp47_tag", "targetLocale")
             .addProjection("tu.name", "name")
             .addProjection("tu.content", "source")
@@ -242,7 +246,13 @@ public class TextUnitSearcher {
             .addProjection("a.path", "assetPath")
             .addProjection("atu.id", "assetTextUnitId")
             .addProjection("tu.created_date", "tmTextUnitCreatedDate")
-            .addProjection("atu.do_not_translate", "doNotTranslate"));
+            .addProjection("atu.do_not_translate", "doNotTranslate");
+
+    if (searchParameters.getStatusFilter() != null
+        && searchParameters.getStatusFilter().equals(StatusFilter.MT_TRANSLATED)) {
+      projection.addProjection("tptu.uploaded_file_uri", "uploadedFileUri");
+    }
+    c.setProjection(projection);
 
     logger.debug("Add search filters");
     NativeJunctionExp conjunction = NativeExps.conjunction();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
@@ -53,7 +53,7 @@ public class TextUnitSearcherParameters {
   String skipAssetPathWithPattern;
   boolean isExcludeUnexpiredPendingMT = false;
   Duration aiTranslationExpiryDuration;
-  boolean isRetrieveUploadedFileUri = false;
+  boolean shouldRetrieveUploadedFileUri = false;
 
   public String getName() {
     return name;
@@ -348,12 +348,12 @@ public class TextUnitSearcherParameters {
     this.aiTranslationExpiryDuration = aiTranslationExpiryDuration;
   }
 
-  public boolean isRetrieveUploadedFileUri() {
-    return isRetrieveUploadedFileUri;
+  public boolean shouldRetrieveUploadedFileUri() {
+    return shouldRetrieveUploadedFileUri;
   }
 
   public void setIsRetrieveUploadedFileUri(boolean retrieveUploadedFileUri) {
-    this.isRetrieveUploadedFileUri = retrieveUploadedFileUri;
+    this.shouldRetrieveUploadedFileUri = retrieveUploadedFileUri;
   }
 
   public static class Builder {
@@ -392,7 +392,7 @@ public class TextUnitSearcherParameters {
     private String skipAssetPathWithPattern;
     private boolean isExcludeUnexpiredPendingMT;
     private Duration aiTranslationExpiryDuration;
-    private boolean isRetrieveUploadedFileUri;
+    private boolean shouldRetrieveUploadedFileUri;
 
     public TextUnitSearcherParameters build() {
       TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
@@ -431,7 +431,7 @@ public class TextUnitSearcherParameters {
       textUnitSearcherParameters.skipAssetPathWithPattern = this.skipAssetPathWithPattern;
       textUnitSearcherParameters.isExcludeUnexpiredPendingMT = this.isExcludeUnexpiredPendingMT;
       textUnitSearcherParameters.aiTranslationExpiryDuration = this.aiTranslationExpiryDuration;
-      textUnitSearcherParameters.isRetrieveUploadedFileUri = this.isRetrieveUploadedFileUri;
+      textUnitSearcherParameters.shouldRetrieveUploadedFileUri = this.shouldRetrieveUploadedFileUri;
       return textUnitSearcherParameters;
     }
 
@@ -626,7 +626,7 @@ public class TextUnitSearcherParameters {
     }
 
     public Builder shouldRetrieveUploadedFileUri(boolean shouldRetrieveUploadedFileUri) {
-      this.isRetrieveUploadedFileUri = shouldRetrieveUploadedFileUri;
+      this.shouldRetrieveUploadedFileUri = shouldRetrieveUploadedFileUri;
       return this;
     }
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
@@ -53,6 +53,7 @@ public class TextUnitSearcherParameters {
   String skipAssetPathWithPattern;
   boolean isExcludeUnexpiredPendingMT = false;
   Duration aiTranslationExpiryDuration;
+  boolean isRetrieveUploadedFileUri = false;
 
   public String getName() {
     return name;
@@ -347,6 +348,14 @@ public class TextUnitSearcherParameters {
     this.aiTranslationExpiryDuration = aiTranslationExpiryDuration;
   }
 
+  public boolean isRetrieveUploadedFileUri() {
+    return isRetrieveUploadedFileUri;
+  }
+
+  public void setIsRetrieveUploadedFileUri(boolean retrieveUploadedFileUri) {
+    this.isRetrieveUploadedFileUri = retrieveUploadedFileUri;
+  }
+
   public static class Builder {
     private String name;
     private String source;
@@ -383,6 +392,7 @@ public class TextUnitSearcherParameters {
     private String skipAssetPathWithPattern;
     private boolean isExcludeUnexpiredPendingMT;
     private Duration aiTranslationExpiryDuration;
+    private boolean isRetrieveUploadedFileUri;
 
     public TextUnitSearcherParameters build() {
       TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
@@ -421,6 +431,7 @@ public class TextUnitSearcherParameters {
       textUnitSearcherParameters.skipAssetPathWithPattern = this.skipAssetPathWithPattern;
       textUnitSearcherParameters.isExcludeUnexpiredPendingMT = this.isExcludeUnexpiredPendingMT;
       textUnitSearcherParameters.aiTranslationExpiryDuration = this.aiTranslationExpiryDuration;
+      textUnitSearcherParameters.isRetrieveUploadedFileUri = this.isRetrieveUploadedFileUri;
       return textUnitSearcherParameters;
     }
 
@@ -611,6 +622,11 @@ public class TextUnitSearcherParameters {
 
     public Builder aiTranslationExpiryDuration(Duration aiTranslationExpiryDuration) {
       this.aiTranslationExpiryDuration = aiTranslationExpiryDuration;
+      return this;
+    }
+
+    public Builder shouldRetrieveUploadedFileUri(boolean shouldRetrieveUploadedFileUri) {
+      this.isRetrieveUploadedFileUri = shouldRetrieveUploadedFileUri;
       return this;
     }
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
@@ -369,6 +369,26 @@ public class SmartlingClient {
       String fileContent,
       String placeholderFormat,
       String placeholderFormatCustom) {
+    return uploadLocalizedFile(
+        projectId,
+        fileUri,
+        fileType,
+        localeId,
+        fileContent,
+        placeholderFormat,
+        placeholderFormatCustom,
+        "PUBLISHED");
+  }
+
+  public FileUploadResponse uploadLocalizedFile(
+      String projectId,
+      String fileUri,
+      String fileType,
+      String localeId,
+      String fileContent,
+      String placeholderFormat,
+      String placeholderFormatCustom,
+      String translationState) {
 
     try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
       HttpPost uploadFileMethod =
@@ -387,7 +407,7 @@ public class SmartlingClient {
 
       multipartEntityBuilder.addTextBody("fileUri", fileUri);
       multipartEntityBuilder.addTextBody("fileType", fileType);
-      multipartEntityBuilder.addTextBody("translationState", "PUBLISHED");
+      multipartEntityBuilder.addTextBody("translationState", translationState);
       multipartEntityBuilder.addTextBody("overwrite", "true");
       if (!Strings.isNullOrEmpty(placeholderFormat)) {
         multipartEntityBuilder.addTextBody("smartling.placeholder_format", placeholderFormat);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
@@ -368,7 +368,7 @@ public class AITranslateCronJobTest {
       assertEquals(3, aiTranslations.size());
       assertThat(aiTranslations).extracting("localeId").containsExactlyInAnyOrder(2L, 3L, 4L);
     }
-    verify(aiTranslationService, times(10)).sendForDeletion(isA(TmTextUnitPendingMT.class));
+    verify(aiTranslationService, times(3)).deleteBatch(isA(List.class));
   }
 
   @Test
@@ -403,7 +403,7 @@ public class AITranslateCronJobTest {
       assertEquals(3, aiTranslations.size());
       assertThat(aiTranslations).extracting("localeId").containsExactlyInAnyOrder(2L, 3L, 4L);
     }
-    verify(aiTranslationService, times(10)).sendForDeletion(isA(TmTextUnitPendingMT.class));
+    verify(aiTranslationService, times(3)).deleteBatch(isA(List.class));
   }
 
   @Test
@@ -437,6 +437,6 @@ public class AITranslateCronJobTest {
       assertEquals(3, aiTranslations.size());
       assertThat(aiTranslations).extracting("localeId").containsExactlyInAnyOrder(2L, 3L, 4L);
     }
-    verify(aiTranslationService, times(5)).sendForDeletion(isA(TmTextUnitPendingMT.class));
+    verify(aiTranslationService, times(2)).deleteBatch(isA(List.class));
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
@@ -368,7 +369,7 @@ public class AITranslateCronJobTest {
       assertEquals(3, aiTranslations.size());
       assertThat(aiTranslations).extracting("localeId").containsExactlyInAnyOrder(2L, 3L, 4L);
     }
-    verify(aiTranslationService, times(3)).deleteBatch(isA(List.class));
+    verify(aiTranslationService, times(3)).deleteBatch(isA(Queue.class));
   }
 
   @Test
@@ -403,7 +404,7 @@ public class AITranslateCronJobTest {
       assertEquals(3, aiTranslations.size());
       assertThat(aiTranslations).extracting("localeId").containsExactlyInAnyOrder(2L, 3L, 4L);
     }
-    verify(aiTranslationService, times(3)).deleteBatch(isA(List.class));
+    verify(aiTranslationService, times(3)).deleteBatch(isA(Queue.class));
   }
 
   @Test
@@ -437,6 +438,6 @@ public class AITranslateCronJobTest {
       assertEquals(3, aiTranslations.size());
       assertThat(aiTranslations).extracting("localeId").containsExactlyInAnyOrder(2L, 3L, 4L);
     }
-    verify(aiTranslationService, times(2)).deleteBatch(isA(List.class));
+    verify(aiTranslationService, times(2)).deleteBatch(isA(Queue.class));
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/StubSmartlingResultProcessor.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/StubSmartlingResultProcessor.java
@@ -10,6 +10,7 @@ public class StubSmartlingResultProcessor extends SmartlingResultProcessor {
 
   List<SmartlingFile> pushFiles = new ArrayList<>();
   List<SmartlingFile> pushTranslationFiles = new ArrayList<>();
+  List<SmartlingFile> pushAITranslationFiles = new ArrayList<>();
   SmartlingOptions options;
 
   public StubSmartlingResultProcessor() {}
@@ -24,6 +25,13 @@ public class StubSmartlingResultProcessor extends SmartlingResultProcessor {
   @Override
   public String processPushTranslations(List<SmartlingFile> files, SmartlingOptions options) {
     this.pushTranslationFiles = files;
+    this.options = options;
+    return "";
+  }
+
+  @Override
+  public String processPushAiTranslations(List<SmartlingFile> files, SmartlingOptions options) {
+    this.pushAITranslationFiles = files;
     this.options = options;
     return "";
   }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -35,6 +35,7 @@ import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.quartz.QuartzSchedulerManager;
 import com.box.l10n.mojito.service.ai.translation.AITranslationConfiguration;
+import com.box.l10n.mojito.service.ai.translation.AITranslationService;
 import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
@@ -167,6 +168,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
   @Mock AITranslationConfiguration aiTranslationConfiguration;
 
+  @Mock AITranslationService aiTranslationService;
+
   @Captor ArgumentCaptor<List<TextUnitDTO>> textUnitListCaptor;
 
   @Captor
@@ -225,7 +228,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
 
     mapper = new AndroidStringDocumentMapper(pluralSep, null);
     RetryBackoffSpec retryConfiguration =
@@ -302,7 +306,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             batchSize,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
 
     TM tm = repository.getTm();
     Asset asset =
@@ -357,7 +362,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             batchSize,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
     // throw timeout exception for first request, following request should be successful
     when(smartlingClient.uploadFile(any(), any(), any(), any(), any(), any(), any()))
         .thenThrow(
@@ -424,7 +430,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             batchSize,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
 
     TM tm = repository.getTm();
     Asset asset =
@@ -476,7 +483,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             batchSize,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
 
     TM tm = repository.getTm();
     Asset asset =
@@ -536,7 +544,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             batchSize,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
 
     TM tm = repository.getTm();
     Asset asset =
@@ -752,7 +761,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
     tmsSmartling.pull(
         repository,
         "projectId",
@@ -825,7 +835,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
     tmsSmartling.pull(
         repository,
         "projectId",
@@ -889,7 +900,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             assetTextUnitToTMTextUnitRepository,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
     tmsSmartling.pull(
         repository,
         "projectId",
@@ -1479,7 +1491,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             batchSize,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
     Repository repository =
         repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
     Locale frCA = localeService.findByBcp47Tag("fr-CA");
@@ -1634,7 +1647,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             3,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
 
     assertThat(tmsSmartling.batchesFor(0)).isEqualTo(0);
     assertThat(tmsSmartling.batchesFor(1)).isEqualTo(1);
@@ -1658,7 +1672,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             35,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
 
     assertThat(tmsSmartling.batchesFor(0)).isEqualTo(0);
     assertThat(tmsSmartling.batchesFor(1)).isEqualTo(1);
@@ -1680,7 +1695,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
             4231,
             meterRegistry,
             mockQuartzPollableTaskScheduler,
-            aiTranslationConfiguration);
+            aiTranslationConfiguration,
+            aiTranslationService);
 
     assertThat(tmsSmartling.batchesFor(0)).isEqualTo(0);
     assertThat(tmsSmartling.batchesFor(1)).isEqualTo(1);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -995,7 +995,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                       eq(locale.getBcp47Tag()),
                       startsWith("<?xml version="),
                       eq(null),
-                      eq(null));
+                      eq(null),
+                      eq("PUBLISHED"));
             });
   }
 
@@ -1005,7 +1006,14 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
     doThrow(new SmartlingClientException(new HttpServerErrorException(HttpStatus.GATEWAY_TIMEOUT)))
         .when(smartlingClient)
         .uploadLocalizedFile(
-            anyString(), anyString(), anyString(), anyString(), anyString(), any(), any());
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any(),
+            anyString());
     List<SmartlingFile> result;
     Repository repository =
         repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
@@ -1055,7 +1063,14 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
     verify(smartlingClient, times(11))
         .uploadLocalizedFile(
-            anyString(), anyString(), anyString(), anyString(), anyString(), any(), any());
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any(),
+            eq("PUBLISHED"));
   }
 
   @Test
@@ -1063,7 +1078,14 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
       throws RepositoryNameAlreadyUsedException, RepositoryLocaleCreationException {
     // First request results in timeout, retry then successful
     when(smartlingClient.uploadLocalizedFile(
-            anyString(), anyString(), anyString(), anyString(), anyString(), any(), any()))
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any(),
+            anyString()))
         .thenThrow(
             new SmartlingClientException(new HttpServerErrorException(HttpStatus.GATEWAY_TIMEOUT)))
         .thenReturn(null);
@@ -1136,7 +1158,14 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
     // Verify upload localized file called three times due to retry on first request
     verify(smartlingClient, times(3))
         .uploadLocalizedFile(
-            anyString(), anyString(), anyString(), anyString(), anyString(), eq(null), eq(null));
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            eq(null),
+            eq(null),
+            eq("PUBLISHED"));
   }
 
   @Test
@@ -1339,7 +1368,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                       eq(locale.getBcp47Tag()),
                       startsWith("<?xml version="),
                       eq(null),
-                      eq(null));
+                      eq(null),
+                      eq("PUBLISHED"));
 
               verify(smartlingClient, times(1))
                   .uploadLocalizedFile(
@@ -1349,7 +1379,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                       eq(locale.getBcp47Tag()),
                       startsWith("<?xml version="),
                       eq(null),
-                      eq(null));
+                      eq(null),
+                      eq("PUBLISHED"));
             });
   }
 
@@ -1468,7 +1499,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                     eq(locale.getBcp47Tag()),
                     startsWith("<?xml version="),
                     eq(null),
-                    eq(null)));
+                    eq(null),
+                    eq("PUBLISHED")));
   }
 
   @Test
@@ -1614,7 +1646,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                               eq(locale.getBcp47Tag()),
                               startsWith("<?xml version="),
                               eq(null),
-                              eq(null)));
+                              eq(null),
+                              eq("PUBLISHED")));
 
           IntStream.range(0, pluralBatches)
               .forEachOrdered(
@@ -1627,7 +1660,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                               eq(locale.getBcp47Tag()),
                               startsWith("<?xml version="),
                               eq(null),
-                              eq(null)));
+                              eq(null),
+                              eq("PUBLISHED")));
         });
   }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingWithJsonTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingWithJsonTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 
 import com.box.l10n.mojito.entity.*;
 import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.service.ai.translation.AITranslationConfiguration;
 import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
@@ -82,6 +83,8 @@ public class ThirdPartyTMSSmartlingWithJsonTest extends ServiceTestBase {
   @Autowired TextUnitSearcher textUnitSearcher;
 
   @Mock ThirdPartyFileChecksumRepository thirdPartyFileChecksumRepositoryMock;
+
+  @Mock AITranslationConfiguration aiTranslationConfiguration;
 
   SmartlingJsonConverter smartlingJsonConverter =
       new SmartlingJsonConverter(ObjectMapper.withIndentedOutput(), new SmartlingJsonKeys());
@@ -255,7 +258,14 @@ public class ThirdPartyTMSSmartlingWithJsonTest extends ServiceTestBase {
 
     ThirdPartyTMSSmartlingWithJson thirdPartyTMSSmartlingWithJson =
         new ThirdPartyTMSSmartlingWithJson(
-            null, null, null, null, null, meterRegistryMock, thirdPartyFileChecksumRepositoryMock);
+            null,
+            null,
+            null,
+            null,
+            null,
+            meterRegistryMock,
+            thirdPartyFileChecksumRepositoryMock,
+            aiTranslationConfiguration);
 
     ImmutableList<TextUnitDTO> result =
         thirdPartyTMSSmartlingWithJson.getTranslatedUnits(


### PR DESCRIPTION
Adds functionality to push AI translations as part of the third party sync using a new action. 

Implemented for the Smartling third party sync command, AI translations will be pushed with the `POST_TRANSLATION` state which means they will be forward to the next step in the Smartling workflow after the 'Translate' step.