### PR TITLE
feat(security): Handle service and user pre-auth headers

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/HeaderPreAuthFilter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/HeaderPreAuthFilter.java
@@ -1,0 +1,47 @@
+package com.box.l10n.mojito.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+
+public class HeaderPreAuthFilter extends AbstractPreAuthenticatedProcessingFilter {
+  protected HeaderSecurityConfig headerSecurityConfig;
+
+  /** logger */
+  static Logger logger = LoggerFactory.getLogger(HeaderPreAuthFilter.class);
+
+  public HeaderPreAuthFilter(HeaderSecurityConfig headerSecurityConfig) {
+    this.headerSecurityConfig = headerSecurityConfig;
+  }
+
+  @Override
+  protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
+    String forwardedUser = request.getHeader(headerSecurityConfig.userIdentifyingHeader);
+    if (forwardedUser != null) {
+      if (!forwardedUser.isEmpty()) {
+        return forwardedUser;
+      }
+    }
+
+    String forwardedServiceSpiffe =
+        request.getHeader(headerSecurityConfig.serviceIdentifyingHeader);
+    if (forwardedServiceSpiffe != null) {
+      if (!forwardedServiceSpiffe.isEmpty()) {
+        return forwardedServiceSpiffe;
+      }
+    }
+
+    logger.error(
+        "No auth principal could be found using headers '{}' and '{}'",
+        headerSecurityConfig.userIdentifyingHeader,
+        headerSecurityConfig.serviceIdentifyingHeader);
+
+    return null;
+  }
+
+  @Override
+  protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
+    return getPreAuthenticatedPrincipal(request);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/HeaderPreAuthFilter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/HeaderPreAuthFilter.java
@@ -8,7 +8,6 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
 public class HeaderPreAuthFilter extends AbstractPreAuthenticatedProcessingFilter {
   protected HeaderSecurityConfig headerSecurityConfig;
 
-  /** logger */
   static Logger logger = LoggerFactory.getLogger(HeaderPreAuthFilter.class);
 
   public HeaderPreAuthFilter(HeaderSecurityConfig headerSecurityConfig) {
@@ -19,6 +18,7 @@ public class HeaderPreAuthFilter extends AbstractPreAuthenticatedProcessingFilte
   protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
     String forwardedUser = request.getHeader(headerSecurityConfig.userIdentifyingHeader);
     if (forwardedUser != null) {
+      logger.debug("Forwarded user: {}", forwardedUser);
       if (!forwardedUser.isEmpty()) {
         return forwardedUser;
       }
@@ -27,6 +27,7 @@ public class HeaderPreAuthFilter extends AbstractPreAuthenticatedProcessingFilte
     String forwardedServiceSpiffe =
         request.getHeader(headerSecurityConfig.serviceIdentifyingHeader);
     if (forwardedServiceSpiffe != null) {
+      logger.debug("Forwarded service: {}", forwardedServiceSpiffe);
       if (!forwardedServiceSpiffe.isEmpty()) {
         return forwardedServiceSpiffe;
       }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/HeaderSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/HeaderSecurityConfig.java
@@ -1,0 +1,16 @@
+package com.box.l10n.mojito.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration()
+@ConditionalOnExpression("'${l10n.security.authenticationType:}'.toUpperCase().contains('HEADER')")
+public class HeaderSecurityConfig {
+
+  @Value("${l10n.spring.security.header.user.identifyingHeader:}")
+  public String userIdentifyingHeader;
+
+  @Value("${l10n.spring.security.header.service.identifyingHeader:}")
+  public String serviceIdentifyingHeader;
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/HeaderSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/HeaderSecurityConfig.java
@@ -3,7 +3,7 @@ package com.box.l10n.mojito.security;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration()
+@Configuration
 public class HeaderSecurityConfig {
 
   @Value("${l10n.spring.security.header.user.identifyingHeader:}")
@@ -17,6 +17,28 @@ public class HeaderSecurityConfig {
 
   @Value("${l10n.spring.security.header.service.delimiter:/}")
   protected String serviceDelimiter;
+
+  @Value("${l10n.spring.security.header.service.pagerduty.enableFailedAuthIncidents:false}")
+  protected boolean isPagerDutyEnabled;
+
+  @Value("${l10n.spring.security.header.service.pagerduty.integration.name:#{null}}")
+  protected String pagerDutyIntegrationName;
+
+  public boolean isPagerDutyEnabled() {
+    return isPagerDutyEnabled;
+  }
+
+  public void setPagerDutyEnabled(boolean pagerDutyEnabled) {
+    isPagerDutyEnabled = pagerDutyEnabled;
+  }
+
+  public String getPagerDutyIntegrationName() {
+    return pagerDutyIntegrationName;
+  }
+
+  public void setPagerDutyIntegrationName(String pagerDutyIntegrationName) {
+    this.pagerDutyIntegrationName = pagerDutyIntegrationName;
+  }
 
   public String getUserIdentifyingHeader() {
     return userIdentifyingHeader;

--- a/webapp/src/main/java/com/box/l10n/mojito/security/HeaderSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/HeaderSecurityConfig.java
@@ -1,11 +1,9 @@
 package com.box.l10n.mojito.security;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration()
-@ConditionalOnExpression("'${l10n.security.authenticationType:}'.toUpperCase().contains('HEADER')")
 public class HeaderSecurityConfig {
 
   @Value("${l10n.spring.security.header.user.identifyingHeader:}")
@@ -13,4 +11,10 @@ public class HeaderSecurityConfig {
 
   @Value("${l10n.spring.security.header.service.identifyingHeader:}")
   public String serviceIdentifyingHeader;
+
+  @Value("${l10n.spring.security.header.service.identifyingPrefix:}")
+  public String servicePrefix;
+
+  @Value("${l10n.spring.security.header.service.delimiter:/}")
+  public String serviceDelimiter;
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/HeaderSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/HeaderSecurityConfig.java
@@ -7,14 +7,46 @@ import org.springframework.context.annotation.Configuration;
 public class HeaderSecurityConfig {
 
   @Value("${l10n.spring.security.header.user.identifyingHeader:}")
-  public String userIdentifyingHeader;
+  protected String userIdentifyingHeader;
 
   @Value("${l10n.spring.security.header.service.identifyingHeader:}")
-  public String serviceIdentifyingHeader;
+  protected String serviceIdentifyingHeader;
 
   @Value("${l10n.spring.security.header.service.identifyingPrefix:}")
-  public String servicePrefix;
+  protected String servicePrefix;
 
   @Value("${l10n.spring.security.header.service.delimiter:/}")
-  public String serviceDelimiter;
+  protected String serviceDelimiter;
+
+  public String getUserIdentifyingHeader() {
+    return userIdentifyingHeader;
+  }
+
+  public void setUserIdentifyingHeader(String userIdentifyingHeader) {
+    this.userIdentifyingHeader = userIdentifyingHeader;
+  }
+
+  public String getServiceIdentifyingHeader() {
+    return serviceIdentifyingHeader;
+  }
+
+  public void setServiceIdentifyingHeader(String serviceIdentifyingHeader) {
+    this.serviceIdentifyingHeader = serviceIdentifyingHeader;
+  }
+
+  public String getServicePrefix() {
+    return servicePrefix;
+  }
+
+  public void setServicePrefix(String servicePrefix) {
+    this.servicePrefix = servicePrefix;
+  }
+
+  public String getServiceDelimiter() {
+    return serviceDelimiter;
+  }
+
+  public void setServiceDelimiter(String serviceDelimiter) {
+    this.serviceDelimiter = serviceDelimiter;
+  }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/PrincipalDetailService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/PrincipalDetailService.java
@@ -1,0 +1,9 @@
+package com.box.l10n.mojito.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+public interface PrincipalDetailService extends UserDetailsService {
+  UserDetails loadServiceWithName(String serviceName) throws UsernameNotFoundException;
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceDisambiguator.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceDisambiguator.java
@@ -2,6 +2,9 @@ package com.box.l10n.mojito.security;
 
 import com.box.l10n.mojito.entity.security.user.User;
 import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -9,6 +12,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty("l10n.spring.security.services.enableFuzzyMatch")
 public class ServiceDisambiguator {
+
+  static Logger logger = LoggerFactory.getLogger(ServiceDisambiguator.class);
+
   @Autowired HeaderSecurityConfig headerSecurityConfig;
 
   /***
@@ -21,6 +27,7 @@ public class ServiceDisambiguator {
    */
   public User findServiceWithCommonAncestor(List<User> services, String servicePath) {
     if (services == null || servicePath == null || services.isEmpty() || servicePath.isEmpty()) {
+      logger.debug("No services found or no service path given");
       return null;
     }
 
@@ -30,8 +37,10 @@ public class ServiceDisambiguator {
 
     for (User currentService : services) {
       String currentServicePath = currentService.getUsername();
+      logger.debug("Evaluating service: {}", currentServicePath);
       // Check for exact match first
       if (servicePath.equals(currentServicePath)) {
+        logger.debug("Found exact service: {}", currentServicePath);
         return currentService;
       }
 
@@ -50,6 +59,8 @@ public class ServiceDisambiguator {
         }
       }
 
+      logger.debug("Common ancestor between services found: {}", commonAncestor);
+
       // Update the service which shares the shortest path
       String mostCommonAncestor = commonAncestor.toString();
       if (mostCommonAncestor.isEmpty()) {
@@ -67,6 +78,9 @@ public class ServiceDisambiguator {
       }
     }
 
+    logger.debug(
+        "Matching ancestor service: {}",
+        Optional.ofNullable(closestService).map(User::getUsername).orElse("null"));
     return closestService;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceDisambiguator.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceDisambiguator.java
@@ -1,0 +1,68 @@
+package com.box.l10n.mojito.security;
+
+import com.box.l10n.mojito.entity.security.user.User;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty("l10n.spring.security.services.enableFuzzyMatch")
+public class ServiceDisambiguator {
+  /***
+   * This method finds the service with the longest shared path (basically a parent in path directory)
+   * The service uses its parents user if it exists. If the exact service exists, then that user is
+   * used instead of the parent; to allow for children services to have different permissions
+   *
+   * @param services list of relevant services
+   * @return the User or null if none match
+   */
+  public User findServiceWithCommonAncestor(List<User> services, String servicePath) {
+    if (services == null || servicePath == null || services.isEmpty() || servicePath.isEmpty()) {
+      return null;
+    }
+
+    String[] servicePathElements = servicePath.split("/");
+    String longestAncestorPath = null;
+    User closestService = null;
+
+    for (User currentService : services) {
+      String currentServicePath = currentService.getUsername();
+      // Check for exact match first
+      if (servicePath.equals(currentServicePath)) {
+        return currentService;
+      }
+
+      String[] currentPathElements = currentServicePath.split("/");
+      StringBuilder commonAncestor = new StringBuilder();
+
+      int minLength = Math.min(servicePathElements.length, currentPathElements.length);
+
+      for (int i = 0; i < minLength; i++) {
+        if (servicePathElements[i].equals(currentPathElements[i])) {
+          commonAncestor.append(servicePathElements[i]);
+          if (i < minLength - 1) {
+            commonAncestor.append("/");
+          }
+        }
+      }
+
+      // Update the service which shares the shortest path
+      String mostCommonAncestor = commonAncestor.toString();
+      if (mostCommonAncestor.isEmpty()) {
+        continue;
+      }
+
+      if (mostCommonAncestor.length() != currentServicePath.length()) {
+        continue;
+      }
+
+      if (longestAncestorPath == null
+          || mostCommonAncestor.length() > longestAncestorPath.length()) {
+        longestAncestorPath = mostCommonAncestor;
+        closestService = currentService;
+      }
+    }
+
+    return closestService;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceDisambiguator.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceDisambiguator.java
@@ -2,12 +2,15 @@ package com.box.l10n.mojito.security;
 
 import com.box.l10n.mojito.entity.security.user.User;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConditionalOnProperty("l10n.spring.security.services.enableFuzzyMatch")
 public class ServiceDisambiguator {
+  @Autowired HeaderSecurityConfig headerSecurityConfig;
+
   /***
    * This method finds the service with the longest shared path (basically a parent in path directory)
    * The service uses its parents user if it exists. If the exact service exists, then that user is
@@ -21,7 +24,7 @@ public class ServiceDisambiguator {
       return null;
     }
 
-    String[] servicePathElements = servicePath.split("/");
+    String[] servicePathElements = servicePath.split(headerSecurityConfig.serviceDelimiter);
     String longestAncestorPath = null;
     User closestService = null;
 
@@ -32,7 +35,8 @@ public class ServiceDisambiguator {
         return currentService;
       }
 
-      String[] currentPathElements = currentServicePath.split("/");
+      String[] currentPathElements =
+          currentServicePath.split(headerSecurityConfig.serviceDelimiter);
       StringBuilder commonAncestor = new StringBuilder();
 
       int minLength = Math.min(servicePathElements.length, currentPathElements.length);
@@ -41,7 +45,7 @@ public class ServiceDisambiguator {
         if (servicePathElements[i].equals(currentPathElements[i])) {
           commonAncestor.append(servicePathElements[i]);
           if (i < minLength - 1) {
-            commonAncestor.append("/");
+            commonAncestor.append(headerSecurityConfig.serviceDelimiter);
           }
         }
       }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailServiceAuthWrapper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailServiceAuthWrapper.java
@@ -9,16 +9,20 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 public class UserDetailServiceAuthWrapper
     implements AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {
   protected PrincipalDetailService userDetailsService = null;
+  protected HeaderSecurityConfig headerSecurityConfig;
 
-  public UserDetailServiceAuthWrapper(PrincipalDetailService userDetailsService) {
+  public UserDetailServiceAuthWrapper(
+      PrincipalDetailService userDetailsService, HeaderSecurityConfig headerSecurityConfig) {
     this.userDetailsService = userDetailsService;
+    this.headerSecurityConfig = headerSecurityConfig;
   }
 
   @Override
   public UserDetails loadUserDetails(PreAuthenticatedAuthenticationToken token)
       throws UsernameNotFoundException {
     String username = token.getName();
-    boolean isService = username.contains("spiffe://");
+    boolean isService =
+        headerSecurityConfig != null && username.contains(headerSecurityConfig.servicePrefix);
     if (isService) {
       return this.userDetailsService.loadServiceWithName(username);
     } else {

--- a/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailServiceAuthWrapper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailServiceAuthWrapper.java
@@ -1,0 +1,28 @@
+package com.box.l10n.mojito.security;
+
+import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+/** This service handles requests from users and services differently */
+public class UserDetailServiceAuthWrapper
+    implements AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {
+  protected PrincipalDetailService userDetailsService = null;
+
+  public UserDetailServiceAuthWrapper(PrincipalDetailService userDetailsService) {
+    this.userDetailsService = userDetailsService;
+  }
+
+  @Override
+  public UserDetails loadUserDetails(PreAuthenticatedAuthenticationToken token)
+      throws UsernameNotFoundException {
+    String username = token.getName();
+    boolean isService = username.contains("spiffe://");
+    if (isService) {
+      return this.userDetailsService.loadServiceWithName(username);
+    } else {
+      return this.userDetailsService.loadUserByUsername(username);
+    }
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailServiceAuthWrapper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailServiceAuthWrapper.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.security;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -8,6 +10,9 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 /** This service handles requests from users and services differently */
 public class UserDetailServiceAuthWrapper
     implements AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {
+
+  Logger logger = LoggerFactory.getLogger(UserDetailServiceAuthWrapper.class);
+
   protected PrincipalDetailService userDetailsService = null;
   protected HeaderSecurityConfig headerSecurityConfig;
 
@@ -23,6 +28,8 @@ public class UserDetailServiceAuthWrapper
     String username = token.getName();
     boolean isService =
         headerSecurityConfig != null && username.contains(headerSecurityConfig.servicePrefix);
+    logger.debug("User identifier: {}", username);
+    logger.debug("Following service logic: {}", isService);
     if (isService) {
       return this.userDetailsService.loadServiceWithName(username);
     } else {

--- a/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailsServiceCreatePartialImpl.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailsServiceCreatePartialImpl.java
@@ -24,7 +24,7 @@ public class UserDetailsServiceCreatePartialImpl implements PrincipalDetailServi
 
   @Override
   public UserDetails loadServiceWithName(String serviceName) throws UsernameNotFoundException {
-    User user = userService.getOrCreateServiceAccountUser(serviceName);
+    User user = userService.getServiceAccountUser(serviceName);
     return new UserDetailsImpl(user);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailsServiceCreatePartialImpl.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailsServiceCreatePartialImpl.java
@@ -7,10 +7,9 @@ import com.box.l10n.mojito.service.security.user.UserService;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
-public class UserDetailsServiceCreatePartialImpl implements UserDetailsService {
+public class UserDetailsServiceCreatePartialImpl implements PrincipalDetailService {
 
   /** logger */
   static Logger logger = getLogger(UserDetailsServiceCreatePartialImpl.class);
@@ -20,6 +19,12 @@ public class UserDetailsServiceCreatePartialImpl implements UserDetailsService {
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
     User user = userService.getOrCreatePartialBasicUser(username);
+    return new UserDetailsImpl(user);
+  }
+
+  @Override
+  public UserDetails loadServiceWithName(String serviceName) throws UsernameNotFoundException {
+    User user = userService.getOrCreateServiceAccountUser(serviceName);
     return new UserDetailsImpl(user);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
@@ -29,7 +29,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
-import org.springframework.security.web.authentication.preauth.RequestHeaderAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
@@ -69,6 +68,8 @@ public class WebSecurityConfig {
   @Autowired UserService userService;
 
   @Autowired UserDetailsServiceImpl userDetailsService;
+
+  @Autowired HeaderSecurityConfig headerSecurityConfig;
 
   @Autowired
   public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
@@ -249,12 +250,8 @@ public class WebSecurityConfig {
         securityConfig.getAuthenticationType()) {
       switch (authenticationType) {
         case HEADER:
-          RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter =
-              new RequestHeaderAuthenticationFilter();
-          requestHeaderAuthenticationFilter.setPrincipalRequestHeader("x-forwarded-user");
-          requestHeaderAuthenticationFilter.setExceptionIfHeaderMissing(false);
-          requestHeaderAuthenticationFilter.setAuthenticationManager(
-              authenticationConfiguration.getAuthenticationManager());
+          HeaderPreAuthFilter requestHeaderAuthenticationFilter =
+              new HeaderPreAuthFilter(headerSecurityConfig);
           logger.debug("Add request header Auth filter");
           requestHeaderAuthenticationFilter.setAuthenticationManager(
               authenticationConfiguration.getAuthenticationManager());

--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityHeaderConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityHeaderConfig.java
@@ -3,7 +3,6 @@ package com.box.l10n.mojito.security;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.core.userdetails.UserDetailsByNameServiceWrapper;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
 
 // This must in sync with {@link
@@ -15,15 +14,15 @@ class WebSecurityHeaderConfig {
   PreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider() {
     PreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider =
         new PreAuthenticatedAuthenticationProvider();
-    UserDetailsByNameServiceWrapper userDetailsByNameServiceWrapper =
-        new UserDetailsByNameServiceWrapper(getUserDetailsServiceCreatePartial());
+    UserDetailServiceAuthWrapper userDetailsByNameServiceWrapper =
+        new UserDetailServiceAuthWrapper(getPrincipalDetailsServiceCreatePartial());
     preAuthenticatedAuthenticationProvider.setPreAuthenticatedUserDetailsService(
         userDetailsByNameServiceWrapper);
     return preAuthenticatedAuthenticationProvider;
   }
 
   @Bean
-  protected UserDetailsServiceCreatePartialImpl getUserDetailsServiceCreatePartial() {
+  protected PrincipalDetailService getPrincipalDetailsServiceCreatePartial() {
     return new UserDetailsServiceCreatePartialImpl();
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityHeaderConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityHeaderConfig.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.security;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,12 +11,15 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 @ConditionalOnExpression("'${l10n.security.authenticationType:}'.toUpperCase().contains('HEADER')")
 @Configuration
 class WebSecurityHeaderConfig {
+  @Autowired HeaderSecurityConfig headerSecurityConfig;
+
   @Bean
   PreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider() {
     PreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider =
         new PreAuthenticatedAuthenticationProvider();
     UserDetailServiceAuthWrapper userDetailsByNameServiceWrapper =
-        new UserDetailServiceAuthWrapper(getPrincipalDetailsServiceCreatePartial());
+        new UserDetailServiceAuthWrapper(
+            getPrincipalDetailsServiceCreatePartial(), headerSecurityConfig);
     preAuthenticatedAuthenticationProvider.setPreAuthenticatedUserDetailsService(
         userDetailsByNameServiceWrapper);
     return preAuthenticatedAuthenticationProvider;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
@@ -56,4 +56,14 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
       """)
   Page<User> findByUsernameOrName(
       @Param("username") String username, @Param("search") String search, Pageable pageable);
+
+  @Query(
+      value =
+          """
+    SELECT u FROM  User u
+      WHERE LOWER(u.username) LIKE 'spiffe://%'
+        AND LOWER(u.username) LIKE LOWER(CONCAT(:serviceName, '%'))
+        AND u.enabled = true
+    """)
+  Optional<List<User>> findService(@Param("serviceName") String serviceName);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
@@ -67,6 +67,6 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
         AND u.enabled IS TRUE
     """)
   @EntityGraph(value = "User.legacy", type = EntityGraphType.FETCH)
-  Optional<List<User>> findService(
+  Optional<List<User>> findServicesByServiceNameAndPrefix(
       @Param("serviceName") String serviceName, @Param("servicePrefix") String servicePrefix);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
@@ -61,11 +61,12 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
       value =
           """
     SELECT u FROM  User u
-      WHERE LOWER(u.username) LIKE 'spiffe://%'
-        AND u.username <> '' AND u.username != NULL
+      WHERE COALESCE(u.username, '') <> ''
+        AND LOWER(u.username) LIKE CONCAT(LOWER(:servicePrefix), '%')
         AND LOWER(:serviceName) LIKE CONCAT(LOWER(u.username), '%')
-        AND u.enabled = true
+        AND u.enabled IS TRUE
     """)
   @EntityGraph(value = "User.legacy", type = EntityGraphType.FETCH)
-  Optional<List<User>> findService(@Param("serviceName") String serviceName);
+  Optional<List<User>> findService(
+      @Param("serviceName") String serviceName, @Param("servicePrefix") String servicePrefix);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
@@ -67,6 +67,6 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
         AND u.enabled IS TRUE
     """)
   @EntityGraph(value = "User.legacy", type = EntityGraphType.FETCH)
-  Optional<List<User>> findServicesByServiceNameAndPrefix(
+  List<User> findServicesByServiceNameAndPrefix(
       @Param("serviceName") String serviceName, @Param("servicePrefix") String servicePrefix);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java
@@ -62,8 +62,10 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
           """
     SELECT u FROM  User u
       WHERE LOWER(u.username) LIKE 'spiffe://%'
-        AND LOWER(u.username) LIKE LOWER(CONCAT(:serviceName, '%'))
+        AND u.username <> '' AND u.username != NULL
+        AND LOWER(:serviceName) LIKE CONCAT(LOWER(u.username), '%')
         AND u.enabled = true
     """)
+  @EntityGraph(value = "User.legacy", type = EntityGraphType.FETCH)
   Optional<List<User>> findService(@Param("serviceName") String serviceName);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserService.java
@@ -409,9 +409,8 @@ public class UserService {
   /**
    * Gets a service by name and if it doesn't exist create a created user.
    *
-   * <p>All admin service accounts should already be created beforehand.
-   * Get the exact service account or any service account which is the
-   * ancestor service to the account
+   * <p>All admin service accounts should already be created beforehand. Get the exact service
+   * account or any service account which is the ancestor service to the account
    *
    * @param serviceName
    * @return
@@ -423,7 +422,8 @@ public class UserService {
     }
 
     Optional<List<User>> users =
-        userRepository.findServicesByServiceNameAndPrefix(serviceName, headerSecurityConfig.getServicePrefix());
+        userRepository.findServicesByServiceNameAndPrefix(
+            serviceName, headerSecurityConfig.getServicePrefix());
     if (users.isEmpty()) {
       logger.debug("No matching services found as per DB query");
       sendPagerDutyNotification(serviceName);
@@ -433,8 +433,7 @@ public class UserService {
       return null;
     }
 
-    User matchingUser =
-        serviceDisambiguator.findServiceWithCommonAncestor(users.get(), serviceName);
+    User matchingUser = serviceDisambiguator.getServiceWithCommonAncestor(users.get(), serviceName);
     if (matchingUser == null) {
       logger.debug("No matching services found as per ServiceDisambiguator");
       sendPagerDutyNotification(serviceName);

--- a/webapp/src/test/java/com/box/l10n/mojito/security/ServiceDisambiguatorTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/security/ServiceDisambiguatorTest.java
@@ -22,16 +22,16 @@ public class ServiceDisambiguatorTest {
   @Test
   public void testFindServiceWithShortestSharedAncestor_EdgeCases() {
     User sharedAncestor =
-        serviceDisambiguator.findServiceWithCommonAncestor(
+        serviceDisambiguator.getServiceWithCommonAncestor(
             new ArrayList<>(), "spiffe://test.com/container/service");
     assertNull(sharedAncestor);
-    sharedAncestor = serviceDisambiguator.findServiceWithCommonAncestor(new ArrayList<>(), "");
+    sharedAncestor = serviceDisambiguator.getServiceWithCommonAncestor(new ArrayList<>(), "");
     assertNull(sharedAncestor);
-    sharedAncestor = serviceDisambiguator.findServiceWithCommonAncestor(new ArrayList<>(), null);
+    sharedAncestor = serviceDisambiguator.getServiceWithCommonAncestor(new ArrayList<>(), null);
     assertNull(sharedAncestor);
-    sharedAncestor = serviceDisambiguator.findServiceWithCommonAncestor(null, "");
+    sharedAncestor = serviceDisambiguator.getServiceWithCommonAncestor(null, "");
     assertNull(sharedAncestor);
-    sharedAncestor = serviceDisambiguator.findServiceWithCommonAncestor(null, "test");
+    sharedAncestor = serviceDisambiguator.getServiceWithCommonAncestor(null, "test");
     assertNull(sharedAncestor);
   }
 
@@ -47,11 +47,11 @@ public class ServiceDisambiguatorTest {
                 "spiffe://test.com/container1/imageService",
                 "spiffe://test.com/container1/userService"));
     User result =
-        serviceDisambiguator.findServiceWithCommonAncestor(
+        serviceDisambiguator.getServiceWithCommonAncestor(
             services, "spiffe://test.com/container1/tagService");
     assertEquals(result, services.get(3));
     result =
-        serviceDisambiguator.findServiceWithCommonAncestor(
+        serviceDisambiguator.getServiceWithCommonAncestor(
             services, "spiffe://test.com/container1/imageService");
     assertEquals(result, services.get(4));
   }
@@ -65,14 +65,14 @@ public class ServiceDisambiguatorTest {
                 "spiffe://test.com/infra/jenkins/agent2",
                 "spiffe://test.com/infra/jenkins"));
     User result =
-        serviceDisambiguator.findServiceWithCommonAncestor(
+        serviceDisambiguator.getServiceWithCommonAncestor(
             services, "spiffe://test.com/infra/jenkins/agent1");
     assertEquals(result, services.getFirst());
     result =
-        serviceDisambiguator.findServiceWithCommonAncestor(
+        serviceDisambiguator.getServiceWithCommonAncestor(
             services, "spiffe://test.com/infra/jenkins/agent3");
     assertEquals(result, services.get(2));
-    result = serviceDisambiguator.findServiceWithCommonAncestor(services, "spiffe://test.com");
+    result = serviceDisambiguator.getServiceWithCommonAncestor(services, "spiffe://test.com");
     assertNull(result);
   }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/security/ServiceDisambiguatorTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/security/ServiceDisambiguatorTest.java
@@ -1,0 +1,93 @@
+package com.box.l10n.mojito.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.box.l10n.mojito.entity.security.user.User;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(
+    properties = {
+      "app.name=InlineTestApplication",
+      "l10n.spring.security.header.service.prefix=spiffe://"
+    })
+public class ServiceDisambiguatorTest {
+
+  ServiceDisambiguator serviceDisambiguator = new ServiceDisambiguator();
+
+  @Test
+  public void testFindServiceWithShortestSharedAncestor_EdgeCases() {
+    User sharedAncestor =
+        serviceDisambiguator.findServiceWithCommonAncestor(
+            new ArrayList<>(), "spiffe://test.com/container/service");
+    assertNull(sharedAncestor);
+    sharedAncestor = serviceDisambiguator.findServiceWithCommonAncestor(new ArrayList<>(), "");
+    assertNull(sharedAncestor);
+    sharedAncestor = serviceDisambiguator.findServiceWithCommonAncestor(new ArrayList<>(), null);
+    assertNull(sharedAncestor);
+    sharedAncestor = serviceDisambiguator.findServiceWithCommonAncestor(null, "");
+    assertNull(sharedAncestor);
+    sharedAncestor = serviceDisambiguator.findServiceWithCommonAncestor(null, "test");
+    assertNull(sharedAncestor);
+  }
+
+  @Test
+  public void testFindServiceWithShortestSharedAncestor_ExactMatch() throws Exception {
+    List<User> services =
+        generateServices(
+            List.of(
+                "spiffe://test.com/container2/tagService",
+                "spiffe://test.com/container2/imageService",
+                "spiffe://test.com/container2/userService",
+                "spiffe://test.com/container1/tagService",
+                "spiffe://test.com/container1/imageService",
+                "spiffe://test.com/container1/userService"));
+    User result =
+        serviceDisambiguator.findServiceWithCommonAncestor(
+            services, "spiffe://test.com/container1/tagService");
+    assertEquals(result, services.get(3));
+    result =
+        serviceDisambiguator.findServiceWithCommonAncestor(
+            services, "spiffe://test.com/container1/imageService");
+    assertEquals(result, services.get(4));
+  }
+
+  @Test
+  public void testFindServiceWithShortestSharedAncestor_SpecificExamples() {
+    List<User> services =
+        generateServices(
+            List.of(
+                "spiffe://test.com/infra/jenkins/agent1",
+                "spiffe://test.com/infra/jenkins/agent2",
+                "spiffe://test.com/infra/jenkins"));
+    User result =
+        serviceDisambiguator.findServiceWithCommonAncestor(
+            services, "spiffe://test.com/infra/jenkins/agent1");
+    assertEquals(result, services.getFirst());
+    result =
+        serviceDisambiguator.findServiceWithCommonAncestor(
+            services, "spiffe://test.com/infra/jenkins/agent3");
+    assertEquals(result, services.get(2));
+    result = serviceDisambiguator.findServiceWithCommonAncestor(services, "spiffe://test.com");
+    assertNull(result);
+  }
+
+  private List<User> generateServices(List<String> names) {
+    return IntStream.range(0, names.size())
+        .mapToObj(
+            i -> {
+              String serviceName = names.get(i);
+              User user = new User();
+              user.setUsername(serviceName);
+              user.setId((long) i);
+              return user;
+            })
+        .toList();
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/security/ServiceDisambiguatorTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/security/ServiceDisambiguatorTest.java
@@ -8,18 +8,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest
-@TestPropertySource(
-    properties = {
-      "app.name=InlineTestApplication",
-      "l10n.spring.security.header.service.prefix=spiffe://"
-    })
 public class ServiceDisambiguatorTest {
+  ServiceDisambiguator serviceDisambiguator;
 
-  ServiceDisambiguator serviceDisambiguator = new ServiceDisambiguator();
+  public ServiceDisambiguatorTest() {
+    this.serviceDisambiguator = new ServiceDisambiguator();
+    this.serviceDisambiguator.headerSecurityConfig = new HeaderSecurityConfig();
+    this.serviceDisambiguator.headerSecurityConfig.servicePrefix = "spiffe://";
+    this.serviceDisambiguator.headerSecurityConfig.serviceDelimiter = "/";
+  }
 
   @Test
   public void testFindServiceWithShortestSharedAncestor_EdgeCases() {


### PR DESCRIPTION
* Create user service endpoint to allow for a fuzzy search based on service name
* Create custom PreAuthFilter which takes both user and service headers into consideration.
   * The precedence is for user headers if both are specified
* Create logic for disambiguate which users / services to use when multiple services match the results
   Summary: use exact service first, then any services which are ancestors to this service (if their users exist)
* If a service does not exist and attempts authenication, a Pager Duty incident is created