### PR TITLE
Fix null asset mapping exception on text unit mapping stage

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -286,20 +286,20 @@ public class ThirdPartyService {
 
     logger.debug("Batch the third party text units by asset");
     LoadingCache<String, Optional<Asset>> assetCache = getAssetCache(repository);
+
     Map<Asset, List<ThirdPartyTextUnit>> thirdPartyTextUnitsByAsset =
         thirdPartyTextUnits.stream()
+            .filter(o -> assetCache.getUnchecked(o.getAssetPath()).isPresent())
             .collect(
                 groupingBy(
-                    o -> assetCache.getUnchecked(o.getAssetPath()).orElse(null),
+                    o -> assetCache.getUnchecked(o.getAssetPath()).get(),
                     LinkedHashMap::new,
                     toList()));
 
-    logger.debug(
-        "Perform mapping by asset (exclude null asset, that could appear if asset path didn't match)");
-    thirdPartyTextUnitsByAsset.entrySet().stream()
-        .filter(e -> e.getKey() != null)
-        .forEach(
-            e -> mapThirdPartyTextUnitsToTextUnitDTOs(e.getKey(), e.getValue(), pluralSeparator));
+    logger.debug("Perform mapping by asset");
+    thirdPartyTextUnitsByAsset.forEach(
+        (asset, textUnits) ->
+            mapThirdPartyTextUnitsToTextUnitDTOs(asset, textUnits, pluralSeparator));
   }
 
   @Pollable(message = "Push AI translations to third party service.")


### PR DESCRIPTION
During the text unit mapping stage of a third party sync: If the third party TMS returned a text unit that had an asset path that was never seen in Mojito the mapping would fail as the key would be null which is not allowed in a Map. 

The idea was already there to filter out text units that have a null key for their asset but that would never be reached because of the above exception.

This is only really a problem for dev instances (cold starts) that are pushing assets and doing a third party sync where the asset stored in the third party TMS doesn't exist locally.

**I have tested this by performing a full third party sync and the hash codes / TMS mappings are present on the text units.**