### PR TITLE
If MT Review needed variant and only status and include in localized file changed, update TU variant

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslation.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslation.java
@@ -13,6 +13,7 @@ public class AITranslation {
   TMTextUnitVariant.Status status;
   boolean includedInLocalizedFile;
   ZonedDateTime createdDate;
+  String comment;
 
   public TMTextUnit getTmTextUnit() {
     return tmTextUnit;
@@ -68,5 +69,13 @@ public class AITranslation {
 
   public void setContentMd5(String content_md5) {
     this.contentMd5 = content_md5;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public void setComment(String comment) {
+    this.comment = comment;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
@@ -131,18 +131,6 @@ public class AITranslationService {
     jdbcTemplate.update(sql);
   }
 
-  /**
-   * Inserts AI translations into the database.
-   *
-   * @param translationDTOs
-   */
-  @Transactional
-  protected void insertMultiRowAITranslationVariant(
-      Long tmTextUnitId, List<AITranslation> translationDTOs) {
-    insertMultiRowTextUnitVariants(tmTextUnitId, translationDTOs);
-    insertMultiRowTextUnitCurrentVariants(tmTextUnitId, translationDTOs);
-  }
-
   private void insertMultiRowTextUnitVariants(
       Long textUnitId, List<AITranslation> translationDTOs) {
     logger.debug(

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslationServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslationServiceTest.java
@@ -1,22 +1,15 @@
 package com.box.l10n.mojito.service.ai.translation;
 
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.box.l10n.mojito.JSR310Migration;
-import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.PromptType;
-import com.box.l10n.mojito.entity.TM;
-import com.box.l10n.mojito.entity.TMTextUnit;
-import com.box.l10n.mojito.entity.TMTextUnitVariant;
 import com.box.l10n.mojito.service.ai.RepositoryLocaleAIPromptRepository;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitVariantRepository;
 import java.time.Duration;
-import java.util.List;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
@@ -98,47 +91,5 @@ public class AITranslationServiceTest {
     aiTranslationService.createPendingMTEntitiesInBatches(1L, tmTextUnitIds);
 
     verify(jdbcTemplate, times(0)).update(anyString());
-  }
-
-  @Test
-  public void testMultiRowAITranslationVariantInserts() {
-    TM tm = new TM();
-    tm.setId(1L);
-    Asset asset = new Asset();
-    asset.setId(1L);
-    TMTextUnit tmTextUnit = new TMTextUnit();
-    tmTextUnit.setAsset(asset);
-    tmTextUnit.setTm(tm);
-    tmTextUnit.setId(1L);
-    tmTextUnit.setContent("content");
-    tmTextUnit.setContentMd5("md5");
-    AITranslation aiTranslation = new AITranslation();
-    aiTranslation.setTmTextUnit(tmTextUnit);
-    aiTranslation.setLocaleId(1L);
-    aiTranslation.setTranslation("translation");
-    aiTranslation.setStatus(TMTextUnitVariant.Status.MT_TRANSLATED);
-    aiTranslation.setCreatedDate(JSR310Migration.newDateTimeEmptyCtor());
-    aiTranslation.setIncludedInLocalizedFile(false);
-
-    AITranslation aiTranslation2 = new AITranslation();
-    aiTranslation2.setTmTextUnit(tmTextUnit);
-    aiTranslation2.setLocaleId(2L);
-    aiTranslation2.setTranslation("translation2");
-    aiTranslation2.setStatus(TMTextUnitVariant.Status.MT_TRANSLATED);
-    aiTranslation2.setCreatedDate(JSR310Migration.newDateTimeEmptyCtor());
-    aiTranslation2.setIncludedInLocalizedFile(false);
-
-    AITranslation aiTranslation3 = new AITranslation();
-    aiTranslation3.setTmTextUnit(tmTextUnit);
-    aiTranslation3.setLocaleId(3L);
-    aiTranslation3.setTranslation("translation3");
-    aiTranslation3.setStatus(TMTextUnitVariant.Status.MT_TRANSLATED);
-    aiTranslation3.setCreatedDate(JSR310Migration.newDateTimeEmptyCtor());
-    aiTranslation3.setIncludedInLocalizedFile(false);
-    List<AITranslation> translations = List.of(aiTranslation, aiTranslation2, aiTranslation3);
-
-    aiTranslationService.insertMultiRowAITranslationVariant(1L, translations);
-
-    verify(jdbcTemplate, times(2)).batchUpdate(anyString(), anyList());
   }
 }


### PR DESCRIPTION
Fixes issue observed in third party pull where we have an AI translated variant coming back from the third party review unchanged, so only status and inLocalizedFile boolean need to be updated. In this case the existing variant is updated and the current variant mapping table should continue to point to the same variant.

Removed variant server side inserts as it breaks the table auditing, the audit tables store a rev number that is not auto-incrementing so for now revert back to Hibernate inserts for AI translated variants