### PR TITLE
Fix flaky scheduled job test

### DIFF
--- a/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
@@ -154,7 +154,7 @@ public class ScheduledJobManagerTest extends ServiceTestBase {
     scheduledJob.setEnabled(false);
     scheduledJob.setEndDate(null);
     scheduledJobRepository.save(scheduledJob);
-    ZonedDateTime start = scheduledJob.getStartDate();
+    ZonedDateTime start = getTestJob().getStartDate();
     // Let the job run
     Thread.sleep(JOB_WAIT_TIME_MS);
     assertEquals(start, getTestJob().getStartDate());


### PR DESCRIPTION
`ScheduledJobManagerTest.testEnableDisableJob:160 expected:<2025-01-24T15:56:34.011054Z> but was:<2025-01-24T15:56:38.004463Z>`

The test was using the start date before the enabled state was applied `".save()"`, this lead to flaky test results.