### PR TITLE
I18N-1308: HEADER Authentication Fix

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserService.java
@@ -417,7 +417,7 @@ public class UserService {
    * @param serviceName
    * @return
    */
-  public User getServiceAccountUser(String serviceName) {
+  public User getServiceAccountUser(String serviceName) throws UsernameNotFoundException {
     if (serviceDisambiguator == null) {
       logger.debug("Service Disambiguator is null. Falling back to regular exact match logic");
       return userRepository.findByUsername(serviceName);
@@ -437,7 +437,8 @@ public class UserService {
       logger.error(
           "Service '{}' attempted and failed authentication. No matching services found.",
           serviceName);
-      return null;
+      throw new UsernameNotFoundException(
+          "Service authentication failed. No matching services found");
     }
 
     User matchingUser = serviceDisambiguator.getServiceWithCommonAncestor(users, serviceName);


### PR DESCRIPTION
Returning null instead of throwing an exception led to a NullPointerException within Spring Security's framework itself. This prevented the Pipeline from falling back to other auth mechanisms when the service was not recognized and masking it with generic Exceptions in the logs