### PR TITLE
Branches page - show spinner while search is still ongoing

### DIFF
--- a/webapp/src/main/resources/public/js/components/branches/BranchesPage.jsx
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesPage.jsx
@@ -154,7 +154,7 @@ class BranchesPage extends React.Component {
                         }}/>
                 </AltContainer>
 
-                <AltContainer stores={{ branchesStore: BranchesStore, branchTextUnitsStore: BranchTextUnitsStore}}>
+                <AltContainer stores={{ branchesSearchParamStore: BranchesSearchParamStore, branchesStore: BranchesStore, branchTextUnitsStore: BranchTextUnitsStore}}>
                     <BranchesSearchResults
                         onChangeSelectedBranchTextUnits={(selectedBranchTextUnitIds) => {
                             BranchesPageActions.changeSelectedBranchTextUnitIds(selectedBranchTextUnitIds);

--- a/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.jsx
@@ -29,6 +29,7 @@ import BranchesPageActions from "../../actions/branches/BranchesPageActions";
 class BranchesSearchResults extends React.Component {
 
     static propTypes = {
+        "branchesSearchParamStore": PropTypes.object.isRequired,
         "branchesStore": PropTypes.object.isRequired,
         "branchTextUnitsStore": PropTypes.object.isRequired,
         "onChangeOpenBranchStatistic": PropTypes.func.isRequired,
@@ -63,7 +64,7 @@ class BranchesSearchResults extends React.Component {
 
     renderGridHeader() {
         return (
-            <Row className="bms" className="branches-branchstatistic-header">
+            <Row className="bms branches-branchstatistic-header">
                 <Col md={4} className="branches-branchstatistic-col1">
                     <FormattedMessage id="branches.header.branch"/>
                 </Col>
@@ -343,9 +344,15 @@ class BranchesSearchResults extends React.Component {
     }
 
     render() {
+        if (this.props.branchesSearchParamStore.isSpinnerShown) {
+            return <div class="branch-spinner mtl mbl">
+                <span className="glyphicon glyphicon-refresh spinning" />
+            </div>
+        }
+
         return (
             <div>
-                <div className="mll mrl" className="branches-branchstatistic">
+                <div className="mll mrl branches-branchstatistic">
                     <Grid fluid={true}>
                         {this.renderGridHeader()}
                         {this.props.branchesStore.branchStatistics.map(this.renderBranchStatistic.bind(this))}

--- a/webapp/src/main/resources/public/js/components/screenshots/ScreenshotsGrid.jsx
+++ b/webapp/src/main/resources/public/js/components/screenshots/ScreenshotsGrid.jsx
@@ -108,6 +108,14 @@ class ScreenshotsGrid extends React.Component {
                 </div>);
     }
 
+    renderSpinner() {
+        return (
+          <div class="branch-spinner mtl mbl">
+            <span className="glyphicon glyphicon-refresh spinning" />
+          </div>
+        );
+    }
+
     /**
      * @return {JSX}
      */
@@ -115,7 +123,7 @@ class ScreenshotsGrid extends React.Component {
         var res;
 
         if (this.props.searching) {
-            res = null;
+            res = this.renderSpinner();
         } else if (this.props.screenshotsData.length > 0) {
             res = this.renderWithResults();
         } else {

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
@@ -695,7 +695,6 @@ let SearchResults = createReactClass({
             }
         }
 
-        return result;
     },
 
     /**
@@ -710,6 +709,13 @@ let SearchResults = createReactClass({
     },
 
     render() {
+        if (this.state.isSearching) {
+            return <div class="branch-spinner mtl mbl">
+                <span className="glyphicon glyphicon-refresh spinning" />
+            </div>
+        }
+
+
         return (
             <div onKeyUp={this.onKeyUpSearchResults} onClick={this.onChangeSearchResults}>
                 {this.getTextUnitToolbarUI()}

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -645,6 +645,12 @@ label.current-pageNumber {
     overflow-y: auto;
 }
 
+.branch-spinner {
+    display: flex;
+    justify-content: center;  
+    align-items: center;
+}
+
 .textunit-toolbar-clear {
     clear: both;
 }


### PR DESCRIPTION
Add spinner while data is still populating (i.e. we should not show old or empty table data if the new search data is not back yet)