### PR TITLE
Allow Request Logger to log requests before Auth

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggerHelper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggerHelper.java
@@ -1,0 +1,114 @@
+package com.box.l10n.mojito.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.UnsupportedEncodingException;
+import java.util.Enumeration;
+import java.util.Set;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.WebUtils;
+
+/***
+ * Adapted from AbstractRequestLoggingFilter
+ */
+@Component
+@ConditionalOnProperty(value = "l10n.logging.requests.enabled", havingValue = "true")
+public class RequestLoggerHelper {
+
+  private static final Set<String> FILTERED_HEADER_NAMES =
+      Set.of(
+          "Accept",
+          "Authorization",
+          "Connection",
+          "Cookie",
+          "From",
+          "Host",
+          "Origin",
+          "Priority",
+          "Range",
+          "Referer",
+          "Upgrade");
+
+  public String summarizeRequest(HttpServletRequest request, RequestLoggingConfig config) {
+    StringBuilder msg = new StringBuilder();
+    msg.append(config.getBeforeMessagePrefix());
+
+    msg.append("Method=").append(request.getMethod()).append(" ");
+    msg.append("RequestURI=").append(request.getRequestURI()).append(" ");
+
+    if (config.includesQueryString()) {
+      msg.append("Query=").append(request.getQueryString()).append(" ");
+    }
+
+    if (config.includesHeader()) {
+      msg.append("Headers=").append(request.getHeaderNames()).append(" ");
+    }
+
+    if (config.includesPayload()) {
+      String payload = getPayload(request, config);
+      msg.append("Payload=").append(payload).append(" ");
+    }
+
+    msg.append(config.getAfterMessagePrefix());
+    return msg.toString();
+  }
+
+  private String getPayload(HttpServletRequest request, RequestLoggingConfig config) {
+    StringBuilder msg = new StringBuilder();
+    msg.append(config.getBeforeMessagePrefix());
+    msg.append(request.getMethod()).append(' ');
+    msg.append(request.getRequestURI());
+
+    if (config.includesQueryString()) {
+      String queryString = request.getQueryString();
+      if (queryString != null) {
+        msg.append('?').append(queryString);
+      }
+    }
+
+    if (config.includesHeader()) {
+      HttpHeaders headers = new ServletServerHttpRequest(request).getHeaders();
+      Enumeration<String> names = request.getHeaderNames();
+      while (names.hasMoreElements()) {
+        String header = names.nextElement();
+        if (isMaskedHeader(header)) {
+          headers.set(header, "masked");
+        }
+      }
+      msg.append(", headers=").append(headers);
+    }
+
+    if (config.includesPayload()) {
+      String payload = getMessagePayload(request, config.getMaxPayloadLength());
+      if (payload != null) {
+        msg.append(", payload=").append(payload);
+      }
+    }
+
+    return msg.toString();
+  }
+
+  private boolean isMaskedHeader(String name) {
+    return FILTERED_HEADER_NAMES.contains(name);
+  }
+
+  private String getMessagePayload(HttpServletRequest request, int maxPayloadLength) {
+    ContentCachingRequestWrapper wrapper =
+        WebUtils.getNativeRequest(request, ContentCachingRequestWrapper.class);
+    if (wrapper != null) {
+      byte[] buf = wrapper.getContentAsByteArray();
+      if (buf.length > 0) {
+        int length = Math.min(buf.length, maxPayloadLength);
+        try {
+          return new String(buf, 0, length, wrapper.getCharacterEncoding());
+        } catch (UnsupportedEncodingException ex) {
+          return "[unknown]";
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggingConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggingConfig.java
@@ -1,42 +1,73 @@
 package com.box.l10n.mojito.security;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.filter.CommonsRequestLoggingFilter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
-@Configuration
+@Component
+@ConfigurationProperties(prefix = "l10n.logging.requests")
 public class RequestLoggingConfig {
 
-  @Value("${l10n.logging.requests.includesQueryString:false}")
-  public boolean includesQueryString;
+  private boolean includesQueryString = true;
+  private boolean includesHeader = false;
+  private boolean includesPayload = true;
+  private int maxPayloadLength = 10000;
+  private String beforeMessagePrefix = "Request Data: [ ";
+  private String afterMessagePrefix = " ]";
+  private boolean enabled = false;
 
-  @Value("${l10n.logging.requests.includesHeader:false}")
-  public boolean includesHeader;
+  public boolean includesQueryString() {
+    return includesQueryString;
+  }
 
-  @Value("${l10n.logging.requests.includesPayload:true}")
-  public boolean includesPayload;
+  public void setIncludesQueryString(boolean includesQueryString) {
+    this.includesQueryString = includesQueryString;
+  }
 
-  @Value("${l10n.logging.requests.maxPayloadLength:10000}")
-  public int maxPayloadLength;
+  public boolean includesHeader() {
+    return includesHeader;
+  }
 
-  @Value("${l10n.logging.requests.beforeMessagePrefix:}")
-  public String beforeMessagePrefix;
+  public void setIncludesHeader(boolean includesHeader) {
+    this.includesHeader = includesHeader;
+  }
 
-  @Value("${l10n.logging.requests.afterMessagePrefix:Request Data: }")
-  public String afterMessagePrefix;
+  public boolean includesPayload() {
+    return includesPayload;
+  }
 
-  @Bean
-  @ConditionalOnProperty(value = "l10n.logging.requests.enabled", havingValue = "true")
-  public CommonsRequestLoggingFilter logFilter() {
-    CommonsRequestLoggingFilter filter = new CommonsRequestLoggingFilter();
-    filter.setIncludeQueryString(includesQueryString);
-    filter.setIncludePayload(includesPayload);
-    filter.setMaxPayloadLength(maxPayloadLength);
-    filter.setIncludeHeaders(includesHeader);
-    filter.setBeforeMessagePrefix(beforeMessagePrefix);
-    filter.setAfterMessagePrefix(afterMessagePrefix);
-    return filter;
+  public void setIncludesPayload(boolean includesPayload) {
+    this.includesPayload = includesPayload;
+  }
+
+  public int getMaxPayloadLength() {
+    return maxPayloadLength;
+  }
+
+  public void setMaxPayloadLength(int maxPayloadLength) {
+    this.maxPayloadLength = maxPayloadLength;
+  }
+
+  public String getBeforeMessagePrefix() {
+    return beforeMessagePrefix;
+  }
+
+  public void setBeforeMessagePrefix(String beforeMessagePrefix) {
+    this.beforeMessagePrefix = beforeMessagePrefix;
+  }
+
+  public String getAfterMessagePrefix() {
+    return afterMessagePrefix;
+  }
+
+  public void setAfterMessagePrefix(String afterMessagePrefix) {
+    this.afterMessagePrefix = afterMessagePrefix;
+  }
+
+  public boolean isLoggingEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggingConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggingConfiguration.java
@@ -1,0 +1,33 @@
+package com.box.l10n.mojito.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+public class RequestLoggingConfiguration {
+
+  private final RequestLoggingConfig requestLoggingConfig;
+  private final RequestLoggerHelper requestLoggerHelper;
+
+  @Autowired
+  public RequestLoggingConfiguration(
+      RequestLoggingConfig requestLoggingConfig,
+      @Autowired(required = false) RequestLoggerHelper requestLoggerHelper) {
+    this.requestLoggingConfig = requestLoggingConfig;
+    this.requestLoggerHelper = requestLoggerHelper;
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "l10n.logging.requests.enabled", havingValue = "true")
+  public FilterRegistrationBean<RequestLoggingFilter> loggingFilter() {
+    FilterRegistrationBean<RequestLoggingFilter> registrationBean = new FilterRegistrationBean<>();
+
+    registrationBean.setFilter(new RequestLoggingFilter(requestLoggerHelper, requestLoggingConfig));
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE); // Ensure it runs before auth filters
+    return registrationBean;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggingFilter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggingFilter.java
@@ -1,0 +1,36 @@
+package com.box.l10n.mojito.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+  private static final Logger logger = LoggerFactory.getLogger(RequestLoggingFilter.class);
+
+  private final RequestLoggingConfig requestLoggingConfig;
+  private final RequestLoggerHelper requestLoggerHelper;
+
+  public RequestLoggingFilter(
+      RequestLoggerHelper requestLoggerHelper, RequestLoggingConfig requestLoggingConfig) {
+    this.requestLoggingConfig = requestLoggingConfig;
+    this.requestLoggerHelper = requestLoggerHelper;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws jakarta.servlet.ServletException, IOException {
+
+    if (requestLoggingConfig.isLoggingEnabled() && requestLoggerHelper != null) {
+      String msg = requestLoggerHelper.summarizeRequest(request, requestLoggingConfig);
+      logger.info(msg);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}


### PR DESCRIPTION
The default logger only gets called after all filters. This meant that request which do not pass authentication do not get logged. This is not ideal since we want to inspect requests before authentication for debugging purposes