### PR TITLE
I18N-1339 - Add PagerDuty incident tracking to avoid sending redundant requests

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/PagerDutyIncident.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/PagerDutyIncident.java
@@ -2,11 +2,18 @@ package com.box.l10n.mojito.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.ZonedDateTime;
 
 @Entity
-@Table(name = "pagerduty_incidents")
+@Table(
+    name = "pagerduty_incidents",
+    indexes = {
+      @Index(
+          name = "I__PAGERDUTY_INCIDENTS__CLIENT_NAME__DEDUP_KEY__RESOLVED_AT",
+          columnList = "client_name, dedup_key, resolved_at")
+    })
 public class PagerDutyIncident extends BaseEntity {
   @Column(name = "client_name")
   String clientName;

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/PagerDutyIncident.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/PagerDutyIncident.java
@@ -1,0 +1,54 @@
+package com.box.l10n.mojito.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "pagerduty_incidents")
+public class PagerDutyIncident extends BaseEntity {
+  @Column(name = "client_name")
+  String clientName;
+
+  @Column(name = "dedup_key")
+  String dedupKey;
+
+  @Column(name = "triggered_at")
+  private ZonedDateTime triggeredAt;
+
+  @Column(name = "resolved_at")
+  private ZonedDateTime resolvedAt;
+
+  public String getClientName() {
+    return clientName;
+  }
+
+  public void setClientName(String clientName) {
+    this.clientName = clientName;
+  }
+
+  public String getDedupKey() {
+    return dedupKey;
+  }
+
+  public void setDedupKey(String dedupKey) {
+    this.dedupKey = dedupKey;
+  }
+
+  public ZonedDateTime getTriggeredAt() {
+    return triggeredAt;
+  }
+
+  public void setTriggeredAt(ZonedDateTime triggeredAt) {
+    this.triggeredAt = triggeredAt;
+  }
+
+  public ZonedDateTime getResolvedAt() {
+    return resolvedAt;
+  }
+
+  public void setResolvedAt(ZonedDateTime resolvedAt) {
+    this.resolvedAt = resolvedAt;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.pagerduty;
 
+import com.box.l10n.mojito.entity.PagerDutyIncident;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.net.URI;
@@ -7,6 +8,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -28,18 +30,21 @@ public class PagerDutyClient {
   private final String integrationKey;
   private final PagerDutyRetryConfiguration retryConfiguration;
   private final String clientName;
+  private final PagerDutyIncidentRepository pagerDutyIncidentRepository;
 
   public PagerDutyClient(
       String integrationKey,
       HttpClient httpClient,
       PagerDutyRetryConfiguration retryConfiguration,
-      String clientName) {
+      String clientName,
+      PagerDutyIncidentRepository pagerDutyIncidentRepository) {
     if (integrationKey == null || integrationKey.isEmpty())
       throw new IllegalArgumentException("Pager Duty integration key is null or empty.");
     this.integrationKey = integrationKey;
     this.httpClient = httpClient;
     this.retryConfiguration = retryConfiguration;
     this.clientName = clientName;
+    this.pagerDutyIncidentRepository = pagerDutyIncidentRepository;
   }
 
   /**
@@ -49,6 +54,11 @@ public class PagerDutyClient {
    * cannot be serialized a PagerDutyException is thrown.
    */
   public void triggerIncident(String dedupKey, PagerDutyPayload payload) throws PagerDutyException {
+    if (pagerDutyIncidentRepository.findOpenIncident(clientName, dedupKey).isPresent()) {
+      logger.debug(
+          "Open incident exists for deduplication key: '{}', ignoring trigger request.", dedupKey);
+      return;
+    }
     sendPayload(dedupKey, payload, PagerDutyPostData.EventAction.TRIGGER);
   }
 
@@ -59,6 +69,11 @@ public class PagerDutyClient {
    * PagerDutyException is thrown.
    */
   public void resolveIncident(String dedupKey) throws PagerDutyException {
+    if (pagerDutyIncidentRepository.findOpenIncident(clientName, dedupKey).isEmpty()) {
+      logger.debug(
+          "No open incident for deduplication key: '{}', ignoring resolve request.", dedupKey);
+      return;
+    }
     sendPayload(dedupKey, null, PagerDutyPostData.EventAction.RESOLVE);
   }
 
@@ -75,7 +90,7 @@ public class PagerDutyClient {
 
     try {
       HttpRequest request = buildRequest(postBody.serialize());
-      sendRequestWithRetries(request).block();
+      sendRequestWithRetries(request, dedupKey, eventAction).block();
     } catch (JsonProcessingException e) {
       throw new PagerDutyException("Failed to serialize PagerDutyPostRequest to a JSON string.");
     } catch (Exception e) {
@@ -87,8 +102,9 @@ public class PagerDutyClient {
     }
   }
 
-  private Mono<Void> sendRequestWithRetries(HttpRequest request) {
-    return Mono.fromCallable(() -> this.sendRequest(request))
+  private Mono<Void> sendRequestWithRetries(
+      HttpRequest request, String dedupKey, PagerDutyPostData.EventAction eventAction) {
+    return Mono.fromCallable(() -> this.sendRequest(request, dedupKey, eventAction))
         .retryWhen(
             Retry.backoff(
                     retryConfiguration.getMaxRetries(),
@@ -110,13 +126,28 @@ public class PagerDutyClient {
         .then();
   }
 
-  private HttpResponse<String> sendRequest(HttpRequest request) throws PagerDutyException {
+  private HttpResponse<String> sendRequest(
+      HttpRequest request, String dedupKey, PagerDutyPostData.EventAction eventAction)
+      throws PagerDutyException {
     try {
       HttpResponse<String> response =
           httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
       int statusCode = response.statusCode();
-      if (statusCode == 200 || statusCode == 202) return response;
+      if (statusCode == 200 || statusCode == 202) {
+        PagerDutyIncident incident;
+        if (eventAction == PagerDutyPostData.EventAction.TRIGGER) {
+          incident = new PagerDutyIncident();
+          incident.setClientName(clientName);
+          incident.setDedupKey(dedupKey);
+          incident.setTriggeredAt(ZonedDateTime.now());
+        } else {
+          incident = pagerDutyIncidentRepository.findOpenIncident(clientName, dedupKey).get();
+          incident.setResolvedAt(ZonedDateTime.now());
+        }
+        pagerDutyIncidentRepository.save(incident);
+        return response;
+      }
 
       throw new PagerDutyException(statusCode, response.body());
     } catch (IOException | InterruptedException e) {

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
@@ -27,16 +27,19 @@ public class PagerDutyClient {
   private final HttpClient httpClient;
   private final String integrationKey;
   private final PagerDutyRetryConfiguration retryConfiguration;
+  private final String clientName;
 
   public PagerDutyClient(
       String integrationKey,
       HttpClient httpClient,
-      PagerDutyRetryConfiguration retryConfiguration) {
+      PagerDutyRetryConfiguration retryConfiguration,
+      String clientName) {
     if (integrationKey == null || integrationKey.isEmpty())
       throw new IllegalArgumentException("Pager Duty integration key is null or empty.");
     this.integrationKey = integrationKey;
     this.httpClient = httpClient;
     this.retryConfiguration = retryConfiguration;
+    this.clientName = clientName;
   }
 
   /**

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
@@ -24,8 +24,6 @@ public class PagerDutyClient {
   static final String BASE_URL = "https://events.pagerduty.com";
   static final String ENQUEUE_PATH = "/v2/enqueue";
 
-  public static final int MAX_RETRIES = 3;
-
   private final HttpClient httpClient;
   private final String integrationKey;
   private final PagerDutyRetryConfiguration retryConfiguration;
@@ -43,7 +41,7 @@ public class PagerDutyClient {
 
   /**
    * Trigger incident using a deduplication key and send PagerDutyPayload with it. The client will
-   * attempt to send the event request MAX_RETRIES times if an internal error is received from the
+   * attempt to send the event request 'maxRetries' times if an internal error is received from the
    * server. If the max number of retries is reached, a bad request is received or the payload
    * cannot be serialized a PagerDutyException is thrown.
    */
@@ -53,7 +51,7 @@ public class PagerDutyClient {
 
   /**
    * Resolve incident using a deduplication key. The client will attempt to send the event request
-   * MAX_RETRIES times if an internal error is received from the server. If the max number of
+   * 'maxRetries' times if an internal error is received from the server. If the max number of
    * retries is reached, a bad request is received or the payload cannot be serialized a
    * PagerDutyException is thrown.
    */

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIncidentRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIncidentRepository.java
@@ -1,0 +1,13 @@
+package com.box.l10n.mojito.pagerduty;
+
+import com.box.l10n.mojito.entity.PagerDutyIncident;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PagerDutyIncidentRepository extends JpaRepository<PagerDutyIncident, Long> {
+
+  @Query(
+      "SELECT pdi FROM PagerDutyIncident pdi WHERE pdi.clientName = :clientName AND pdi.dedupKey = :dedupKey AND pdi.resolvedAt IS NULL")
+  Optional<PagerDutyIncident> findOpenIncident(String clientName, String dedupKey);
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationConfiguration.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties("l10n.pagerduty")
 public class PagerDutyIntegrationConfiguration {
+  private String defaultIntegration;
+
   private Map<String, String> integrations = new HashMap<>();
 
   public Map<String, String> getIntegrations() {
@@ -16,5 +18,13 @@ public class PagerDutyIntegrationConfiguration {
 
   public void setIntegrations(Map<String, String> integrations) {
     this.integrations = integrations;
+  }
+
+  public String getDefaultIntegration() {
+    return defaultIntegration;
+  }
+
+  public void setDefaultIntegration(String defaultIntegration) {
+    this.defaultIntegration = defaultIntegration;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationService.java
@@ -7,20 +7,28 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/**
+ * Service for serving PagerDuty clients created from the app properties. To use the default PD
+ * client method the default client must be set under `l10n.pagerduty.defaultIntegration`
+ *
+ * @author mattwilshire
+ */
 @Component
 public class PagerDutyIntegrationService {
 
   private final PagerDutyIntegrationConfiguration pagerDutyIntegrationConfiguration;
   private final PagerDutyRetryConfiguration pagerDutyRetryConfiguration;
-
   private Map<String, PagerDutyClient> pagerDutyClients;
+  private final PagerDutyIncidentRepository pagerDutyIncidentRepository;
 
   @Autowired
   public PagerDutyIntegrationService(
       PagerDutyIntegrationConfiguration pagerDutyIntegrationsConfiguration,
-      PagerDutyRetryConfiguration pagerDutyRetryConfiguration) {
+      PagerDutyRetryConfiguration pagerDutyRetryConfiguration,
+      PagerDutyIncidentRepository pagerDutyIncidentRepository) {
     this.pagerDutyIntegrationConfiguration = pagerDutyIntegrationsConfiguration;
     this.pagerDutyRetryConfiguration = pagerDutyRetryConfiguration;
+    this.pagerDutyIncidentRepository = pagerDutyIncidentRepository;
 
     createClientsFromConfiguration();
   }
@@ -47,6 +55,7 @@ public class PagerDutyIntegrationService {
                             e.getValue(),
                             HttpClient.newHttpClient(),
                             pagerDutyRetryConfiguration,
-                            e.getKey())));
+                            e.getKey(),
+                            pagerDutyIncidentRepository)));
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationService.java
@@ -32,7 +32,8 @@ public class PagerDutyIntegrationService {
   }
 
   public Optional<PagerDutyClient> getDefaultPagerDutyClient() {
-    return getPagerDutyClient("default");
+    if (pagerDutyIntegrationConfiguration.getDefaultIntegration() == null) return Optional.empty();
+    return getPagerDutyClient(pagerDutyIntegrationConfiguration.getDefaultIntegration());
   }
 
   private void createClientsFromConfiguration() {
@@ -45,6 +46,7 @@ public class PagerDutyIntegrationService {
                         new PagerDutyClient(
                             e.getValue(),
                             HttpClient.newHttpClient(),
-                            pagerDutyRetryConfiguration)));
+                            pagerDutyRetryConfiguration,
+                            e.getKey())));
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/jobs/ScheduledThirdPartySync.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/jobs/ScheduledThirdPartySync.java
@@ -133,7 +133,7 @@ public class ScheduledThirdPartySync implements IScheduledJob {
 
               String scheduledJobUrl =
                   UriComponentsBuilder.fromHttpUrl(serverConfig.getUrl())
-                      .path("api/jobs/" + scheduledJob.getId())
+                      .path("api/jobs/" + scheduledJob.getUuid())
                       .build()
                       .toUriString();
 

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -256,8 +256,9 @@ spring.session.jdbc.table-name=SPRING_SESSION_V2
 #l10n.blob-storage.s3.bucket=mojito
 #l10n.blob-storage.s3.prefix=mojito
 
-# PagerDuty - Value is an integration key for 'Events API v2' integration
-#l10n.pagerduty.integrations.default=xxxyyyzzz
+# PagerDuty - Value 'xyz' should be an integration key for 'Events API v2' integration
+# l10n.pagerduty.defaultIntegration=namehere
+# l10n.pagerduty.integrations.namehere=xyz
 
 # Adjust the number of retries and delay between retries for the PagerDuty client
 # l10n.pagerduty.retry.maxRetries=5

--- a/webapp/src/main/resources/db/migration/V73__Add_pagerduty_incidents.sql
+++ b/webapp/src/main/resources/db/migration/V73__Add_pagerduty_incidents.sql
@@ -5,3 +5,5 @@ CREATE TABLE pagerduty_incidents (
     triggered_at DATETIME NULL NOT NULL,
     resolved_at DATETIME NULL DEFAULT NULL
 );
+
+create index I__PAGERDUTY_INCIDENTS__CLIENT_NAME__DEDUP_KEY__RESOLVED_AT on pagerduty_incidents (client_name, dedup_key, resolved_at);

--- a/webapp/src/main/resources/db/migration/v73__Add_pagerduty_incidents.sql
+++ b/webapp/src/main/resources/db/migration/v73__Add_pagerduty_incidents.sql
@@ -1,0 +1,7 @@
+CREATE TABLE pagerduty_incidents (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    client_name VARCHAR(255) NOT NULL,
+    dedup_key VARCHAR(255) NOT NULL,
+    triggered_at DATETIME NULL NOT NULL,
+    resolved_at DATETIME NULL DEFAULT NULL
+);

--- a/webapp/src/test/java/com/box/l10n/mojito/pagerduty/PagerDutyClientTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/pagerduty/PagerDutyClientTest.java
@@ -35,7 +35,7 @@ public class PagerDutyClientTest {
     httpClient = mock(HttpClient.class);
     httpResponse = mock(HttpResponse.class);
 
-    pagerDutyClient = new PagerDutyClient("xxxyyyzzz", httpClient, retryConfiguration);
+    pagerDutyClient = new PagerDutyClient("xxxyyyzzz", httpClient, retryConfiguration, "test");
 
     Map<String, String> customDetails = new HashMap<>();
     customDetails.put("Example Custom Details", "Example Value");
@@ -177,9 +177,9 @@ public class PagerDutyClientTest {
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> new PagerDutyClient(null, httpClient, retryConfiguration));
+        () -> new PagerDutyClient(null, httpClient, retryConfiguration, "test"));
     assertThrows(
         IllegalArgumentException.class,
-        () -> new PagerDutyClient("", httpClient, retryConfiguration));
+        () -> new PagerDutyClient("", httpClient, retryConfiguration, "test"));
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/pagerduty/PagerDutyClientTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/pagerduty/PagerDutyClientTest.java
@@ -2,18 +2,21 @@ package com.box.l10n.mojito.pagerduty;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.box.l10n.mojito.entity.PagerDutyIncident;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,13 +32,17 @@ public class PagerDutyClientTest {
 
   private PagerDutyPayload samplePayload;
   private PagerDutyRetryConfiguration retryConfiguration = new PagerDutyRetryConfiguration();
+  private PagerDutyIncidentRepository pagerDutyIncidentRepository;
 
   @BeforeEach
   public void setup() {
     httpClient = mock(HttpClient.class);
     httpResponse = mock(HttpResponse.class);
+    pagerDutyIncidentRepository = mock(PagerDutyIncidentRepository.class);
 
-    pagerDutyClient = new PagerDutyClient("xxxyyyzzz", httpClient, retryConfiguration, "test");
+    pagerDutyClient =
+        new PagerDutyClient(
+            "xxxyyyzzz", httpClient, retryConfiguration, "test", pagerDutyIncidentRepository);
 
     Map<String, String> customDetails = new HashMap<>();
     customDetails.put("Example Custom Details", "Example Value");
@@ -53,6 +60,10 @@ public class PagerDutyClientTest {
 
     try {
       pagerDutyClient.triggerIncident("dedpuKey", samplePayload);
+
+      // Respond with fake open incident to allow resolve to go through.
+      when(pagerDutyIncidentRepository.findOpenIncident(any(), any()))
+          .thenReturn(Optional.of(new PagerDutyIncident()));
       pagerDutyClient.resolveIncident("dedupKey");
     } catch (PagerDutyException e) {
       fail("PagerDutyClient should not throw exception when the response code is 202.");
@@ -146,6 +157,9 @@ public class PagerDutyClientTest {
     assertThrows(
         PagerDutyException.class, () -> pagerDutyClient.triggerIncident("dedpuKey", samplePayload));
 
+    // Fake open incident
+    when(pagerDutyIncidentRepository.findOpenIncident(any(), any()))
+        .thenReturn(Optional.of(new PagerDutyIncident()));
     assertThrows(PagerDutyException.class, () -> pagerDutyClient.resolveIncident("dedupKey"));
 
     verify(httpClient, times(2))
@@ -162,6 +176,9 @@ public class PagerDutyClientTest {
     assertThrows(
         PagerDutyException.class, () -> pagerDutyClient.triggerIncident("", samplePayload));
 
+    // Respond with fake open incident to allow resolve to go through.
+    when(pagerDutyIncidentRepository.findOpenIncident(any(), any()))
+        .thenReturn(Optional.of(new PagerDutyIncident()));
     assertThrows(PagerDutyException.class, () -> pagerDutyClient.resolveIncident(null));
 
     verify(httpClient, never())
@@ -177,9 +194,36 @@ public class PagerDutyClientTest {
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> new PagerDutyClient(null, httpClient, retryConfiguration, "test"));
+        () ->
+            new PagerDutyClient(
+                null, httpClient, retryConfiguration, "test", pagerDutyIncidentRepository));
     assertThrows(
         IllegalArgumentException.class,
-        () -> new PagerDutyClient("", httpClient, retryConfiguration, "test"));
+        () ->
+            new PagerDutyClient(
+                "", httpClient, retryConfiguration, "test", pagerDutyIncidentRepository));
+  }
+
+  @Test
+  public void testDoesntSendPayload() throws IOException, InterruptedException {
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpClient.send(
+            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    try {
+      // There is an open incident, the client shouldn't send the trigger payload
+      when(pagerDutyIncidentRepository.findOpenIncident(any(), any()))
+          .thenReturn(Optional.of(new PagerDutyIncident()));
+      pagerDutyClient.triggerIncident("dedpuKey", samplePayload);
+
+      // There is no open incident, the client shouldn't send the resolve payload
+      when(pagerDutyIncidentRepository.findOpenIncident(any(), any())).thenReturn(Optional.empty());
+      pagerDutyClient.resolveIncident("dedupKey");
+    } catch (PagerDutyException e) {
+      fail("PagerDutyClient should not throw exception when the response code is 202.");
+    }
+
+    verify(httpClient, times(0)).send(any(), any());
   }
 }


### PR DESCRIPTION
Add tracking to creating / resolving PagerDuty incidents to ensure we are not making any duplicate requests to PD as there is no need to resolve an incident that has never been open or to trigger an incident that is already opened.