### PR TITLE
Fix NullPointerException for ScheduledThirdPartySync configs

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManager.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManager.java
@@ -11,6 +11,7 @@ import com.box.l10n.mojito.service.thirdparty.ThirdPartySyncJobConfig;
 import com.box.l10n.mojito.service.thirdparty.ThirdPartySyncJobsConfig;
 import com.google.common.base.Strings;
 import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -215,7 +216,10 @@ public class ScheduledJobManager {
     thirdPartySyncProperties.setSkipAssetsWithPathPattern(jobConfig.getSkipAssetsWithPathPattern());
     thirdPartySyncProperties.setIncludeTextUnitsWithPattern(
         jobConfig.getIncludeTextUnitsWithPattern());
-    thirdPartySyncProperties.setOptions(jobConfig.getOptions());
+
+    thirdPartySyncProperties.setOptions(
+        jobConfig.getOptions() != null ? jobConfig.getOptions() : new ArrayList<>());
+
     return thirdPartySyncProperties;
   }
 


### PR DESCRIPTION
If the options is not defined in the config it will be set as null as opposed to an empty list. This PR fixes this by ensuring its always an empty list if no options are defined in the application.properties.