### PR TITLE
Docs: Update to specific pre-fork repo issue

### DIFF
--- a/docs/_docs/refs/configurations.md
+++ b/docs/_docs/refs/configurations.md
@@ -98,7 +98,7 @@ Depending on the file size that will be processed, it might be required to incre
     max_allowed_packet = 256M
     
 
-If using a older version of MySQL, there is a [known issue]({{ site.github_url }}/issues/120) when creating the schema. One workaround is to use `utf8`
+If using a older version of MySQL, there is a [known issue](https://github.com/box/mojito/issues/120) when creating the schema. One workaround is to use `utf8`
 instead `utf8mb4` but it has its limitation in term of character support.
 
 


### PR DESCRIPTION
I assumed that forked repos also clone previous issues and this is not the case, so point back to original issue before the fork