### PR TITLE
Header Authentication: Ignore services masquerading as users

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/HeaderPreAuthFilter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/HeaderPreAuthFilter.java
@@ -17,7 +17,7 @@ public class HeaderPreAuthFilter extends AbstractPreAuthenticatedProcessingFilte
   @Override
   protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
     String forwardedUser = request.getHeader(headerSecurityConfig.userIdentifyingHeader);
-    if (forwardedUser != null) {
+    if (forwardedUser != null && !forwardedUser.contains(headerSecurityConfig.servicePrefix)) {
       logger.debug("Forwarded user: {}", forwardedUser);
       if (!forwardedUser.isEmpty()) {
         return forwardedUser;


### PR DESCRIPTION
During service-service authentication, both the user and service headers are sent. For the user flow, accounts are created however if these are actually services we do not want to create accounts on the fly. So validate that a user is not a service before creating their accounts