### PR TITLE
Add Dockerfile for JDK 21

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+webapp/node_modules
+webapp/node

--- a/docker/Dockerfile-bk21
+++ b/docker/Dockerfile-bk21
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:experimental
+
+# Force the platform to ensure npm downloads the correct packages with the right architecture
+FROM --platform=linux/amd64 maven:3.9.9-eclipse-temurin-21 as build
+VOLUME ["/tmp"]
+
+WORKDIR /mnt/mojito
+COPY . /mnt/mojito
+
+ENV PATH="/mnt/mojito/webapp/node/:${PATH}"
+RUN --mount=type=cache,target=/root/.m2 --mount=type=cache,target=/mnt/mojito/node --mount=type=cache,target=/mnt/mojito/node_module mvn clean install -DskipTests
+
+FROM amazoncorretto:21-alpine
+VOLUME /tmp
+
+ENV MOJITO_BIN=/usr/local/mojito/bin
+ENV PATH $PATH:${MOJITO_BIN}
+ENV MOJITO_HOST=localhost
+ENV MOJITO_SCHEME=http
+ENV MOJITO_PORT=8080
+
+COPY --from=build /mnt/mojito/webapp/target/mojito-webapp-*-exec.jar ${MOJITO_BIN}/mojito-webapp.jar
+COPY --from=build /mnt/mojito/cli/target/mojito-cli-*-exec.jar ${MOJITO_BIN}/mojito-cli.jar
+RUN sh -c 'touch ${MOJITO_BIN}/mojito-webapp.jar'
+RUN sh -c 'touch ${MOJITO_BIN}/mojito-cli.jar'
+
+# Create the shell wrapper for the jar
+RUN /bin/echo -e "#!/bin/sh \n\
+java -Dl10n.resttemplate.host=\${MOJITO_HOST} \\\\\n \
+     -Dl10n.resttemplate.scheme=\${MOJITO_SCHEME} \\\\\n \
+     -Dl10n.resttemplate.port=\${MOJITO_PORT} \\\\\n \
+     -jar $MOJITO_BIN/mojito-cli.jar \"\${@}\"" \
+    >> /usr/local/mojito/bin/mojito && chmod +x $MOJITO_BIN/mojito
+
+ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar $MOJITO_BIN/mojito-webapp.jar

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:8-jre
+FROM amazoncorretto:21-alpine
 
 ENV MOJITO_BIN=/usr/local/mojito/bin
 ENV PATH $PATH:${MOJITO_BIN}

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.6-eclipse-temurin-17
+FROM maven:3.9.9-eclipse-temurin-21
 VOLUME ["/tmp"]
 WORKDIR /mnt/mojito
 ENV PATH="/mnt/mojito/webapp/node/:${PATH}"

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -36,8 +36,15 @@ services:
 
 ## Common issues
 
-Incompatibility Mac/Linux for `node/` `node_modules/`, remove the directories before calling docker commands. Some
-`Dockerfile` remove the directories explicitly.
+```
+208.1 # A fatal error has been detected by the Java Runtime Environment:
+208.1 #
+208.1 #  SIGSEGV (0xb) at pc=0x00007fffe7f0f4d0, pid=7, tid=22
+```
+This is a result of not allocating enough disk space and or memory to the docker environment. Make sure to increase the memory limit and disk usage limit in docker desktop.
+
+~~Incompatibility Mac/Linux for `node/` `node_modules/`, remove the directories before calling docker commands. Some
+`Dockerfile` remove the directories explicitly.~~ (.dockerignore solves this)
 
 # One-off build and push 
 


### PR DESCRIPTION
- Added Dockerfile for JDK 21.
- Added `.dockerignore` to ignore the `node_modules` and `node` folders when building the image as the architecture of the packages / node can be different in the image from the host causing build failures.
- Updated Docker docs to add information / remediation for a segment fault issue in the JVM during the build process.