### PR TITLE
Fix inline-source-map for npm start-dev

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -58,7 +58,7 @@
     "fsevents": "^1.2.13"
   },
   "scripts": {
-    "start-dev": "npm run start-server & npm run watch",
+    "start-dev": "npm run start-server-nofe & npm run watch",
     "start-server": "mvn spring-boot:run -Dspring-boot.run.jvmArguments=\"-Dspring.config.additional-location=optional:file://$HOME/.l10n/config/webapp/ -Dspring.profiles.active=$USER,npm -Duser.timezone=UTC\"",
     "start-server-debug": "mvn spring-boot:run -Dspring-boot.run.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005 -Dspring.config.additional-location=optional:file://$HOME/.l10n/config/webapp/ -Dspring.profiles.active=$USER,npm -Duser.timezone=UTC\"",
     "start-server-debugn": "mvn spring-boot:run -Dspring-boot.run.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 -Dspring.config.additional-location=optional:file://$HOME/.l10n/config/webapp/ -Dspring.profiles.active=$USER,npm -Duser.timezone=UTC\"",

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -5,7 +5,9 @@ const TerserPlugin = require("terser-webpack-plugin");
 module.exports = (env) => {
     env = env || {};
 
-    const isProdEnv = Boolean(env.production)
+    const isProdEnv = Boolean(env.production);
+    const inlineSourceMap = Boolean(env.inlineSourceMap);
+
     const config = {
         entry: {
             'app': path.resolve(__dirname, './src/main/resources/public/js/app.jsx'),
@@ -18,6 +20,7 @@ module.exports = (env) => {
             chunkFilename: 'js/[name]-[chunkhash].js'
         },
         mode: isProdEnv ? 'production' : 'development',
+        devtool: inlineSourceMap ? "inline-source-map" : false,
         module: {
             rules: [
                 {
@@ -109,7 +112,7 @@ module.exports = (env) => {
             minimize: isProdEnv,
         },
         performance: {
-            hints: 'error',
+            hints: 'warning',
             maxEntrypointSize: 1_800_000, // 1.8MB
             maxAssetSize: 1_800_000 // 1.8MB
         },
@@ -134,10 +137,6 @@ module.exports = (env) => {
                         'NODE_ENV': JSON.stringify('production')
                     }
                 }));
-    }
-
-    if (env.inlineSourceMap) {
-        config.devtool = "inline-source-map";
     }
 
     return config;


### PR DESCRIPTION
We currently have inline-source-map defined, however when you run `npm run start-dev` it doesn't use it.
This is because start-dev runs the watcher with the correct config but the run start-server command embedded in this command completely builds the bundle again overriding the inline-source-map configuration. The front-end doesn't need to be compiled when watcher is in charge of it. Also changed the performance hints to warning instead of error if the bundle size is large.

This setting maps the compiled code to the source code, **allowing developers to use breakpoints and follow call stacks in devtools.**

Before on start-dev:
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/ecee90bf-faa2-4079-b51c-7be1e656c333" />

After on start-dev: 
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/8710c9c3-9253-46e6-87ef-771cb8f519d0" />
