### PR TITLE
Make repository optional parameter in prompt creation command

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/AIRepositoryLocaleOverrideCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/AIRepositoryLocaleOverrideCommand.java
@@ -45,7 +45,7 @@ public class AIRepositoryLocaleOverrideCommand extends Command {
       names = {"--disabled"},
       required = false,
       description =
-          "Indicates if the locales are disabled for AI translation. Setting to false means AI translation will be skipped for the relevant locales. Default is false")
+          "Indicates if the locales are disabled for AI translation. Setting to true means AI translation will be skipped for the relevant locales. Default is false")
   boolean disabled = false;
 
   @Parameter(

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/CreateAIPromptCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/CreateAIPromptCommand.java
@@ -24,7 +24,7 @@ public class CreateAIPromptCommand extends Command {
 
   @Parameter(
       names = {"--repository-name", "-r"},
-      required = true,
+      required = false,
       description = "Repository name")
   String repository;
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/RepositoryLocaleAIPromptRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/RepositoryLocaleAIPromptRepository.java
@@ -34,4 +34,12 @@ public interface RepositoryLocaleAIPromptRepository
           + "WHERE rlap.repository = :repository AND rlap.locale IS NOT NULL AND aipt.name = 'TRANSLATION'")
   Optional<List<RepositoryLocaleAIPrompt>> getRepositoryLocaleTranslationPromptOverrides(
       @Param("repository") Repository repository);
+
+  @Query(
+      "SELECT rlap from RepositoryLocaleAIPrompt rlap "
+          + "JOIN rlap.aiPrompt aip "
+          + "JOIN aip.promptType aipt "
+          + "WHERE rlap.repository = :repository AND rlap.locale IS NULL AND aipt.name = 'TRANSLATION'")
+  Optional<RepositoryLocaleAIPrompt> getRepositoryDefaultTranslationPrompt(
+      @Param("repository") Repository repository);
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/LLMPromptServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/LLMPromptServiceTest.java
@@ -63,6 +63,7 @@ public class LLMPromptServiceTest {
     repositoryLocaleAIPrompt.setId(1L);
     AIPromptType promptType = new AIPromptType();
     promptType.setId(1L);
+    promptType.setName("SOURCE_STRING_CHECKER");
     AIPrompt prompt = new AIPrompt();
     prompt.setId(1L);
     prompt.setUserPrompt("Check strings for spelling");


### PR DESCRIPTION
Removes repository as a required parameter when creating a prompt, if a repository is provided check for an existing default translation prompt for that repository and if it exists update it, if it doesn't exist create it as per previous flow.