### PR TITLE
I18N-1398: Mojito UX Adjustments

### DIFF
--- a/webapp/src/main/resources/public/js/components/branches/BranchesPage.jsx
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesPage.jsx
@@ -154,7 +154,7 @@ class BranchesPage extends React.Component {
                         }}/>
                 </AltContainer>
 
-                <AltContainer stores={{ branchesStore: BranchesStore, branchTextUnitsStore: BranchTextUnitsStore}}>
+                <AltContainer stores={{ branchesSearchParamStore: BranchesSearchParamStore, branchesStore: BranchesStore, branchTextUnitsStore: BranchTextUnitsStore}}>
                     <BranchesSearchResults
                         onChangeSelectedBranchTextUnits={(selectedBranchTextUnitIds) => {
                             BranchesPageActions.changeSelectedBranchTextUnitIds(selectedBranchTextUnitIds);

--- a/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.jsx
@@ -29,6 +29,7 @@ import BranchesPageActions from "../../actions/branches/BranchesPageActions";
 class BranchesSearchResults extends React.Component {
 
     static propTypes = {
+        "branchesSearchParamStore": PropTypes.object.isRequired,
         "branchesStore": PropTypes.object.isRequired,
         "branchTextUnitsStore": PropTypes.object.isRequired,
         "onChangeOpenBranchStatistic": PropTypes.func.isRequired,
@@ -63,7 +64,7 @@ class BranchesSearchResults extends React.Component {
 
     renderGridHeader() {
         return (
-            <Row className="bms" className="branches-branchstatistic-header">
+            <Row className="bms branches-branchstatistic-header">
                 <Col md={4} className="branches-branchstatistic-col1">
                     <FormattedMessage id="branches.header.branch"/>
                 </Col>
@@ -343,9 +344,15 @@ class BranchesSearchResults extends React.Component {
     }
 
     render() {
+        if (this.props.branchesSearchParamStore.isSpinnerShown) {
+            return <div class="branch-spinner mtl mbl">
+                <span className="glyphicon glyphicon-refresh spinning" />
+            </div>
+        }
+
         return (
             <div>
-                <div className="mll mrl" className="branches-branchstatistic">
+                <div className="mll mrl branches-branchstatistic">
                     <Grid fluid={true}>
                         {this.renderGridHeader()}
                         {this.props.branchesStore.branchStatistics.map(this.renderBranchStatistic.bind(this))}

--- a/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.jsx
@@ -1,6 +1,11 @@
 import React from "react";
-import PropTypes from 'prop-types';
-import {FormattedDate, FormattedMessage, FormattedNumber, injectIntl} from "react-intl";
+import PropTypes from "prop-types";
+import {
+    FormattedDate,
+    FormattedMessage,
+    FormattedNumber,
+    injectIntl,
+} from "react-intl";
 import {
     Button,
     Col,
@@ -12,11 +17,11 @@ import {
     MenuItem,
     OverlayTrigger,
     Row,
-    Tooltip
+    Tooltip,
 } from "react-bootstrap";
-import {Link, withRouter} from "react-router";
+import { Link, withRouter } from "react-router";
 import ClassNames from "classnames";
-import {withAppConfig} from "../../utils/AppConfig";
+import { withAppConfig } from "../../utils/AppConfig";
 import LinkHelper from "../../utils/LinkHelper";
 import Paginator from "../widgets/Paginator";
 import AltContainer from "alt-container";
@@ -24,68 +29,77 @@ import BranchTextUnitsPaginatorStore from "../../stores/branches/BranchTextUnits
 import BranchTextUnitsPaginatorActions from "../../actions/branches/BranchTextUnitsPaginatorActions";
 import BranchTextUnitsPageActions from "../../actions/branches/BranchTextUnitsPageActions";
 import BranchesPageActions from "../../actions/branches/BranchesPageActions";
-
+import DelayedSpinner from "../common/DelayedSpinner";
 
 class BranchesSearchResults extends React.Component {
-
     static propTypes = {
-        "branchesSearchParamStore": PropTypes.object.isRequired,
-        "branchesStore": PropTypes.object.isRequired,
-        "branchTextUnitsStore": PropTypes.object.isRequired,
-        "onChangeOpenBranchStatistic": PropTypes.func.isRequired,
-        "onChangeSelectedBranchTextUnits": PropTypes.func.isRequired,
-        "onShowBranchScreenshotsClick": PropTypes.func.isRequired,
-        "onNeedTranslationClick": PropTypes.func.isRequired,
-        "onTextUnitNameClick": PropTypes.func.isRequired,
+        branchesSearchParamStore: PropTypes.object.isRequired,
+        branchesStore: PropTypes.object.isRequired,
+        branchTextUnitsStore: PropTypes.object.isRequired,
+        onChangeOpenBranchStatistic: PropTypes.func.isRequired,
+        onChangeSelectedBranchTextUnits: PropTypes.func.isRequired,
+        onShowBranchScreenshotsClick: PropTypes.func.isRequired,
+        onNeedTranslationClick: PropTypes.func.isRequired,
+        onTextUnitNameClick: PropTypes.func.isRequired,
     };
 
     isBranchStatisticOpen(branchStatistic) {
-        return this.props.branchesStore.openBranchStatisticId === branchStatistic.id;
+        return (
+            this.props.branchesStore.openBranchStatisticId ===
+            branchStatistic.id
+        );
     }
 
     renderScreenshotPreview(branchStatistic) {
-
         let numberOfScreenshots =
-            this.props.branchesStore.textUnitsWithScreenshotsByBranchStatisticId[branchStatistic.id].size;
-        let { textUnitTotalCount : expectedNumberOfScreenshots} = branchStatistic;
-        let needScreenshot = Math.max(expectedNumberOfScreenshots - numberOfScreenshots, 0);
+            this.props.branchesStore
+                .textUnitsWithScreenshotsByBranchStatisticId[branchStatistic.id]
+                .size;
+        let { textUnitTotalCount: expectedNumberOfScreenshots } =
+            branchStatistic;
+        let needScreenshot = Math.max(
+            expectedNumberOfScreenshots - numberOfScreenshots,
+            0
+        );
 
-        return <div>
-            {
-                needScreenshot === 0 ?
+        return (
+            <div>
+                {needScreenshot === 0 ? (
                     <Label bsStyle="success" className="mrs">
-                        <FormattedMessage id="branches.done"/>
+                        <FormattedMessage id="branches.done" />
                     </Label>
-                    :
-                    <FormattedNumber value={needScreenshot}/>
-            }
-        </div>;
+                ) : (
+                    <FormattedNumber value={needScreenshot} />
+                )}
+            </div>
+        );
     }
 
     renderGridHeader() {
         return (
             <Row className="bms branches-branchstatistic-header">
                 <Col md={4} className="branches-branchstatistic-col1">
-                    <FormattedMessage id="branches.header.branch"/>
+                    <FormattedMessage id="branches.header.branch" />
                 </Col>
                 <Col md={2}>
-                    <FormattedMessage id="branches.header.needsTranslation"/>
+                    <FormattedMessage id="branches.header.needsTranslation" />
                 </Col>
                 <Col md={2}>
-                    <FormattedMessage id="branches.header.screenshots"/>
+                    <FormattedMessage id="branches.header.screenshots" />
                 </Col>
                 <Col md={2}>
-                    <FormattedMessage id="branches.header.createdBy"/>
+                    <FormattedMessage id="branches.header.createdBy" />
                 </Col>
                 <Col md={2}>
-                    <FormattedMessage id="branches.header.createdDate"/>
+                    <FormattedMessage id="branches.header.createdDate" />
                 </Col>
             </Row>
         );
     }
 
     renderBranchTextUnitsPagination() {
-        const branchTextUnitsPaginatorState = BranchTextUnitsPaginatorStore.getState();
+        const branchTextUnitsPaginatorState =
+            BranchTextUnitsPaginatorStore.getState();
         let pageSizes = [];
         for (let i of [10, 25, 50, 100]) {
             pageSizes.push(
@@ -96,31 +110,51 @@ class BranchesSearchResults extends React.Component {
                     onSelect={(s, _) => {
                         BranchTextUnitsPaginatorActions.changePageSize(s);
                         BranchTextUnitsPageActions.getBranchTextUnits();
-                    }
-                }>
+                    }}
+                >
                     {i}
                 </MenuItem>
             );
         }
-        const title = <FormattedMessage values={{"pageSize": branchTextUnitsPaginatorState.limit}} id="search.unitsPerPage" />;
+        const title = (
+            <FormattedMessage
+                values={{ pageSize: branchTextUnitsPaginatorState.limit }}
+                id="search.unitsPerPage"
+            />
+        );
         return (
             <Row>
-                <div className="pull-right" style={{display: "flex", alignItems: "center", "gap": "15px"}}>
-                    <DropdownButton id="branch-text-units-per-page" title={title}>
+                <div
+                    className="pull-right"
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "15px",
+                    }}
+                >
+                    <DropdownButton
+                        id="branch-text-units-per-page"
+                        title={title}
+                    >
                         {pageSizes}
                     </DropdownButton>
                     <AltContainer store={BranchTextUnitsPaginatorStore}>
                         <Paginator
                             onPreviousPageClicked={() => {
-                                BranchesPageActions.changeSelectedBranchTextUnitIds([]);
+                                BranchesPageActions.changeSelectedBranchTextUnitIds(
+                                    []
+                                );
                                 BranchTextUnitsPaginatorActions.goToPreviousPage();
                                 BranchTextUnitsPageActions.getBranchTextUnits();
                             }}
                             onNextPageClicked={() => {
-                                BranchesPageActions.changeSelectedBranchTextUnitIds([]);
+                                BranchesPageActions.changeSelectedBranchTextUnitIds(
+                                    []
+                                );
                                 BranchTextUnitsPaginatorActions.goToNextPage();
                                 BranchTextUnitsPageActions.getBranchTextUnits();
-                            }}/>
+                            }}
+                        />
                     </AltContainer>
                 </div>
             </Row>
@@ -132,17 +166,30 @@ class BranchesSearchResults extends React.Component {
 
         rows.push(this.renderBranchStatisticSummary(branchStatistic));
 
-        if (branchStatistic.isPaginated === false){
-            branchStatistic.branchTextUnitStatistics.map((branchTextUnitStatistic) => {
-                rows.push(this.renderBranchTextUnitStatistic(branchStatistic, branchTextUnitStatistic));
-            });
+        if (branchStatistic.isPaginated === false) {
+            branchStatistic.branchTextUnitStatistics.map(
+                (branchTextUnitStatistic) => {
+                    rows.push(
+                        this.renderBranchTextUnitStatistic(
+                            branchStatistic,
+                            branchTextUnitStatistic
+                        )
+                    );
+                }
+            );
         } else {
             if (this.isBranchStatisticOpen(branchStatistic)) {
                 rows.push(this.renderBranchTextUnitsPagination());
             }
-            const { branchTextUnitStatistics } = this.props.branchTextUnitsStore;
+            const { branchTextUnitStatistics } =
+                this.props.branchTextUnitsStore;
             branchTextUnitStatistics.map((branchTextUnitStatistic) => {
-                rows.push(this.renderBranchTextUnitStatistic(branchStatistic, branchTextUnitStatistic));
+                rows.push(
+                    this.renderBranchTextUnitStatistic(
+                        branchStatistic,
+                        branchTextUnitStatistic
+                    )
+                );
             });
         }
 
@@ -153,191 +200,302 @@ class BranchesSearchResults extends React.Component {
 
     getPullRequestUrlTemplate = (branch) => {
         try {
-            return this.props.appConfig.link[branch.repository.name].pullRequest.url;
+            return this.props.appConfig.link[branch.repository.name].pullRequest
+                .url;
         } catch (e) {
             return null;
         }
     };
 
     hasScreenshot(branchStatistic) {
-        return this.props.branchesStore.textUnitsWithScreenshotsByBranchStatisticId[branchStatistic.id].size > 0;
+        return (
+            this.props.branchesStore
+                .textUnitsWithScreenshotsByBranchStatisticId[branchStatistic.id]
+                .size > 0
+        );
     }
 
     renderBranchName(branch) {
         let renderedBranchName;
 
         let pullRequestUrlTemplate = this.getPullRequestUrlTemplate(branch);
-        renderedBranchName = LinkHelper.renderLinkOrLabel(pullRequestUrlTemplate, branch.name, {
-            branchName: branch.name
-        });
+        renderedBranchName = LinkHelper.renderLinkOrLabel(
+            pullRequestUrlTemplate,
+            branch.name,
+            {
+                branchName: branch.name,
+            }
+        );
 
         return renderedBranchName;
     }
 
     renderOpenModalScreenshotButton(branchStatistic) {
-
         let disabled = !this.hasScreenshot(branchStatistic);
 
         // we use this construct instead of putting the button in the overlay because tooltips don't work on disabled buttons
         let button = (
-            <div style={{display: "inline-block"}}>
-                <Button bsStyle="default"
-                        style={disabled ? {pointerEvents: "none"} : {}}
-                        bsSize="small" disabled={disabled}
-                        onClick={() => this.props.onShowBranchScreenshotsClick(branchStatistic)}>
-                    <Glyphicon className="branches-branchstatistic-col1-screenshot" glyph="picture"/>
+            <div style={{ display: "inline-block" }}>
+                <Button
+                    bsStyle="default"
+                    style={disabled ? { pointerEvents: "none" } : {}}
+                    bsSize="small"
+                    disabled={disabled}
+                    onClick={() =>
+                        this.props.onShowBranchScreenshotsClick(branchStatistic)
+                    }
+                >
+                    <Glyphicon
+                        className="branches-branchstatistic-col1-screenshot"
+                        glyph="picture"
+                    />
                 </Button>
             </div>
         );
 
         button = (
-            <OverlayTrigger placement="bottom"
-                            overlay={<Tooltip id="BranchesSearchResults.tooltip.screenshot">
-                                <FormattedMessage
-                                    id={disabled ? "branches.searchResults.tooltip.noscreenshots" : "branches.searchResults.tooltip.withscreenshots"}/>
-                            </Tooltip>}>
+            <OverlayTrigger
+                placement="bottom"
+                overlay={
+                    <Tooltip id="BranchesSearchResults.tooltip.screenshot">
+                        <FormattedMessage
+                            id={
+                                disabled
+                                    ? "branches.searchResults.tooltip.noscreenshots"
+                                    : "branches.searchResults.tooltip.withscreenshots"
+                            }
+                        />
+                    </Tooltip>
+                }
+            >
                 {button}
-            </OverlayTrigger>);
+            </OverlayTrigger>
+        );
 
-
-        return <div className="branches-branchstatistic-screenshotpreview">{button}</div>;
+        return (
+            <div className="branches-branchstatistic-screenshotpreview">
+                {button}
+            </div>
+        );
     }
 
     renderBranchStatisticSummary(branchStatistic) {
-
         let isBranchStatisticOpen = this.isBranchStatisticOpen(branchStatistic);
 
         return (
-            <Row key={"branchStatistic-" + branchStatistic.id} className="branches-branchstatistic-summary">
+            <Row
+                key={"branchStatistic-" + branchStatistic.id}
+                className="branches-branchstatistic-summary"
+            >
                 <Col md={4} className="branches-branchstatistic-col1">
                     <Row className="branches-branchstatistic-col1-row">
                         <Col md={4}>
-                            <Button bsSize="xsmall"
-                                    onClick={() =>
-                                        this.props.onChangeOpenBranchStatistic(isBranchStatisticOpen ? null : branchStatistic)
-                                    }>
-                                <Glyphicon glyph={isBranchStatisticOpen ? "chevron-down" : "chevron-right"}
-                                           className="color-gray-light"/>
+                            <Button
+                                bsSize="xsmall"
+                                onClick={() =>
+                                    this.props.onChangeOpenBranchStatistic(
+                                        isBranchStatisticOpen
+                                            ? null
+                                            : branchStatistic
+                                    )
+                                }
+                            >
+                                <Glyphicon
+                                    glyph={
+                                        isBranchStatisticOpen
+                                            ? "chevron-down"
+                                            : "chevron-right"
+                                    }
+                                    className="color-gray-light"
+                                />
                             </Button>
                             <span className="mlm">
                                 {this.renderBranchName(branchStatistic.branch)}
                             </span>
                         </Col>
                         <Col md={4}>
-                            <span className="mls color-gray-light2"><small>{branchStatistic.branch.repository.name}</small></span>
+                            <span className="mls color-gray-light2">
+                                <small>
+                                    {branchStatistic.branch.repository.name}
+                                </small>
+                            </span>
                         </Col>
                         <Col md={2}>
-                            {branchStatistic.branch.deleted ?
+                            {branchStatistic.branch.deleted ? (
                                 <Label bsStyle="light">
-                                    <FormattedMessage id="branches.deleted"/>
+                                    <FormattedMessage id="branches.deleted" />
                                 </Label>
-                                :
+                            ) : (
                                 ""
-                            }
+                            )}
                         </Col>
                         <Col md={2}>
-                            {this.renderOpenModalScreenshotButton(branchStatistic)}
+                            {this.renderOpenModalScreenshotButton(
+                                branchStatistic
+                            )}
                         </Col>
                     </Row>
-
                 </Col>
                 <Col md={2}>
-                    <Link className="clickable"
-                          onClick={() => this.props.onNeedTranslationClick(branchStatistic, null, branchStatistic.forTranslationCount > 0)}>
-                        {branchStatistic.forTranslationCount > 0 ?
-                            <FormattedNumber value={branchStatistic.forTranslationCount}/>
-                            :
-                            <Label bsStyle="success" className="mrs">
-                                <FormattedMessage id="branches.done"/>
-                            </Label>
+                    <Link
+                        className="clickable"
+                        onClick={() =>
+                            this.props.onNeedTranslationClick(
+                                branchStatistic,
+                                null,
+                                branchStatistic.forTranslationCount > 0
+                            )
                         }
+                    >
+                        {branchStatistic.forTranslationCount > 0 ? (
+                            <FormattedNumber
+                                value={branchStatistic.forTranslationCount}
+                            />
+                        ) : (
+                            <Label bsStyle="success" className="mrs">
+                                <FormattedMessage id="branches.done" />
+                            </Label>
+                        )}
                     </Link>
                 </Col>
                 <Col md={2}>
                     {this.renderScreenshotPreview(branchStatistic)}
                 </Col>
                 <Col md={2}>
-                    <span>{branchStatistic.branch.createdByUser ? branchStatistic.branch.createdByUser.username : "-"}</span>
+                    <span>
+                        {branchStatistic.branch.createdByUser
+                            ? branchStatistic.branch.createdByUser.username
+                            : "-"}
+                    </span>
                 </Col>
                 <Col md={2}>
-                    <span><FormattedDate value={branchStatistic.branch.createdDate} day="numeric" month="numeric"
-                                         year="numeric"/></span>
+                    <span>
+                        <FormattedDate
+                            value={branchStatistic.branch.createdDate}
+                            day="numeric"
+                            month="numeric"
+                            year="numeric"
+                        />
+                    </span>
                 </Col>
             </Row>
         );
     }
 
     renderBranchTextUnitStatistic(branchStatistic, branchTextUnitStatistic) {
-
         let isTextUnitChecked =
-            this.props.branchesStore.selectedBranchTextUnitIds.indexOf(branchTextUnitStatistic.id) !== -1;
+            this.props.branchesStore.selectedBranchTextUnitIds.indexOf(
+                branchTextUnitStatistic.id
+            ) !== -1;
 
-        let className = ClassNames("branches-branchstatistic-textunit", {"branches-branchstatistic-textunit-open": this.isBranchStatisticOpen(branchStatistic)});
+        let className = ClassNames("branches-branchstatistic-textunit", {
+            "branches-branchstatistic-textunit-open":
+                this.isBranchStatisticOpen(branchStatistic),
+        });
 
-        return (<Collapse in={this.isBranchStatisticOpen(branchStatistic)} key={"branchStatisticTextUnit-" + branchTextUnitStatistic.id}>
-            <div>
-                <Row className={className}>
+        return (
+            <Collapse
+                in={this.isBranchStatisticOpen(branchStatistic)}
+                key={"branchStatisticTextUnit-" + branchTextUnitStatistic.id}
+            >
+                <div>
+                    <Row className={className}>
+                        <Col md={4} className="branches-branchstatistic-col1">
+                            <div>
+                                <div className="branches-branchstatistic-textunit-check">
+                                    <input
+                                        type="checkbox"
+                                        checked={isTextUnitChecked}
+                                        onClick={(e) => {
+                                            let newSelected =
+                                                this.props.branchesStore.selectedBranchTextUnitIds.slice();
 
-                    <Col md={4} className="branches-branchstatistic-col1">
-                        <div>
-                            <div className="branches-branchstatistic-textunit-check">
-                                <input
-                                    type="checkbox"
-                                    checked={isTextUnitChecked}
-                                    onClick={(e) => {
-                                        let newSelected = this.props.branchesStore.selectedBranchTextUnitIds.slice();
+                                            let index = newSelected.indexOf(
+                                                branchTextUnitStatistic.id
+                                            );
 
-                                        let index = newSelected.indexOf(branchTextUnitStatistic.id);
+                                            if (index !== -1) {
+                                                newSelected.splice(index, 1);
+                                            } else {
+                                                newSelected.push(
+                                                    branchTextUnitStatistic.id
+                                                );
+                                            }
 
-                                        if (index !== -1) {
-                                            newSelected.splice(index, 1);
-                                        } else {
-                                            newSelected.push(branchTextUnitStatistic.id);
+                                            this.props.onChangeSelectedBranchTextUnits(
+                                                newSelected
+                                            );
+                                        }}
+                                    />
+                                </div>
+                                <div className="plm">
+                                    <Link
+                                        className="clickable"
+                                        onClick={() => {
+                                            this.props.onTextUnitNameClick(
+                                                branchStatistic,
+                                                branchTextUnitStatistic
+                                                    .tmTextUnit.id
+                                            );
+                                        }}
+                                    >
+                                        {
+                                            branchTextUnitStatistic.tmTextUnit
+                                                .name
                                         }
-
-                                        this.props.onChangeSelectedBranchTextUnits(newSelected);
-                                    }}/>
+                                    </Link>
+                                </div>
+                                <div className="branches-branchstatistic-textunit-content">
+                                    {branchTextUnitStatistic.tmTextUnit.content}
+                                </div>
                             </div>
-                            <div className="plm">
-                                <Link className="clickable"
-                                      onClick={() => {this.props.onTextUnitNameClick(branchStatistic, branchTextUnitStatistic.tmTextUnit.id);}}>
-                                    {branchTextUnitStatistic.tmTextUnit.name}
-                                </Link>
+                        </Col>
+                        <Col md={2}>
+                            <div>
+                                {branchTextUnitStatistic.forTranslationCount >
+                                    0 && (
+                                    <Link
+                                        className="clickable"
+                                        onClick={() =>
+                                            this.props.onNeedTranslationClick(
+                                                branchStatistic,
+                                                branchTextUnitStatistic
+                                                    .tmTextUnit.id,
+                                                branchTextUnitStatistic.forTranslationCount >
+                                                    0
+                                            )
+                                        }
+                                    >
+                                        <FormattedNumber
+                                            value={
+                                                branchTextUnitStatistic.forTranslationCount
+                                            }
+                                        />
+                                    </Link>
+                                )}
                             </div>
-                            <div
-                                className="branches-branchstatistic-textunit-content">{branchTextUnitStatistic.tmTextUnit.content}
+                        </Col>
+                        <Col md={2}>
+                            <div>
+                                {this.props.branchesStore.textUnitsWithScreenshotsByBranchStatisticId[
+                                    branchStatistic.id
+                                ].has(branchTextUnitStatistic.tmTextUnit.id)
+                                    ? ""
+                                    : "1"}
                             </div>
-                        </div>
-                    </Col>
-                    <Col md={2}>
-                        <div>
-                            {branchTextUnitStatistic.forTranslationCount > 0 &&
-                            <Link className="clickable"
-                                  onClick={() => this.props.onNeedTranslationClick(
-                                      branchStatistic,
-                                      branchTextUnitStatistic.tmTextUnit.id,
-                                      branchTextUnitStatistic.forTranslationCount > 0)}
-                            >
-                                <FormattedNumber value={branchTextUnitStatistic.forTranslationCount}/>
-                            </Link>
-                            }
-                        </div>
-                    </Col>
-                    <Col md={2}>
-                        <div>
-                            {this.props.branchesStore.textUnitsWithScreenshotsByBranchStatisticId[branchStatistic.id].has(branchTextUnitStatistic.tmTextUnit.id) ?
-                                "" :
-                                "1"}
-                        </div>
-                    </Col>
-                </Row>
-            </div>
-        </Collapse>);
+                        </Col>
+                    </Row>
+                </div>
+            </Collapse>
+        );
     }
 
     renderBranchStatisticSeparator(branchStatistic) {
         return (
-            <Collapse key={`renderBranchStatisticSeparator-${branchStatistic.id}`} in={this.isBranchStatisticOpen(branchStatistic)}>
+            <Collapse
+                key={`renderBranchStatisticSeparator-${branchStatistic.id}`}
+                in={this.isBranchStatisticOpen(branchStatistic)}
+            >
                 <Row className="mbl"></Row>
             </Collapse>
         );
@@ -345,9 +503,11 @@ class BranchesSearchResults extends React.Component {
 
     render() {
         if (this.props.branchesSearchParamStore.isSpinnerShown) {
-            return <div class="branch-spinner mtl mbl">
-                <span className="glyphicon glyphicon-refresh spinning" />
-            </div>
+            return (
+                <div class="branch-spinner mtl mbl">
+                    <DelayedSpinner />
+                </div>
+            );
         }
 
         return (
@@ -355,7 +515,9 @@ class BranchesSearchResults extends React.Component {
                 <div className="mll mrl branches-branchstatistic">
                     <Grid fluid={true}>
                         {this.renderGridHeader()}
-                        {this.props.branchesStore.branchStatistics.map(this.renderBranchStatistic.bind(this))}
+                        {this.props.branchesStore.branchStatistics.map(
+                            this.renderBranchStatistic.bind(this)
+                        )}
                     </Grid>
                 </div>
             </div>

--- a/webapp/src/main/resources/public/js/components/common/DelayedSpinner.jsx
+++ b/webapp/src/main/resources/public/js/components/common/DelayedSpinner.jsx
@@ -1,0 +1,17 @@
+import React, { useEffect, useState } from "react";
+
+import Spinner from "./Spinner";
+
+const DelayedSpinner = () => {
+    const [showSpinner, setShowSpinner] = useState(false);
+
+    useEffect(() => {
+        const timer = setTimeout(() => setShowSpinner(true), 300);
+
+        return () => clearTimeout(timer);
+    });
+
+    return showSpinner && <Spinner />;
+};
+
+export default DelayedSpinner;

--- a/webapp/src/main/resources/public/js/components/common/Spinner.jsx
+++ b/webapp/src/main/resources/public/js/components/common/Spinner.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Spinner = () => {
+  return <span className="glyphicon glyphicon-refresh spinning"/>
+};
+
+export default Spinner;

--- a/webapp/src/main/resources/public/js/components/screenshots/ScreenshotsGrid.jsx
+++ b/webapp/src/main/resources/public/js/components/screenshots/ScreenshotsGrid.jsx
@@ -108,6 +108,14 @@ class ScreenshotsGrid extends React.Component {
                 </div>);
     }
 
+    renderSpinner() {
+        return (
+          <div class="branch-spinner mtl mbl">
+            <span className="glyphicon glyphicon-refresh spinning" />
+          </div>
+        );
+    }
+
     /**
      * @return {JSX}
      */
@@ -115,7 +123,7 @@ class ScreenshotsGrid extends React.Component {
         var res;
 
         if (this.props.searching) {
-            res = null;
+            res = this.renderSpinner();
         } else if (this.props.screenshotsData.length > 0) {
             res = this.renderWithResults();
         } else {

--- a/webapp/src/main/resources/public/js/components/workbench/LocalesDropdown.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/LocalesDropdown.jsx
@@ -2,7 +2,7 @@ import _ from "lodash";
 import React from "react";
 import createReactClass from 'create-react-class';
 import {FormattedMessage, injectIntl} from 'react-intl';
-import {DropdownButton, MenuItem} from "react-bootstrap";
+import {DropdownButton, MenuItem, OverlayTrigger, Tooltip} from "react-bootstrap";
 import FluxyMixin from "alt-mixins/FluxyMixin";
 
 import RepositoryStore from "../../stores/RepositoryStore";
@@ -262,18 +262,47 @@ let LocalesDropDown = createReactClass({
     },
 
     /**
+     * Whether there is no data for the dropdown
+     * 
+     * @returns {boolean}
+     */
+    hasLocaleData() {
+        return this.state.bcp47Tags.length > 0;
+    },
+
+    /**
      * Renders the locale menu item list.
      *
      * @returns {XML}
      */
     renderLocales() {
-        return this.getSortedLocales().map(
-                (locale) =>
-                        <MenuItem key={"Workbench.LocaleDropdown." + locale.displayName}
-                                  eventKey={locale}
-                                  active={locale.selected}
-                                  onSelect={this.onLocaleSelected}
-                        >{locale.displayName}</MenuItem>
+        return this.getSortedLocales().map((locale) => (
+          <MenuItem
+            key={"Workbench.LocaleDropdown." + locale.displayName}
+            eventKey={locale}
+            active={locale.selected}
+            onSelect={this.onLocaleSelected}
+          >
+            {locale.displayName}
+          </MenuItem>
+        ));
+    },
+
+    renderNoLocaleTooltip(wrappedComponent, hasLocaleData) {
+        if (hasLocaleData) {
+            return wrappedComponent;
+        }
+
+        return (
+            <OverlayTrigger
+                overlay={
+                    <Tooltip id="locale-dropdown-toolip">
+                        Please selected a repository first
+                    </Tooltip>
+                }
+            >
+                {wrappedComponent}
+            </OverlayTrigger>
         );
     },
 
@@ -281,16 +310,18 @@ let LocalesDropDown = createReactClass({
      * @return {JSX}
      */
     render() {
-
+        const hasLocaleData = this.hasLocaleData();
         return (
                 <span className="mlm locale-dropdown">
-                <DropdownButton id="WorkbenchLocaleDropdown" title={this.getButtonText()} onToggle={this.onDropdownToggle} open={this.state.isDropdownOpenned}>
-                    <MenuItem active={this.isToBeFullyTranslatedActive()} onSelect={this.onSelectToBeFullyTranslated}><FormattedMessage id="search.locale.selectToBeFullyTranslated"/></MenuItem>
-                    <MenuItem active={this.isAllActive()} onSelect={this.onSelectAll}><FormattedMessage id="search.locale.selectAll"/></MenuItem>
-                    <MenuItem active={this.isNoneActive()} onSelect={this.onSelectNone}><FormattedMessage id="search.locale.selectNone"/></MenuItem>
-                    <MenuItem divider/>
-                    {this.renderLocales()}
-                </DropdownButton>
+                    {
+                        this.renderNoLocaleTooltip(
+                            <DropdownButton id="WorkbenchLocaleDropdown" disabled={!hasLocaleData} title={this.getButtonText()} onToggle={this.onDropdownToggle} open={this.state.isDropdownOpenned}>
+                                <MenuItem active={this.isToBeFullyTranslatedActive()} onSelect={this.onSelectToBeFullyTranslated}><FormattedMessage id="search.locale.selectToBeFullyTranslated"/></MenuItem>
+                                <MenuItem active={this.isAllActive()} onSelect={this.onSelectAll}><FormattedMessage id="search.locale.selectAll"/></MenuItem>
+                                <MenuItem active={this.isNoneActive()} onSelect={this.onSelectNone}><FormattedMessage id="search.locale.selectNone"/></MenuItem>
+                                <MenuItem divider/>
+                                {this.renderLocales()}
+                            </DropdownButton>, hasLocaleData)} 
                 </span>
         );
 

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
@@ -695,7 +695,6 @@ let SearchResults = createReactClass({
             }
         }
 
-        return result;
     },
 
     /**
@@ -710,6 +709,13 @@ let SearchResults = createReactClass({
     },
 
     render() {
+        if (this.state.isSearching) {
+            return <div class="branch-spinner mtl mbl">
+                <span className="glyphicon glyphicon-refresh spinning" />
+            </div>
+        }
+
+
         return (
             <div onKeyUp={this.onKeyUpSearchResults} onClick={this.onChangeSearchResults}>
                 {this.getTextUnitToolbarUI()}

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
@@ -1,10 +1,15 @@
 import _ from "lodash";
 import FluxyMixin from "alt-mixins/FluxyMixin";
 import keycode from "keycode";
-import React, {Fragment} from "react";
-import createReactClass from 'create-react-class';
-import {FormattedMessage, injectIntl} from "react-intl";
-import {Button, ButtonToolbar, DropdownButton, MenuItem} from "react-bootstrap";
+import React, { Fragment } from "react";
+import createReactClass from "create-react-class";
+import { FormattedMessage, injectIntl } from "react-intl";
+import {
+    Button,
+    ButtonToolbar,
+    DropdownButton,
+    MenuItem,
+} from "react-bootstrap";
 import Error from "../../utils/Error";
 import DeleteConfirmationModal from "../widgets/DeleteConfirmationModal";
 import ErrorModal from "../widgets/ErrorModal";
@@ -23,6 +28,7 @@ import ViewModeStore from "../../stores/workbench/ViewModeStore";
 import ViewModeDropdown from "./ViewModeDropdown";
 import ViewModeActions from "../../actions/workbench/ViewModeActions";
 import AuthorityService from "../../utils/AuthorityService";
+import DelayedSpinner from "../common/DelayedSpinner";
 
 let SearchResults = createReactClass({
     displayName: 'SearchResults',
@@ -38,57 +44,56 @@ let SearchResults = createReactClass({
      * @return {{searchResults: (*|Array|TextUnit[]), searchHadNoResults: boolean, noMoreResults: boolean, mustShowToolbar: boolean, currentPageNumber: (*|Number|number), activeTextUnitIndex: number, showDeleteModal: boolean, mustShowReviewModal: boolean, isErrorOccurred: boolean, errorObject: null, errorResponse: null, textUnitInEditMode: null}}
      */
     getInitialState() {
-
         let resultsStoreState = SearchResultsStore.getState();
         let searchParamsStoreState = SearchParamsStore.getState();
         return {
             /** @type [] Array of textunits in the current page of the search results. */
-            "searchResults": resultsStoreState.searchResults,
+            searchResults: resultsStoreState.searchResults,
 
             /** @type {Boolean} */
-            "isSearching": SearchResultsStore.getState().isSearching,
+            isSearching: SearchResultsStore.getState().isSearching,
 
             /** @type {Boolean} True if the minimum set of parameters are required for searching */
-            "isReadyForSearching": false,
+            isReadyForSearching: false,
 
             /** @type {Boolean} True when search didn't result any result, It's different than searchResults.length equals to 0 b'c it can be 0 if search has not been requested. */
-            "searchHadNoResults": false,
+            searchHadNoResults: false,
 
             /** @type {Boolean} Indicates that no more results exist for the search criteria. Helps maintain enabled status of toolbar buttons. */
-            "noMoreResults": false,
+            noMoreResults: false,
 
             /** @type {Boolean} If no results exist for the provided search criteria, this boolean helps to hide the workbench toolbar. */
-            "mustShowToolbar": false,
+            mustShowToolbar: false,
 
             /** @type {Number} Indicates the current page number of the search results. */
-            "currentPageNumber": searchParamsStoreState.currentPageNumber,
+            currentPageNumber: searchParamsStoreState.currentPageNumber,
 
             /** @type {Number} The number of items on each page. */
-            "pageSize": searchParamsStoreState.pageSize,
+            pageSize: searchParamsStoreState.pageSize,
 
             /** @type {Number}  The index of the currently active textunit. */
-            "activeTextUnitIndex": 0,
+            activeTextUnitIndex: 0,
 
             /** @type {Boolean} Displays the DeleteConfirmationModal when the delete button is clicked. */
-            "showDeleteModal": false,
+            showDeleteModal: false,
 
             /** @type {Boolean} Helps show the ErrorModal if set to true. */
-            "mustShowReviewModal": false,
+            mustShowReviewModal: false,
 
             /** @type {Boolean} Displays the TranslateModal when the delete button is clicked. */
-            "showTranslateModal": false,
+            showTranslateModal: false,
 
             /** @type {Boolean} */
-            "isErrorOccurred": false,
+            isErrorOccurred: false,
 
             /** @type {Boolean} The Error object created by the store.  */
-            "errorObject": null,
+            errorObject: null,
 
             /** @type {Boolean} The error object returned by the promise. This can be used to pass parameters to translate the error. See getErrorMessage() in this file for details. */
-            "errorResponse": null,
+            errorResponse: null,
 
             /** @type {TextUnit}   the text unit currently in edit mode if any*/
-            "textUnitInEditMode": null
+            textUnitInEditMode: null,
         };
     },
 
@@ -143,7 +148,7 @@ let SearchResults = createReactClass({
         let searchResultsLength = this.state.searchResults.length;
         if (activeTextUnitIndex >= searchResultsLength && !this.state.noMoreResults) {
             WorkbenchActions.searchParamsChanged({
-                "changedParam": SearchConstants.NEXT_PAGE_REQUESTED
+                changedParam: SearchConstants.NEXT_PAGE_REQUESTED,
             });
         } else if (activeTextUnitIndex >= searchResultsLength && this.state.noMoreResults) {
             // boundary condition for pressing down arrow on the last textunit of the last page
@@ -218,7 +223,7 @@ let SearchResults = createReactClass({
      */
     showReviewModal() {
         this.setState({
-            "mustShowReviewModal": true
+            mustShowReviewModal: true,
         });
     },
 
@@ -227,7 +232,7 @@ let SearchResults = createReactClass({
      */
     hideReviewModal() {
         this.setState({
-            "mustShowReviewModal": false
+            mustShowReviewModal: false,
         });
     },
 
@@ -236,7 +241,7 @@ let SearchResults = createReactClass({
      */
     showTranslateModal() {
         this.setState({
-            "showTranslateModal": true
+            showTranslateModal: true,
         });
     },
 
@@ -245,7 +250,7 @@ let SearchResults = createReactClass({
      */
     hideDoNotTranslateModal() {
         this.setState({
-            "showTranslateModal": false
+            showTranslateModal: false,
         });
     },
 
@@ -254,7 +259,7 @@ let SearchResults = createReactClass({
      */
     showDeleteModal() {
         this.setState({
-            "showDeleteModal": true
+            showDeleteModal: true,
         });
     },
 
@@ -263,7 +268,7 @@ let SearchResults = createReactClass({
      */
     hideDeleteModal() {
         this.setState({
-            "showDeleteModal": false
+            showDeleteModal: false,
         });
     },
 
@@ -312,7 +317,7 @@ let SearchResults = createReactClass({
      */
     onErrorModalClosed() {
         this.setState({
-            "isErrorOccurred": false
+            isErrorOccurred: false,
         });
         WorkbenchActions.resetErrorState();
     },
@@ -345,23 +350,22 @@ let SearchResults = createReactClass({
     onSearchResultsStoreUpdated() {
         let resultsStoreState = SearchResultsStore.getState();
         let paramsStoreState = SearchParamsStore.getState();
-        let resultsInComponent = this.state.searchResults;
         let mustShowToolbar = this.mustToolbarBeShown();
         let isReadyForSearching = SearchParamsStore.isReadyForSearching(paramsStoreState);
 
         this.setState({
-            "searchResults": resultsStoreState.searchResults,
-            "isReadyForSearching": isReadyForSearching,
-            "isSearching": resultsStoreState.isSearching,
-            "searchHadNoResults": resultsStoreState.searchHadNoResults,
-            "noMoreResults": resultsStoreState.noMoreResults,
-            "currentPageNumber": paramsStoreState.currentPageNumber,
-            "pageSize": paramsStoreState.pageSize,
-            "mustShowToolbar": mustShowToolbar,
-            "activeTextUnitIndex": this.getActiveTextUnitIndex(),
-            "isErrorOccurred": resultsStoreState.isErrorOccurred,
-            "errorObject": resultsStoreState.errorObject,
-            "textUnitInEditMode": this.state.textUnitInEditMode
+            searchResults: resultsStoreState.searchResults,
+            isReadyForSearching: isReadyForSearching,
+            isSearching: resultsStoreState.isSearching,
+            searchHadNoResults: resultsStoreState.searchHadNoResults,
+            noMoreResults: resultsStoreState.noMoreResults,
+            currentPageNumber: paramsStoreState.currentPageNumber,
+            pageSize: paramsStoreState.pageSize,
+            mustShowToolbar: mustShowToolbar,
+            activeTextUnitIndex: this.getActiveTextUnitIndex(),
+            isErrorOccurred: resultsStoreState.isErrorOccurred,
+            errorObject: resultsStoreState.errorObject,
+            textUnitInEditMode: this.state.textUnitInEditMode,
         });
     },
 
@@ -393,7 +397,7 @@ let SearchResults = createReactClass({
      */
     onTextUnitEditModeSetToFalse(textUnit) {
         // don't need to set "activeTextUnitIndex"
-        this.setState({"textUnitInEditMode": null});
+        this.setState({ textUnitInEditMode: null });
     },
 
     /**
@@ -401,8 +405,8 @@ let SearchResults = createReactClass({
      */
     setStateForEditingTextUnit(textUnit) {
         this.setState({
-            "textUnitInEditMode": textUnit,
-            "activeTextUnitIndex": textUnit.props.textUnitIndex
+            textUnitInEditMode: textUnit,
+            activeTextUnitIndex: textUnit.props.textUnitIndex,
         });
     },
 
@@ -411,11 +415,10 @@ let SearchResults = createReactClass({
      *  of search results.
      */
     onFetchNextPageClicked() {
-
         if (!this.state.noMoreResults) {
-            this.setState({"textUnitInEditMode": null}, () => {
+            this.setState({ textUnitInEditMode: null }, () => {
                 WorkbenchActions.searchParamsChanged({
-                    "changedParam": SearchConstants.NEXT_PAGE_REQUESTED
+                    changedParam: SearchConstants.NEXT_PAGE_REQUESTED,
                 });
             });
         }
@@ -426,11 +429,10 @@ let SearchResults = createReactClass({
      * page of search results if the currentPage is greater than one.
      */
     onFetchPreviousPageClicked() {
-
         if (this.state.currentPageNumber > 1) {
-            this.setState({"textUnitInEditMode": null}, () => {
+            this.setState({ textUnitInEditMode: null }, () => {
                 WorkbenchActions.searchParamsChanged({
-                    "changedParam": SearchConstants.PREVIOUS_PAGE_REQUESTED
+                    changedParam: SearchConstants.PREVIOUS_PAGE_REQUESTED,
                 });
             });
         }
@@ -441,7 +443,7 @@ let SearchResults = createReactClass({
      */
     setActiveTextUnitIndexState(activeTextUnitIndex) {
         this.setState({
-            "activeTextUnitIndex": activeTextUnitIndex
+            activeTextUnitIndex: activeTextUnitIndex,
         });
     },
 
@@ -497,7 +499,9 @@ let SearchResults = createReactClass({
         let errorMessage = "";
         //TODO: fill in the error message with parameter values if any.
         if (errorObject !== null) {
-            errorMessage = this.props.intl.formatMessage({id: Error.MESSAGEKEYS_MAP[errorObject.getErrorId()]});
+            errorMessage = this.props.intl.formatMessage({
+                id: Error.MESSAGEKEYS_MAP[errorObject.getErrorId()],
+            });
         }
         return errorMessage;
     },
@@ -520,16 +524,16 @@ let SearchResults = createReactClass({
      * @returns {JSX} The JSX to paint the TextUnit component.
      */
     createTextUnitComponent(textUnit, arrayIndex) {
-
         return (
-            <AltContainer key={this.getTextUnitComponentKey(textUnit)} stores={{"viewMode": ViewModeStore}}>
+            <AltContainer key={this.getTextUnitComponentKey(textUnit)} stores={{ viewMode: ViewModeStore }}>
                 <TextUnit
-                        textUnit={textUnit} textUnitIndex={arrayIndex}
-                        translation={textUnit.getTarget()}
-                        isActive={arrayIndex === this.state.activeTextUnitIndex}
-                        isSelected={this.isTextUnitSelected(textUnit)}
-                        onEditModeSetToTrue={this.onTextUnitEditModeSetToTrue}
-                        onEditModeSetToFalse={this.onTextUnitEditModeSetToFalse}
+                    textUnit={textUnit}
+                    textUnitIndex={arrayIndex}
+                    translation={textUnit.getTarget()}
+                    isActive={arrayIndex === this.state.activeTextUnitIndex}
+                    isSelected={this.isTextUnitSelected(textUnit)}
+                    onEditModeSetToTrue={this.onTextUnitEditModeSetToTrue}
+                    onEditModeSetToFalse={this.onTextUnitEditModeSetToFalse}
                 />
             </AltContainer>
         );
@@ -547,7 +551,12 @@ let SearchResults = createReactClass({
          * This forces the TextUnit component getInitialState to be called. This is desired behavior
          * because getInitialState resets the TextUnit component state.
          */
-        return textUnit.getTmTextUnitId() + '_' + textUnit.getLocaleId() + textUnit.getTmTextUnitVariantId();
+        return (
+            textUnit.getTmTextUnitId() +
+            "_" +
+            textUnit.getLocaleId() +
+            textUnit.getTmTextUnitVariantId()
+        );
     },
 
     /**
@@ -704,10 +713,12 @@ let SearchResults = createReactClass({
         let ui = "";
         if (this.state.mustShowReviewModal) {
             ui = (
-                <TextUnitsReviewModal isShowModal={this.state.mustShowReviewModal}
-                                      onReviewModalSaveClicked={this.onReviewModalSaveClicked}
-                                      textUnitsArray={this.getSelectedTextUnits()}
-                                      onCloseModal={this.hideReviewModal}/>
+                <TextUnitsReviewModal
+                    isShowModal={this.state.mustShowReviewModal}
+                    onReviewModalSaveClicked={this.onReviewModalSaveClicked}
+                    textUnitsArray={this.getSelectedTextUnits()}
+                    onCloseModal={this.hideReviewModal}
+                />
             );
         }
         return ui;
@@ -720,10 +731,12 @@ let SearchResults = createReactClass({
         let ui = "";
         if (this.state.showTranslateModal) {
             ui = (
-                <TranslateModal showModal={this.state.showTranslateModal}
-                                selectedTextArray={this.getSelectedTextUnits()}
-                                onSave={this.onTranslateModalSave}
-                                onCancel={this.onTranslateModalCancel}/>
+                <TranslateModal
+                    showModal={this.state.showTranslateModal}
+                    selectedTextArray={this.getSelectedTextUnits()}
+                    onSave={this.onTranslateModalSave}
+                    onCancel={this.onTranslateModalCancel}
+                />
             );
         }
         return ui;
@@ -751,6 +764,7 @@ let SearchResults = createReactClass({
             }
         }
 
+        return result;
     },
 
     /**
@@ -758,31 +772,43 @@ let SearchResults = createReactClass({
      * @returns {JSX}
      */
     getEmptyStateContainerContent(messageId) {
-        return <div className="empty-search-container text-center center-block">
-            <div><FormattedMessage id={messageId}/></div>
-            <img className="empty-search-container-img" src={require('../../../img/magnifying-glass.svg')}/>
-        </div>;
+        return (
+            <div className="empty-search-container text-center center-block">
+                <div>
+                    <FormattedMessage id={messageId} />
+                </div>
+                <img
+                    className="empty-search-container-img"
+                    src={require("../../../img/magnifying-glass.svg")}
+                />
+            </div>
+        );
     },
 
     render() {
         if (this.state.isSearching) {
-            return <div class="branch-spinner mtl mbl">
-                <span className="glyphicon glyphicon-refresh spinning" />
-            </div>
+            return (
+                <div class="branch-spinner mtl mbl">
+                    <DelayedSpinner />
+                </div>
+            );
         }
-
 
         return (
             <div onKeyUp={this.onKeyUpSearchResults} onClick={this.onChangeSearchResults}>
                 {this.getTextUnitToolbarUI()}
                 {this.createTextUnitComponents()}
-                <DeleteConfirmationModal showModal={this.state.showDeleteModal}
-                                         modalBodyMessage="textUnits.bulk.deleteMessage"
-                                         onDeleteCancelledCallback={this.onDeleteTextUnitsCancelled}
-                                         onDeleteClickedCallback={this.onDeleteTextUnitsConfirmed}/>
-                <ErrorModal showModal={this.state.isErrorOccurred}
-                            errorMessage={this.getErrorMessage()}
-                            onErrorModalClosed={this.onErrorModalClosed}/>
+                <DeleteConfirmationModal
+                    showModal={this.state.showDeleteModal}
+                    modalBodyMessage="textUnits.bulk.deleteMessage"
+                    onDeleteCancelledCallback={this.onDeleteTextUnitsCancelled}
+                    onDeleteClickedCallback={this.onDeleteTextUnitsConfirmed}
+                />
+                <ErrorModal
+                    showModal={this.state.isErrorOccurred}
+                    errorMessage={this.getErrorMessage()}
+                    onErrorModalClosed={this.onErrorModalClosed}
+                />
                 {this.getTextUnitsTranslateModal()}
                 {this.getEmptyStateContainer()}
                 {this.getTextUnitsReviewModal()}

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import FluxyMixin from "alt-mixins/FluxyMixin";
 import keycode from "keycode";
-import React from "react";
+import React, {Fragment} from "react";
 import createReactClass from 'create-react-class';
 import {FormattedMessage, injectIntl} from "react-intl";
 import {Button, ButtonToolbar, DropdownButton, MenuItem} from "react-bootstrap";
@@ -565,7 +565,8 @@ let SearchResults = createReactClass({
         let isAtLeastOneTextUnitSelected = numberOfSelectedTextUnits >= 1;
 
         let selectorCheckBoxDisabled = !AuthorityService.canEditTranslations();
-        let actionButtonsDisabled = isSearching || !isAtLeastOneTextUnitSelected || !AuthorityService.canEditTranslations();
+        const canEditTranslations = AuthorityService.canEditTranslations();
+        let actionButtonsDisabled = isSearching || !isAtLeastOneTextUnitSelected || !canEditTranslations;
         let nextPageButtonDisabled = isSearching || noMoreResults;
         let previousPageButtonDisabled = isSearching || isFirstPage;
 
@@ -591,50 +592,105 @@ let SearchResults = createReactClass({
                     <div>
                         <div className="pull-left">
                             <ButtonToolbar>
-                                <Button bsSize="small" disabled={actionButtonsDisabled}
-                                        onClick={this.onDeleteTextUnitsClicked}>
-                                    <FormattedMessage id="label.delete"/>
-                                </Button>
-                                <Button bsSize="small" bsStyle="primary" disabled={actionButtonsDisabled}
-                                        onClick={this.onStatusTextUnitsClicked}>
-                                    <FormattedMessage id="workbench.toolbar.status"/>
-                                </Button>
+                                {canEditTranslations && (
+                                    <Fragment>
+                                        <Button
+                                            bsSize="small"
+                                            disabled={actionButtonsDisabled}
+                                            onClick={
+                                                this.onDeleteTextUnitsClicked
+                                            }
+                                        >
+                                            <FormattedMessage id="label.delete" />
+                                        </Button>
+                                        <Button
+                                            bsSize="small"
+                                            bsStyle="primary"
+                                            disabled={actionButtonsDisabled}
+                                            onClick={
+                                                this.onStatusTextUnitsClicked
+                                            }
+                                        >
+                                            <FormattedMessage id="workbench.toolbar.status" />
+                                        </Button>
 
-                                <DropdownButton bsSize="small"
-                                                disabled={actionButtonsDisabled}
-                                                noCaret
-                                                id="dropdown-more-options"
-                                                title={(
-                                                    <span className="glyphicon glyphicon-option-horizontal"></span>)}>
-
-                                    <MenuItem header><FormattedMessage id="workbench.toolbar.textUnitsAttribute"/></MenuItem>
-                                    <MenuItem eventKey="1" onClick={this.onDoNotTranslateClick}><FormattedMessage id="workbench.toolbar.setTranslate"/></MenuItem>
-                                </DropdownButton>
+                                        <DropdownButton
+                                            bsSize="small"
+                                            disabled={actionButtonsDisabled}
+                                            noCaret
+                                            id="dropdown-more-options"
+                                            title={
+                                                <span className="glyphicon glyphicon-option-horizontal"></span>
+                                            }
+                                        >
+                                            <MenuItem header>
+                                                <FormattedMessage id="workbench.toolbar.textUnitsAttribute" />
+                                            </MenuItem>
+                                            <MenuItem
+                                                eventKey="1"
+                                                onClick={
+                                                    this.onDoNotTranslateClick
+                                                }
+                                            >
+                                                <FormattedMessage id="workbench.toolbar.setTranslate" />
+                                            </MenuItem>
+                                        </DropdownButton>
+                                    </Fragment>
+                                )}
                             </ButtonToolbar>
                         </div>
-                        <div className="pull-right" style={{display: "flex", alignItems: "center", "gap": "15px"}}>
+                        <div
+                            className="pull-right"
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "15px",
+                            }}
+                        >
                             <AltContainer store={ViewModeStore}>
-                                <ViewModeDropdown onModeSelected={(mode) => ViewModeActions.changeViewMode(mode)}/>
+                                <ViewModeDropdown
+                                    onModeSelected={(mode) =>
+                                        ViewModeActions.changeViewMode(mode)
+                                    }
+                                />
                             </AltContainer>
 
-                            <TextUnitSelectorCheckBox numberOfSelectedTextUnits={numberOfSelectedTextUnits} disabled={selectorCheckBoxDisabled}/>
+                            {!selectorCheckBoxDisabled && (
+                                <TextUnitSelectorCheckBox
+                                    numberOfSelectedTextUnits={
+                                        numberOfSelectedTextUnits
+                                    }
+                                    disabled={selectorCheckBoxDisabled}
+                                />
+                            )}
 
-                            <DropdownButton id="text-units-per-page" title={title}>
+                            <DropdownButton
+                                id="text-units-per-page"
+                                title={title}
+                            >
                                 {pageSizes}
                             </DropdownButton>
-                            <Button bsSize="small" disabled={previousPageButtonDisabled}
-                                    onClick={this.onFetchPreviousPageClicked}><span
-                                className="glyphicon glyphicon-chevron-left"></span></Button>
+                            <Button
+                                bsSize="small"
+                                disabled={previousPageButtonDisabled}
+                                onClick={this.onFetchPreviousPageClicked}
+                            >
+                                <span className="glyphicon glyphicon-chevron-left"></span>
+                            </Button>
                             <label className="default-label current-pageNumber">
                                 {this.displayCurrentPageNumber()}
                             </label>
-                            <Button bsSize="small" disabled={nextPageButtonDisabled}
-                                    onClick={this.onFetchNextPageClicked}><span
-                                className="glyphicon glyphicon-chevron-right"></span></Button>
+                            <Button
+                                bsSize="small"
+                                disabled={nextPageButtonDisabled}
+                                onClick={this.onFetchNextPageClicked}
+                            >
+                                <span className="glyphicon glyphicon-chevron-right"></span>
+                            </Button>
                         </div>
                     </div>
 
-                    <div className="textunit-toolbar-clear"/>
+                    <div className="textunit-toolbar-clear" />
                 </div>
             );
         }

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.jsx
@@ -427,40 +427,63 @@ let TextUnit = createReactClass({
      * @returns {JSX}
      */
     renderReviewGlyph() {
-
         let ui = "";
         if (this.props.textUnit.isTranslated()) {
-
             let glyphType = "ok";
             let glyphTitle = this.props.intl.formatMessage({id: "textUnit.reviewModal.accepted"});
+            let tooltipDescriptor = "Translated";
 
             if (this.props.textUnit.getStatus() === TextUnitSDK.STATUS.MACHINE_TRANSLATED) {
                 glyphType = "asterisk";
                 glyphTitle = this.props.intl.formatMessage({id: "textUnit.reviewModal.mt"});
+                tooltipDescriptor = "Machine Translated";
             }
             else if (this.props.textUnit.getStatus() === TextUnitSDK.STATUS.MT_REVIEW_NEEDED) {
                 glyphType = "hourglass";
                 glyphTitle = this.props.intl.formatMessage({id: "textUnit.reviewModal.mtReview"});
+                tooltipDescriptor = "Machine Translated - Review Needed";
             }
             else if (!this.props.textUnit.isIncludedInLocalizedFile()) {
-
                 glyphType = "alert";
                 glyphTitle = this.props.intl.formatMessage({id: "textUnit.reviewModal.rejected"});
+                tooltipDescriptor = "Rejected";
 
             } else if (this.props.textUnit.getStatus() === TextUnitSDK.STATUS.REVIEW_NEEDED) {
-
                 glyphType = "eye-open";
                 glyphTitle = this.props.intl.formatMessage({id: "textUnit.reviewModal.needsReview"});
+                tooltipDescriptor = "Needs Review";
 
             } else if (this.props.textUnit.getStatus() === TextUnitSDK.STATUS.TRANSLATION_NEEDED) {
-
                 glyphType = "edit";
                 glyphTitle = this.props.intl.formatMessage({id: "textUnit.reviewModal.translationNeeded"});
+                tooltipDescriptor = "Translation Needed";
             }
+            console.log({tooltipDescriptor})
+
             ui = (
-                <Glyphicon glyph={glyphType} id="reviewStringButton" title={glyphTitle} className="btn"
-                           onClick={this.onTextUnitGlyphClicked} disabled={!AuthorityService.canEditTranslations()}/>
+                <Glyphicon
+                    glyph={glyphType}
+                    id="reviewStringButton"
+                    title={glyphTitle}
+                    className="btn"
+                    onClick={this.onTextUnitGlyphClicked}
+                    disabled={!AuthorityService.canEditTranslations()}
+                />
             );
+            if (tooltipDescriptor) {
+                ui = (
+                    <OverlayTrigger
+                        placement="top"
+                        overlay={
+                            <Tooltip className="text-center">
+                                {tooltipDescriptor}
+                            </Tooltip>
+                        }
+                    >
+                        {ui}
+                    </OverlayTrigger>
+                );
+            }
         }
 
         return ui;
@@ -574,7 +597,7 @@ let TextUnit = createReactClass({
 
             ui = (
                 <label className={targetClassName} onClick={this.editStringClicked} dir={dir} style={{margin: "0px"}}>
-                {leadingWhitespacesSymbol}{targetString}{trailingWhitespacesSymbol}
+                    {leadingWhitespacesSymbol}{targetString}{trailingWhitespacesSymbol}
                 </label>
             );
         }
@@ -1013,6 +1036,7 @@ let TextUnit = createReactClass({
             textunitClass = textunitClass + " textunit-selected";
         }
 
+        const canEditTranslations = AuthorityService.canEditTranslations()
         return (
             <div ref="textunit" className={textunitClass} onKeyUp={this.onKeyUpTextUnit} tabIndex={0}
                  onClick={this.onTextUnitClick}>
@@ -1020,9 +1044,9 @@ let TextUnit = createReactClass({
                 <div>
                     <div className="text-unit-root">
                         <div className="left mls">
-                            <span style={{gridArea: "cb"}} className="mrxs">
-                                <input type="checkbox" checked={isSelected} readOnly={true} disabled={!AuthorityService.canEditTranslations()}/>
-                            </span>
+                            {canEditTranslations && <span style={{gridArea: "cb"}} className="mrxs">
+                                <input type="checkbox" checked={isSelected} readOnly={true} disabled={!canEditTranslations}/>
+                            </span>}
                             <div style={{gridArea: "locale"}}>
                                 <Label bsStyle='primary' bsSize='large' className="clickable" onClick={this.onLocaleLabelClick}>
                                     {this.props.textUnit.getTargetLocale()}

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -645,6 +645,12 @@ label.current-pageNumber {
     overflow-y: auto;
 }
 
+.branch-spinner {
+    display: flex;
+    justify-content: center;  
+    align-items: center;
+}
+
 .textunit-toolbar-clear {
     clear: both;
 }


### PR DESCRIPTION
- Do not show buttons and checkboxes to non-admin users as they cannot use them.
- Show spinners when the data is loading (branches, workbench page)
   - The stale data is still kept on the screen and the current icon is not as noticeable as it should be
- Add a tooltip to status icons of text units
- The locale filter needs the repository filter to be selected first. So disable the filter until that filter has been used