### PR TITLE
I18N-1308: Fix circular DI for PreAuthFilter

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
@@ -64,9 +64,6 @@ public class WebSecurityConfig {
   Filter oauth2Filter;
 
   @Autowired(required = false)
-  RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter;
-
-  @Autowired(required = false)
   PreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider;
 
   @Autowired UserService userService;
@@ -252,9 +249,12 @@ public class WebSecurityConfig {
         securityConfig.getAuthenticationType()) {
       switch (authenticationType) {
         case HEADER:
-          Preconditions.checkNotNull(
-              requestHeaderAuthenticationFilter,
-              "The requestHeaderAuthenticationFilter must be configured");
+          RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter =
+              new RequestHeaderAuthenticationFilter();
+          requestHeaderAuthenticationFilter.setPrincipalRequestHeader("x-forwarded-user");
+          requestHeaderAuthenticationFilter.setExceptionIfHeaderMissing(false);
+          requestHeaderAuthenticationFilter.setAuthenticationManager(
+              authenticationConfiguration.getAuthenticationManager());
           logger.debug("Add request header Auth filter");
           requestHeaderAuthenticationFilter.setAuthenticationManager(
               authenticationConfiguration.getAuthenticationManager());

--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityHeaderConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityHeaderConfig.java
@@ -3,38 +3,14 @@ package com.box.l10n.mojito.security;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetailsByNameServiceWrapper;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
-import org.springframework.security.web.authentication.preauth.RequestHeaderAuthenticationFilter;
 
 // This must in sync with {@link
 // com.box.l10n.mojito.security.SecurityConfig.AuthenticationType#HEADER}
 @ConditionalOnExpression("'${l10n.security.authenticationType:}'.toUpperCase().contains('HEADER')")
 @Configuration
 class WebSecurityHeaderConfig {
-
-  @Bean
-  RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter() throws Exception {
-    RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter =
-        new RequestHeaderAuthenticationFilter();
-    requestHeaderAuthenticationFilter.setPrincipalRequestHeader("x-forwarded-user");
-    requestHeaderAuthenticationFilter.setExceptionIfHeaderMissing(false);
-    requestHeaderAuthenticationFilter.setAuthenticationManager(
-        new AuthenticationManager() {
-          @Override
-          public Authentication authenticate(Authentication authentication)
-              throws AuthenticationException {
-            throw new RuntimeException(
-                "This must be overridden with the actual authentication manager of the app - it is not injectable yet with this config style");
-          }
-        });
-
-    return requestHeaderAuthenticationFilter;
-  }
-
   @Bean
   PreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider() {
     PreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider =


### PR DESCRIPTION
`requestHeaderAuthenticationFilter` needs an `AuthenticationManager` or else it throws some  RunTimeException. The previous solution was to create a faked out `AuthenticationManager` which just throws an Exception on the abstract method. 

Later on in the pipeline, the real `AuthenticationManager` is buillt via `AuthConfig` config. The `AuthConfig`cannot be injected into the `WebSecurityHeaderConfig.java` because it builds a dependency of the `AuthConfig`. So it is circular in nature

Ultimately, a bean does not need to be registered for `requestHeaderAuthenticationFilter`. It can be created when the appropriate HEADER auth type is selected. If it is created by `WebSecurityConfig.java`, the `AuthConfig` (and hence `AuthManager`) already exist, so a fake `AuthManager` does not need to be created and there is less confusion about where this auth mechanism gets its config from!