### PR TITLE
Set AITranslationBean as optional dependency in ThirdPartyTMSSync

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -127,7 +127,7 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
       MeterRegistry meterRegistry,
       QuartzPollableTaskScheduler quartzPollableTaskScheduler,
       AITranslationConfiguration aiTranslationConfiguration,
-      AITranslationService aiTranslationService) {
+      @Autowired(required = false) AITranslationService aiTranslationService) {
     this(
         smartlingClient,
         textUnitSearcher,
@@ -754,6 +754,10 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
       String skipAssetsWithPathPattern,
       String includeTextUnitsWithPattern,
       List<String> optionList) {
+    if (aiTranslationService == null) {
+      throw new UnsupportedOperationException(
+          "AI translation service is not supported as no AITranslationService bean is configured.");
+    }
     try (var timer =
         Timer.resource(meterRegistry, "SmartlingSync.pushAITranslations")
             .tag("repository", repository.getName())) {


### PR DESCRIPTION
Allows application to startup if no `AITranslationService` bean is configured.