### PR TITLE
I18N-1308: Correlation ID Fix

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -306,6 +306,11 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-observation</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
While testing the tutorial recommended multiple packages. Some of which were not needed. So every package was removed one by one until a stable working set was found but unfortunately there must have been some cache because it does not work without this package