### PR TITLE
Exclude AI translations from repository statistics translated stats

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
@@ -227,7 +227,8 @@ public class OpenAILLMService implements LLMService {
             })
         .doOnError(
             e -> {
-              logger.error("Error translating text unit {}", tmTextUnit.getId(), e);
+              logger.error(
+                  "Error translating text unit {} to {}", tmTextUnit.getId(), targetBcp47Tag, e);
               meterRegistry
                   .counter(
                       "OpenAILLMService.translate.result",
@@ -237,7 +238,8 @@ public class OpenAILLMService implements LLMService {
         .retryWhen(llmTranslateRetryConfig)
         .doOnError(
             e -> {
-              logger.error("Error translating text unit {}", tmTextUnit.getId(), e);
+              logger.error(
+                  "Error translating text unit {} to {}", tmTextUnit.getId(), targetBcp47Tag, e);
               meterRegistry
                   .counter(
                       "OpenAILLMService.translate.result",
@@ -245,7 +247,10 @@ public class OpenAILLMService implements LLMService {
                   .increment();
             })
         .blockOptional()
-        .orElseThrow(() -> new AIException("Error translating text unit " + tmTextUnit.getId()));
+        .orElseThrow(
+            () ->
+                new AIException(
+                    "Error translating text unit " + tmTextUnit.getId() + " to " + targetBcp47Tag));
   }
 
   @Timed("OpenAILLMService.checkString")

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticService.java
@@ -35,6 +35,7 @@ import jakarta.persistence.EntityManager;
 import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -359,6 +360,7 @@ public class RepositoryStatisticService {
                         textUnitDTOsForLocaleByMD5.values().stream()
                             .filter(TextUnitDTO::isTranslated)
                             .filter(TextUnitDTO::isUsed)
+                            .filter(Predicate.not(TextUnitDTO::isAiTranslateStatus))
                             .peek(
                                 t ->
                                     logger.debug(
@@ -369,6 +371,7 @@ public class RepositoryStatisticService {
                         textUnitDTOsForLocaleByMD5.values().stream()
                             .filter(TextUnitDTO::isTranslated)
                             .filter(TextUnitDTO::isUsed)
+                            .filter(Predicate.not(TextUnitDTO::isAiTranslateStatus))
                             .mapToLong(wordCountFunction())
                             .sum());
 
@@ -422,6 +425,7 @@ public class RepositoryStatisticService {
                         textUnitDTOsForLocaleByMD5.values().stream()
                             .filter(TextUnitDTO::isUsed)
                             .filter(TextUnitDTO::isIncludedInLocalizedFile)
+                            .filter(Predicate.not(TextUnitDTO::isAiTranslateStatus))
                             .peek(
                                 t ->
                                     logger.debug(
@@ -434,6 +438,7 @@ public class RepositoryStatisticService {
                         textUnitDTOsForLocaleByMD5.values().stream()
                             .filter(TextUnitDTO::isUsed)
                             .filter(TextUnitDTO::isIncludedInLocalizedFile)
+                            .filter(Predicate.not(TextUnitDTO::isAiTranslateStatus))
                             .mapToLong(wordCountFunction())
                             .sum());
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
@@ -251,4 +251,9 @@ public class TextUnitDTO {
   public void setUploadedFileUri(String uploadedFileUri) {
     this.uploadedFileUri = uploadedFileUri;
   }
+
+  public boolean isAiTranslateStatus() {
+    return status == TMTextUnitVariant.Status.MT_TRANSLATED
+        || status == TMTextUnitVariant.Status.MT_REVIEW_NEEDED;
+  }
 }


### PR DESCRIPTION
Exclude variants with status `MT_TRANSLATED` or `MT_REVIEW_NEEDED` from repository statistics 'translated' counts are they are not included in the localized files when in these states.