### PR TITLE
I18N-1195: Trigger BranchStatsJob when Branch is created

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetService.java
@@ -163,7 +163,7 @@ public class AssetService {
       FilterConfigIdOverride filterConfigIdOverride,
       List<String> filterOptions,
       @InjectCurrentTask PollableTask currentTask)
-      throws InterruptedException, ExecutionException, UnsupportedAssetFilterTypeException {
+      throws InterruptedException, UnsupportedAssetFilterTypeException {
 
     PollableFutureTaskResult<Asset> pollableFutureTaskResult = new PollableFutureTaskResult<>();
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchService.java
@@ -11,6 +11,7 @@ import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.tm.BranchSourceRepository;
+import com.box.l10n.mojito.service.tm.textunitdtocache.UpdateType;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import java.text.MessageFormat;
@@ -42,6 +43,8 @@ public class BranchService {
 
   @Autowired BranchSourceConfig branchSourceConfig;
 
+  @Autowired BranchStatisticService branchStatisticService;
+
   @Value("${l10n.branchService.quartz.schedulerName:" + DEFAULT_SCHEDULER_NAME + "}")
   String schedulerName;
 
@@ -56,8 +59,9 @@ public class BranchService {
     branch.setCreatedByUser(createdByUser);
     branch.setNotifiers(branchNotifierIds);
     branch = branchRepository.save(branch);
-
     addBranchSource(branch);
+
+    branchStatisticService.computeAndSaveBranchStatistic(repository, branchName, UpdateType.ALWAYS);
 
     return branch;
   }


### PR DESCRIPTION
Prior to this change, when a branch is created, the stats for the branch would only be created when a RepoStats Job is run. This would only happen when a text unit is updated in the DB.

Problem: for smaller repos which do not update text units often, this would mean a branch notification would only be sent much later

Now, we trigger a compute branch stats on branch create so that the branch gets notified as soon as possible