### PR TITLE
Reorder auth filter precedence

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
@@ -269,7 +269,7 @@ public class WebSecurityConfig {
           logger.debug("Add request header Auth filter with fallback");
           requestHeaderAuthenticationFilter.setAuthenticationManager(
               authenticationConfiguration.getAuthenticationManager());
-          http.addFilterBefore(
+          http.addFilterAfter(
               requestHeaderAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
           break;
         case OAUTH2:


### PR DESCRIPTION
By resorting to header based authentication last,
we are able to prioritize prior forms of authentication