### PR TITLE
Add Parsing functionality for service headers

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceIdentifierParser.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceIdentifierParser.java
@@ -13,6 +13,7 @@ public class ServiceIdentifierParser {
     if (serviceIdentifierParserConfig.isEnabled()) {
       return keyValueParser.parseHeader(
           header,
+          serviceIdentifierParserConfig.getServiceInstanceDelimiter(),
           serviceIdentifierParserConfig.getKeyValueDelimiter(),
           serviceIdentifierParserConfig.getValueDelimiter(),
           serviceIdentifierParserConfig.getIdentifierKey());

--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceIdentifierParser.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceIdentifierParser.java
@@ -1,0 +1,23 @@
+package com.box.l10n.mojito.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServiceIdentifierParser {
+  private final ServiceKeyValueParser keyValueParser = new ServiceKeyValueParser();
+
+  @Autowired ServiceIdentifierParserConfig serviceIdentifierParserConfig;
+
+  String parseHeader(String header) throws ServiceNotIdentifiableException {
+    if (serviceIdentifierParserConfig.isEnabled()) {
+      return keyValueParser.parseHeader(
+          header,
+          serviceIdentifierParserConfig.getKeyValueDelimiter(),
+          serviceIdentifierParserConfig.getValueDelimiter(),
+          serviceIdentifierParserConfig.getIdentifierKey());
+    }
+
+    return header;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceIdentifierParserConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceIdentifierParserConfig.java
@@ -5,13 +5,16 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ServiceIdentifierParserConfig {
+  @Value("${l10n.spring.security.header.parser.serviceInstanceDelimiter:,}")
+  protected String serviceInstanceDelimiter;
+
   @Value("${l10n.spring.security.header.parser.keyValueDelimiter:;}")
   protected String keyValueDelimiter;
 
   @Value("${l10n.spring.security.header.parser.valueDelimiter:=}")
   protected String valueDelimiter;
 
-  @Value("${l10n.spring.security.header.parser.identifierKey:}")
+  @Value("${l10n.spring.security.header.parser.identifierKey:URI}")
   protected String identifierKey;
 
   @Value("${l10n.spring.security.header.serviceParser.enabled:false}")
@@ -47,5 +50,13 @@ public class ServiceIdentifierParserConfig {
 
   public void setIdentifierKey(String identifierKey) {
     this.identifierKey = identifierKey;
+  }
+
+  public String getServiceInstanceDelimiter() {
+    return serviceInstanceDelimiter;
+  }
+
+  public void setServiceInstanceDelimiter(String serviceInstanceDelimiter) {
+    this.serviceInstanceDelimiter = serviceInstanceDelimiter;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceIdentifierParserConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceIdentifierParserConfig.java
@@ -1,0 +1,51 @@
+package com.box.l10n.mojito.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServiceIdentifierParserConfig {
+  @Value("${l10n.spring.security.header.parser.keyValueDelimiter:;}")
+  protected String keyValueDelimiter;
+
+  @Value("${l10n.spring.security.header.parser.valueDelimiter:=}")
+  protected String valueDelimiter;
+
+  @Value("${l10n.spring.security.header.parser.identifierKey:}")
+  protected String identifierKey;
+
+  @Value("${l10n.spring.security.header.serviceParser.enabled:false}")
+  protected boolean isEnabled;
+
+  public boolean isEnabled() {
+    return isEnabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    isEnabled = enabled;
+  }
+
+  public String getKeyValueDelimiter() {
+    return keyValueDelimiter;
+  }
+
+  public void setKeyValueDelimiter(String keyValueDelimiter) {
+    this.keyValueDelimiter = keyValueDelimiter;
+  }
+
+  public String getValueDelimiter() {
+    return valueDelimiter;
+  }
+
+  public void setValueDelimiter(String valueDelimiter) {
+    this.valueDelimiter = valueDelimiter;
+  }
+
+  public String getIdentifierKey() {
+    return identifierKey;
+  }
+
+  public void setIdentifierKey(String identifierKey) {
+    this.identifierKey = identifierKey;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceKeyValueParser.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceKeyValueParser.java
@@ -14,15 +14,23 @@ public class ServiceKeyValueParser {
   Logger logger = LoggerFactory.getLogger(ServiceKeyValueParser.class);
 
   public String parseHeader(
-      String header, String keyValueDelimiter, String valueDelimiter, String identifierKey)
+      String header,
+      String serviceInstanceDelimiter,
+      String keyValueDelimiter,
+      String valueDelimiter,
+      String identifierKey)
       throws ServiceNotIdentifiableException {
     logger.debug("Parsing header: {}", header);
     if (header == null || header.isEmpty()) {
       throw new ServiceNotIdentifiableException("Service identifier not found");
     }
 
+    String[] serviceIdentifiers = header.split(serviceInstanceDelimiter);
+    // We assume that only the last service identifier is relevant
+    String relevantService = serviceIdentifiers[serviceIdentifiers.length - 1];
+
     Map<String, String> keyValueMap =
-        Stream.of(header.split(keyValueDelimiter))
+        Stream.of(relevantService.split(keyValueDelimiter))
             .map(kv -> kv.split(valueDelimiter))
             .filter(pair -> pair.length == 2)
             .collect(Collectors.toMap(parts -> parts[0], parts -> parts[1]));

--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceKeyValueParser.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceKeyValueParser.java
@@ -1,0 +1,38 @@
+package com.box.l10n.mojito.security;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/***
+ * Service for parsing the contents of a service header for identification
+ */
+public class ServiceKeyValueParser {
+
+  Logger logger = LoggerFactory.getLogger(ServiceKeyValueParser.class);
+
+  public String parseHeader(
+      String header, String keyValueDelimiter, String valueDelimiter, String identifierKey)
+      throws ServiceNotIdentifiableException {
+    logger.debug("Parsing header: {}", header);
+    if (header == null || header.isEmpty()) {
+      throw new ServiceNotIdentifiableException("Service identifier not found");
+    }
+
+    Map<String, String> keyValueMap =
+        Stream.of(header.split(keyValueDelimiter))
+            .map(kv -> kv.split(valueDelimiter))
+            .filter(pair -> pair.length == 2)
+            .collect(Collectors.toMap(parts -> parts[0], parts -> parts[1]));
+
+    String serviceIdentifierValue = keyValueMap.get(identifierKey);
+    logger.debug("Service identifier: {}", serviceIdentifierValue);
+    if (serviceIdentifierValue == null || serviceIdentifierValue.isEmpty()) {
+      throw new ServiceNotIdentifiableException("Service identifier not found");
+    }
+
+    return serviceIdentifierValue;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/ServiceNotIdentifiableException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ServiceNotIdentifiableException.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.security;
+
+public class ServiceNotIdentifiableException extends RuntimeException {
+
+  public ServiceNotIdentifiableException(String message) {
+    super(message);
+  }
+
+  public ServiceNotIdentifiableException(String message, Throwable t) {
+    super(message, t);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailServiceAuthWrapper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailServiceAuthWrapper.java
@@ -15,11 +15,15 @@ public class UserDetailServiceAuthWrapper
 
   protected PrincipalDetailService userDetailsService = null;
   protected HeaderSecurityConfig headerSecurityConfig;
+  protected ServiceIdentifierParser serviceIdentifierParser;
 
   public UserDetailServiceAuthWrapper(
-      PrincipalDetailService userDetailsService, HeaderSecurityConfig headerSecurityConfig) {
+      PrincipalDetailService userDetailsService,
+      HeaderSecurityConfig headerSecurityConfig,
+      ServiceIdentifierParser serviceIdentifierParser) {
     this.userDetailsService = userDetailsService;
     this.headerSecurityConfig = headerSecurityConfig;
+    this.serviceIdentifierParser = serviceIdentifierParser;
   }
 
   @Override
@@ -29,9 +33,10 @@ public class UserDetailServiceAuthWrapper
     boolean isService =
         headerSecurityConfig != null && username.contains(headerSecurityConfig.servicePrefix);
     logger.debug("User identifier: {}", username);
-    logger.debug("Following service logic: {}", isService);
+    logger.debug("Is using service authentication flow: {}", isService);
     if (isService) {
-      return this.userDetailsService.loadServiceWithName(username);
+      String serviceName = serviceIdentifierParser.parseHeader(username);
+      return this.userDetailsService.loadServiceWithName(serviceName);
     } else {
       return this.userDetailsService.loadUserByUsername(username);
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityHeaderConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityHeaderConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 @Configuration
 class WebSecurityHeaderConfig {
   @Autowired HeaderSecurityConfig headerSecurityConfig;
+  @Autowired ServiceIdentifierParser serviceIdentifierParser;
 
   @Bean
   PreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider() {
@@ -19,7 +20,9 @@ class WebSecurityHeaderConfig {
         new PreAuthenticatedAuthenticationProvider();
     UserDetailServiceAuthWrapper userDetailsByNameServiceWrapper =
         new UserDetailServiceAuthWrapper(
-            getPrincipalDetailsServiceCreatePartial(), headerSecurityConfig);
+            getPrincipalDetailsServiceCreatePartial(),
+            headerSecurityConfig,
+            serviceIdentifierParser);
     preAuthenticatedAuthenticationProvider.setPreAuthenticatedUserDetailsService(
         userDetailsByNameServiceWrapper);
     return preAuthenticatedAuthenticationProvider;

--- a/webapp/src/test/java/com/box/l10n/mojito/security/ServiceKeyValueParserTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/security/ServiceKeyValueParserTest.java
@@ -1,0 +1,64 @@
+package com.box.l10n.mojito.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+public class ServiceKeyValueParserTest {
+
+  private ServiceKeyValueParser parser;
+
+  @BeforeEach
+  public void setUp() {
+    parser = new ServiceKeyValueParser();
+  }
+
+  @Test
+  public void testParseHeader_EmptyHeaderOrNull() {
+    Executable executable = () -> parser.parseHeader("", ",", "=", "id");
+    assertThrows(ServiceNotIdentifiableException.class, executable);
+    executable = () -> parser.parseHeader(null, ",", "=", "id");
+    assertThrows(ServiceNotIdentifiableException.class, executable);
+  }
+
+  @Test
+  public void testParseHeader_ValidCsvInput() {
+    String header = "key1=value1,key2=value2,id=someService";
+    String result = parser.parseHeader(header, ",", "=", "id");
+    assertEquals("someService", result);
+  }
+
+  @Test
+  public void testParseHeader_ValidSemicolonInput() {
+    String header = "key1:=value1;key2:=value2;id:=someService";
+    String result = parser.parseHeader(header, ";", ":=", "id");
+    assertEquals("someService", result);
+  }
+
+  @Test
+  public void testParseHeader_NoIdentifierKey() {
+    String header = "key1=value1,key2=value2";
+    Executable executable = () -> parser.parseHeader(header, ",", "=", "id");
+    ServiceNotIdentifiableException exception =
+        assertThrows(ServiceNotIdentifiableException.class, executable);
+    assertEquals("Service identifier not found", exception.getMessage());
+  }
+
+  @Test
+  public void testParseHeader_InvalidFormat() {
+    String header = "key1=value1&key2value2&id=someService";
+    Executable executable = () -> parser.parseHeader(header, ";", "=", "id");
+    assertThrows(ServiceNotIdentifiableException.class, executable);
+  }
+
+  @Test
+  public void testParseHeader_EmptyServiceIdentifier() {
+    String header = "key1=value1,key2=value2,id=";
+    Executable executable = () -> parser.parseHeader(header, ",", "=", "id");
+    ServiceNotIdentifiableException exception =
+        assertThrows(ServiceNotIdentifiableException.class, executable);
+    assertEquals("Service identifier not found", exception.getMessage());
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/security/ServiceKeyValueParserTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/security/ServiceKeyValueParserTest.java
@@ -17,30 +17,37 @@ public class ServiceKeyValueParserTest {
 
   @Test
   public void testParseHeader_EmptyHeaderOrNull() {
-    Executable executable = () -> parser.parseHeader("", ",", "=", "id");
+    Executable executable = () -> parser.parseHeader("", "/", ",", "=", "id");
     assertThrows(ServiceNotIdentifiableException.class, executable);
-    executable = () -> parser.parseHeader(null, ",", "=", "id");
+    executable = () -> parser.parseHeader(null, "&", ",", "=", "id");
     assertThrows(ServiceNotIdentifiableException.class, executable);
   }
 
   @Test
   public void testParseHeader_ValidCsvInput() {
     String header = "key1=value1,key2=value2,id=someService";
-    String result = parser.parseHeader(header, ",", "=", "id");
+    String result = parser.parseHeader(header, "&", ",", "=", "id");
     assertEquals("someService", result);
+  }
+
+  @Test
+  public void testParseHeader_ValidMultipleServiceInstanceInput() {
+    String header = "key1=value1,key2=value2,id=firstService&id=lastService";
+    String result = parser.parseHeader(header, "&", ",", "=", "id");
+    assertEquals("lastService", result);
   }
 
   @Test
   public void testParseHeader_ValidSemicolonInput() {
     String header = "key1:=value1;key2:=value2;id:=someService";
-    String result = parser.parseHeader(header, ";", ":=", "id");
+    String result = parser.parseHeader(header, "&", ";", ":=", "id");
     assertEquals("someService", result);
   }
 
   @Test
   public void testParseHeader_NoIdentifierKey() {
     String header = "key1=value1,key2=value2";
-    Executable executable = () -> parser.parseHeader(header, ",", "=", "id");
+    Executable executable = () -> parser.parseHeader(header, "&", ",", "=", "id");
     ServiceNotIdentifiableException exception =
         assertThrows(ServiceNotIdentifiableException.class, executable);
     assertEquals("Service identifier not found", exception.getMessage());
@@ -49,14 +56,14 @@ public class ServiceKeyValueParserTest {
   @Test
   public void testParseHeader_InvalidFormat() {
     String header = "key1=value1&key2value2&id=someService";
-    Executable executable = () -> parser.parseHeader(header, ";", "=", "id");
+    Executable executable = () -> parser.parseHeader(header, "-", ";", "=", "id");
     assertThrows(ServiceNotIdentifiableException.class, executable);
   }
 
   @Test
   public void testParseHeader_EmptyServiceIdentifier() {
     String header = "key1=value1,key2=value2,id=";
-    Executable executable = () -> parser.parseHeader(header, ",", "=", "id");
+    Executable executable = () -> parser.parseHeader(header, "&", ",", "=", "id");
     ServiceNotIdentifiableException exception =
         assertThrows(ServiceNotIdentifiableException.class, executable);
     assertEquals("Service identifier not found", exception.getMessage());


### PR DESCRIPTION
Our service headers are a more complex string type and not solely the identifier of the service.
As such, It is necessary to parse the string to extract just the service identifier.

An example such a header:
By=example.com/mojito/dev;Hash=hash;URI=serviceExample