### PR TITLE
Fix <description> being removed from checker failure errors

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractPlaceholderDescriptionCheck.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractPlaceholderDescriptionCheck.java
@@ -20,8 +20,10 @@ public abstract class AbstractPlaceholderDescriptionCheck {
               + placeholder
               + QUOTE_MARKER
               + " in comment. Please add a description in the string comment in the form "
+              + QUOTE_MARKER
               + placeholder
-              + ":<description>";
+              + ":<description>"
+              + QUOTE_MARKER;
     } else if (!placeholder.trim().isEmpty()) {
       failureText =
           "Missing description for placeholder with name "
@@ -29,8 +31,10 @@ public abstract class AbstractPlaceholderDescriptionCheck {
               + placeholder
               + QUOTE_MARKER
               + " in comment. Please add a description in the string comment in the form "
+              + QUOTE_MARKER
               + placeholder
-              + ":<description>";
+              + ":<description>"
+              + QUOTE_MARKER;
     }
     return Optional.ofNullable(failureText);
   }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/DoubleBracesPlaceholderDescriptionCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/DoubleBracesPlaceholderDescriptionCheckerTest.java
@@ -37,7 +37,7 @@ public class DoubleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "placeholder"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form placeholder:<description>"));
+                + " in comment. Please add a description in the string comment in the form `placeholder:<description>`"));
   }
 
   @Test
@@ -52,7 +52,7 @@ public class DoubleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "placeholder"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form placeholder:<description>"));
+                + " in comment. Please add a description in the string comment in the form `placeholder:<description>`"));
   }
 
   @Test
@@ -60,7 +60,7 @@ public class DoubleBracesPlaceholderDescriptionCheckerTest {
     Set<String> failures =
         doubleBracesPlaceholderCommentChecker.checkCommentForDescriptions(
             "A source string with a single {{placeholder}} and {another} and so {more}.",
-            "Test comment placeholder:description 1,another: description 2,more: description 3");
+            "Test comment `placeholder:description 1`,`another: description 2`,`more: description 3`");
     Assert.assertTrue(failures.isEmpty());
   }
 
@@ -77,7 +77,7 @@ public class DoubleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "another"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form another:<description>"));
+                + " in comment. Please add a description in the string comment in the form `another:<description>`"));
   }
 
   @Test
@@ -93,7 +93,7 @@ public class DoubleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "numFiles"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form numFiles:<description>"));
+                + " in comment. Please add a description in the string comment in the form `numFiles:<description>`"));
   }
 
   @Test
@@ -109,6 +109,6 @@ public class DoubleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "0"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form 0:<description>"));
+                + " in comment. Please add a description in the string comment in the form `0:<description>`"));
   }
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
@@ -146,7 +146,7 @@ public class PlaceholderCommentCheckerTest {
             + QUOTE_MARKER
             + "another"
             + QUOTE_MARKER
-            + " in comment. Please add a description in the string comment in the form another:<description>",
+            + " in comment. Please add a description in the string comment in the form `another:<description>`",
         result.getNotificationText());
   }
 
@@ -270,17 +270,17 @@ public class PlaceholderCommentCheckerTest {
         result
             .getNotificationText()
             .contains(
-                "Please add a description in the string comment in the form %1$@:<description>"));
+                "Please add a description in the string comment in the form `%1$@:<description>`"));
     Assert.assertTrue(
         result
             .getNotificationText()
             .contains(
-                "Please add a description in the string comment in the form %@:<description>"));
+                "Please add a description in the string comment in the form `%@:<description>`"));
     Assert.assertTrue(
         result
             .getNotificationText()
             .contains(
-                "Please add a description in the string comment in the form %2$@ld:<description>"));
+                "Please add a description in the string comment in the form `%2$@ld:<description>`"));
   }
 
   @Test

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PrintfLikeVariableTypePlaceholderDescriptionCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PrintfLikeVariableTypePlaceholderDescriptionCheckerTest.java
@@ -52,7 +52,7 @@ public class PrintfLikeVariableTypePlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "count"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form count:<description>"));
+                + " in comment. Please add a description in the string comment in the form `count:<description>`"));
   }
 
   @Test
@@ -69,7 +69,7 @@ public class PrintfLikeVariableTypePlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "count"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form count:<description>"));
+                + " in comment. Please add a description in the string comment in the form `count:<description>`"));
   }
 
   @Test
@@ -86,7 +86,7 @@ public class PrintfLikeVariableTypePlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "count"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form count:<description>"));
+                + " in comment. Please add a description in the string comment in the form `count:<description>`"));
   }
 
   @Test
@@ -103,7 +103,7 @@ public class PrintfLikeVariableTypePlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "shelf_count"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form shelf_count:<description>"));
+                + " in comment. Please add a description in the string comment in the form `shelf_count:<description>`"));
   }
 
   @Test

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SimpleRegexPlaceholderDescriptionCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SimpleRegexPlaceholderDescriptionCheckerTest.java
@@ -42,7 +42,7 @@ public class SimpleRegexPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "%1"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form %1:<description>"));
+                + " in comment. Please add a description in the string comment in the form `%1:<description>`"));
   }
 
   @Test
@@ -58,7 +58,7 @@ public class SimpleRegexPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "%1"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form %1:<description>"));
+                + " in comment. Please add a description in the string comment in the form `%1:<description>`"));
   }
 
   @Test
@@ -74,7 +74,7 @@ public class SimpleRegexPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "%2"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form %2:<description>"));
+                + " in comment. Please add a description in the string comment in the form `%2:<description>`"));
   }
 
   @Test
@@ -103,7 +103,7 @@ public class SimpleRegexPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "%d"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form %d:<description>"));
+                + " in comment. Please add a description in the string comment in the form `%d:<description>`"));
   }
 
   @Test
@@ -121,6 +121,6 @@ public class SimpleRegexPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "%s"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form %s:<description>"));
+                + " in comment. Please add a description in the string comment in the form `%s:<description>`"));
   }
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SingleBracesPlaceholderDescriptionCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SingleBracesPlaceholderDescriptionCheckerTest.java
@@ -37,7 +37,7 @@ public class SingleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "placeholder"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form placeholder:<description>"));
+                + " in comment. Please add a description in the string comment in the form `placeholder:<description>`"));
   }
 
   @Test
@@ -52,7 +52,7 @@ public class SingleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "placeholder"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form placeholder:<description>"));
+                + " in comment. Please add a description in the string comment in the form `placeholder:<description>`"));
   }
 
   @Test
@@ -77,7 +77,7 @@ public class SingleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "another"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form another:<description>"));
+                + " in comment. Please add a description in the string comment in the form `another:<description>`"));
   }
 
   @Test
@@ -93,7 +93,7 @@ public class SingleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "numFiles"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form numFiles:<description>"));
+                + " in comment. Please add a description in the string comment in the form `numFiles:<description>`"));
   }
 
   @Test
@@ -110,7 +110,7 @@ public class SingleBracesPlaceholderDescriptionCheckerTest {
                 + QUOTE_MARKER
                 + "0"
                 + QUOTE_MARKER
-                + " in comment. Please add a description in the string comment in the form 0:<description>"));
+                + " in comment. Please add a description in the string comment in the form `0:<description>`"));
   }
 
   @Test


### PR DESCRIPTION
The <description> piece of the placeholder checker error message is stripped in Github due to markdown.

Updated to wrap the `<placeholder name>:<description>` in backticks so the full message is displayed correctly.