### PR TITLE
Track metrics of appending fully translated branch text units

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
@@ -489,7 +489,7 @@ public class AssetWS {
       Long countTextUnitsPushed =
           pushRunRepository.countTextUnitsFromLastPushRun(repository.getId());
       Long countTextUnitsToAppend =
-          tmTextUnitRepository.countTextUnitsReadyForAppending(repository.getId());
+          tmTextUnitRepository.countTextUnitsReadyForAppending(repository.getId(), "master", 14);
 
       // Uptick counter before decimal calculation in the chance an exception is thrown
       meterRegistry

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
@@ -293,7 +293,7 @@ public class AssetWS {
         .increment();
 
     Repository repository = asset.getRepository();
-    if (recordMetricsForRepositories.contains(repository.getId().toString())) {
+    if (recordMetricsForRepositories.contains(repository.getName())) {
       recordAppendMetrics(repository);
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
@@ -487,6 +487,14 @@ public class AssetWS {
 
   private void recordAppendMetrics(Repository repository) {
     try {
+
+      if (pushRunRepository.findLatestPushRunIdByRepositoryId(repository.getId()).isEmpty()) {
+        logger.warn(
+            "Attempted to log append text unit metrics for repository '{}' but there was no latest push run id found for this repository.",
+            repository.getName());
+        return;
+      }
+
       AssetMetricsConfigurationProperties assetMetricsConfigurationProperties =
           assetMetricsConfigurationsProperties.getAssetMetrics().get(repository.getName());
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetMetricsConfigurationProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetMetricsConfigurationProperties.java
@@ -1,0 +1,31 @@
+package com.box.l10n.mojito.service.asset;
+
+public class AssetMetricsConfigurationProperties {
+  private String repository;
+  private String mainBranch;
+  private int daysInterval;
+
+  public String getRepository() {
+    return repository;
+  }
+
+  public void setRepository(String repository) {
+    this.repository = repository;
+  }
+
+  public String getMainBranch() {
+    return mainBranch;
+  }
+
+  public void setMainBranch(String mainBranch) {
+    this.mainBranch = mainBranch;
+  }
+
+  public int getDaysInterval() {
+    return daysInterval;
+  }
+
+  public void setDaysInterval(int daysInterval) {
+    this.daysInterval = daysInterval;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetMetricsConfigurationsProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetMetricsConfigurationsProperties.java
@@ -1,0 +1,20 @@
+package com.box.l10n.mojito.service.asset;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("l10n")
+public class AssetMetricsConfigurationsProperties {
+  Map<String, AssetMetricsConfigurationProperties> assetMetrics = new HashMap<>();
+
+  public Map<String, AssetMetricsConfigurationProperties> getAssetMetrics() {
+    return assetMetrics;
+  }
+
+  public void setAssetMetrics(Map<String, AssetMetricsConfigurationProperties> assetMetrics) {
+    this.assetMetrics = assetMetrics;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunRepository.java
@@ -61,7 +61,7 @@ public interface PushRunRepository extends JpaRepository<PushRun, Long> {
       JOIN push_run_asset pra ON pra.id = pratu.push_run_asset_id
       JOIN push_run pr ON pr.id = pra.push_run_id
       WHERE pr.id = (
-          SELECT p.id FROM push_run p WHERE p.repository_id = 4 ORDER BY p.created_date DESC LIMIT 1
+          SELECT p.id FROM push_run p WHERE p.repository_id = :repositoryId ORDER BY p.created_date DESC LIMIT 1
       )
     """,
       nativeQuery = true)

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunRepository.java
@@ -66,4 +66,12 @@ public interface PushRunRepository extends JpaRepository<PushRun, Long> {
     """,
       nativeQuery = true)
   Long countTextUnitsFromLastPushRun(@Param("repositoryId") Long repositoryId);
+
+  @Query(
+      value =
+          """
+          SELECT p.id FROM PushRun p
+          WHERE p.repository.id = :repositoryId ORDER BY p.createdDate DESC LIMIT 1
+          """)
+  Optional<Long> findLatestPushRunIdByRepositoryId(@Param("repositoryId") Long repositoryId);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunRepository.java
@@ -52,4 +52,18 @@ public interface PushRunRepository extends JpaRepository<PushRun, Long> {
           where pr.created_date < :beforeDate
           """)
   void deleteAllByCreatedDateBefore(@Param("beforeDate") ZonedDateTime beforeDate);
+
+  @Query(
+      value =
+          """
+      SELECT COUNT(*)
+      FROM push_run_asset_tm_text_unit pratu
+      JOIN push_run_asset pra ON pra.id = pratu.push_run_asset_id
+      JOIN push_run pr ON pr.id = pra.push_run_id
+      WHERE pr.id = (
+          SELECT p.id FROM push_run p WHERE p.repository_id = 4 ORDER BY p.created_date DESC LIMIT 1
+      )
+    """,
+      nativeQuery = true)
+  Long countTextUnitsFromLastPushRun(@Param("repositoryId") Long repositoryId);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
@@ -55,6 +55,6 @@ public interface TMTextUnitRepository extends JpaRepository<TMTextUnit, Long> {
       "SELECT t FROM TMTextUnit t JOIN FETCH t.asset a JOIN FETCH a.repository JOIN FETCH t.tm WHERE t.id = :id")
   Optional<TMTextUnit> findByIdWithAssetAndRepositoryAndTMFetched(@Param("id") Long id);
 
-  @Procedure(procedureName = "fetch_text_units_ready_for_appending")
-  Long countTextUnitsReadyForAppending(@Param("repo") Long repositoryId);
+  @Procedure(procedureName = "fetch_text_unit_count_for_appending")
+  Long countTextUnitsReadyForAppending(@Param("repositoryId") Long repositoryId);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.query.Procedure;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
@@ -53,4 +54,7 @@ public interface TMTextUnitRepository extends JpaRepository<TMTextUnit, Long> {
   @Query(
       "SELECT t FROM TMTextUnit t JOIN FETCH t.asset a JOIN FETCH a.repository JOIN FETCH t.tm WHERE t.id = :id")
   Optional<TMTextUnit> findByIdWithAssetAndRepositoryAndTMFetched(@Param("id") Long id);
+
+  @Procedure(procedureName = "fetch_text_units_ready_for_appending")
+  Long countTextUnitsReadyForAppending(@Param("repo") Long repositoryId);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
@@ -56,5 +56,8 @@ public interface TMTextUnitRepository extends JpaRepository<TMTextUnit, Long> {
   Optional<TMTextUnit> findByIdWithAssetAndRepositoryAndTMFetched(@Param("id") Long id);
 
   @Procedure(procedureName = "fetch_text_unit_count_for_appending")
-  Long countTextUnitsReadyForAppending(@Param("repositoryId") Long repositoryId);
+  Long countTextUnitsReadyForAppending(
+      @Param("repositoryId") Long repositoryId,
+      @Param("mainBranch") String mainBranch,
+      @Param("daysInterval") int daysInterval);
 }

--- a/webapp/src/main/resources/db/migration/V74__Add_append_text_unit_count_procedure.sql
+++ b/webapp/src/main/resources/db/migration/V74__Add_append_text_unit_count_procedure.sql
@@ -1,12 +1,12 @@
 DELIMITER //
-CREATE PROCEDURE fetch_text_unit_count_for_appending(IN repositoryId BIGINT, OUT result_count INT)
+CREATE PROCEDURE fetch_text_unit_count_for_appending(IN repositoryId BIGINT, IN mainBranch VARCHAR(255), IN daysInterval INT, OUT result_count INT)
 BEGIN
-    -- Pull out text units that are in a fully translated branch which are not in the latest push run.
+-- Pull out text units that are in a fully translated branch which are not in the latest push run.
 SELECT COUNT(DISTINCT tu.id) INTO result_count
 FROM tm_text_unit tu
-         JOIN asset_text_unit_to_tm_text_unit atutttu ON tu.id = atutttu.tm_text_unit_id
-         JOIN asset_text_unit atu ON atutttu.asset_text_unit_id = atu.id
-         JOIN branch b ON atu.branch_id = b.id
+JOIN asset_text_unit_to_tm_text_unit atutttu ON tu.id = atutttu.tm_text_unit_id
+JOIN asset_text_unit atu ON atutttu.asset_text_unit_id = atu.id
+JOIN branch b ON atu.branch_id = b.id
 WHERE atu.branch_id IN (
     -- All fully translated branches that are not master or null (created last 2 weeks)
     SELECT b.id
@@ -15,18 +15,18 @@ WHERE atu.branch_id IN (
     WHERE b.repository_id = repositoryId
       AND b.deleted = false
       AND b.name IS NOT NULL
-      AND b.name <> 'master'
+      AND b.name <> mainBranch
       AND bs.for_translation_count = 0
-      AND b.created_date >= DATE_SUB(CURDATE(), INTERVAL 14 DAY)
+      AND b.created_date >= DATE_SUB(CURDATE(), INTERVAL daysInterval DAY)
 )
-  AND tu.id NOT IN (
+AND tu.id NOT IN (
     -- All text units that were in the last push run
     SELECT push_run_asset_tm_text_unit.tm_text_unit_id FROM push_run_asset_tm_text_unit
-                                                                JOIN push_run_asset ON push_run_asset.id = push_run_asset_tm_text_unit.push_run_asset_id
-                                                                JOIN push_run ON push_run.id = push_run_asset.push_run_id
+    JOIN push_run_asset ON push_run_asset.id = push_run_asset_tm_text_unit.push_run_asset_id
+    JOIN push_run ON push_run.id = push_run_asset.push_run_id
     WHERE push_run.id = (
         SELECT p.id FROM push_run p WHERE p.repository_id = repositoryId ORDER BY p.created_date DESC LIMIT 1
-    )
+        )
     );
 END //
 DELIMITER ;

--- a/webapp/src/main/resources/db/migration/V74__Add_append_text_unit_count_procedure.sql
+++ b/webapp/src/main/resources/db/migration/V74__Add_append_text_unit_count_procedure.sql
@@ -1,0 +1,32 @@
+DELIMITER //
+CREATE PROCEDURE fetch_text_unit_count_for_appending(IN repositoryId BIGINT, OUT result_count INT)
+BEGIN
+    -- Pull out text units that are in a fully translated branch which are not in the latest push run.
+SELECT COUNT(DISTINCT tu.id) INTO result_count
+FROM tm_text_unit tu
+         JOIN asset_text_unit_to_tm_text_unit atutttu ON tu.id = atutttu.tm_text_unit_id
+         JOIN asset_text_unit atu ON atutttu.asset_text_unit_id = atu.id
+         JOIN branch b ON atu.branch_id = b.id
+WHERE atu.branch_id IN (
+    -- All fully translated branches that are not master or null (created last 2 weeks)
+    SELECT b.id
+    FROM branch b
+             INNER JOIN branch_statistic bs ON b.id = bs.branch_id
+    WHERE b.repository_id = repositoryId
+      AND b.deleted = false
+      AND b.name IS NOT NULL
+      AND b.name <> 'master'
+      AND bs.for_translation_count = 0
+      AND b.created_date >= DATE_SUB(CURDATE(), INTERVAL 14 DAY)
+)
+  AND tu.id NOT IN (
+    -- All text units that were in the last push run
+    SELECT push_run_asset_tm_text_unit.tm_text_unit_id FROM push_run_asset_tm_text_unit
+                                                                JOIN push_run_asset ON push_run_asset.id = push_run_asset_tm_text_unit.push_run_asset_id
+                                                                JOIN push_run ON push_run.id = push_run_asset.push_run_id
+    WHERE push_run.id = (
+        SELECT p.id FROM push_run p WHERE p.repository_id = repositoryId ORDER BY p.created_date DESC LIMIT 1
+    )
+    );
+END //
+DELIMITER ;


### PR DESCRIPTION
This change is to temporarily track the percentage increase in text units for an asset if we were to append text units from fully translated branches against that repository. **The text units to be appended must not have been pushed up in the last push and are in an open branch on Mojito that is full translated**. This metric (text unit count) is pulled from an SQL procedure to allow us to dynamically update the query during runtime. The repositories to be tracked must be listed in the application properties under: `l10n.assetWS.metrics.append-text-units.repositories=1,2,3` where each value is a repository id.