### PR TITLE
Log text units exceeds max request only if there are active prompts for the repository

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
@@ -55,16 +55,16 @@ public class AITranslationService {
 
   @Transactional
   public void createPendingMTEntitiesInBatches(Long repositoryId, Set<Long> tmTextUnitIds) {
-    if (tmTextUnitIds.size() > maxTextUnitsAIRequest) {
-      logger.warn(
-          "Number of text units ({}) exceeds the maximum number of text units that can be sent for AI translation per request ({}). AI translation will be skipped.",
-          tmTextUnitIds.size(),
-          maxTextUnitsAIRequest);
-      return;
-    }
     if (repositoryLocaleAIPromptRepository.findCountOfActiveRepositoryPromptsByType(
             repositoryId, PromptType.TRANSLATION.toString())
         > 0) {
+      if (tmTextUnitIds.size() > maxTextUnitsAIRequest) {
+        logger.warn(
+            "Number of text units ({}) exceeds the maximum number of text units that can be sent for AI translation per request ({}). AI translation will be skipped.",
+            tmTextUnitIds.size(),
+            maxTextUnitsAIRequest);
+        return;
+      }
       createPendingMTEntitiesInBatches(tmTextUnitIds);
     } else {
       logger.debug("No active prompts for repository: {}, no job scheduled", repositoryId);


### PR DESCRIPTION
This change ensures that we don't log warnings for repositories that are not configured for AI translation, by first checking if we have any active translation prompts for this repository. If not no log is required as no AI translation would occur anyway.