### PR TITLE
Fix double textunit search call when entering the workbench 

### DIFF
--- a/webapp/src/main/resources/public/js/stores/workbench/SearchResultsStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/SearchResultsStore.js
@@ -6,6 +6,7 @@ import SearchParamsStore from "./SearchParamsStore";
 import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
 import RepositoryActions from "../../actions/RepositoryActions";
 import textUnitStore from "./TextUnitStore";
+import ShareSearchParamsModalStore from "./ShareSearchParamsModalStore";
 
 class SearchResultsStore {
 
@@ -232,7 +233,9 @@ class SearchResultsStore {
     }
 
     getAllRepositoriesSuccess() {
-        this.onSearchParamsChanged();
+        if(ShareSearchParamsModalStore.getState().url) {
+            this.onSearchParamsChanged();
+        }
     }
 
     /**


### PR DESCRIPTION
Upon entering the workbench by clicking on a repository in the Repositories tab, the client sends two identical textunit search requests. This is wasteful and was introduced to ensure entering the workbench on a generated link renders correctly: [9cdd4d5](https://github.com/pinterest/mojito/commit/9cdd4d50954547474040ff2b00e6371cd3c5b3a6)

This PR makes the re-render (re-search) only trigger when the ShareSearchParamsModalStore's url is populated. This fixes the flickering when entering the workbench as there is not two renders running for the search.

Entering the workbench (before change):
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/df1b4e6f-22bb-4171-b30b-77f9e64ea3a4" />

Entering the workbench (after change):
<img width="1622" alt="image" src="https://github.com/user-attachments/assets/5846083d-c2bb-4628-b7eb-964c7790a1ed" />

Tested the UI locally and tested generating links and visiting them which work as expected.