### PR TITLE
I18N-1424: Fix missing CSRF token header in AuthenticatedClient

### DIFF
--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/CustomHttpRequestWrapper.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/CustomHttpRequestWrapper.java
@@ -1,0 +1,33 @@
+package com.box.l10n.mojito.rest.resttemplate;
+
+import java.net.URI;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+
+public class CustomHttpRequestWrapper implements HttpRequest {
+  private final HttpRequest original;
+  private final HttpHeaders headers;
+
+  public CustomHttpRequestWrapper(HttpRequest original, HttpHeaders extraHeaders) {
+    this.original = original;
+    this.headers = new HttpHeaders();
+    this.headers.putAll(original.getHeaders());
+    this.headers.putAll(extraHeaders);
+  }
+
+  @Override
+  public HttpMethod getMethod() {
+    return original.getMethod();
+  }
+
+  @Override
+  public URI getURI() {
+    return original.getURI();
+  }
+
+  @Override
+  public HttpHeaders getHeaders() {
+    return headers;
+  }
+}


### PR DESCRIPTION
When interceptors are used, new requests should be created because old requests are meant to stay immutable. 
This doesn't seem to be as necessary when there is only one such interceptor however when multiple are configured, this seems to not work correctly.

[JIRA 1424](https://jira.pinadmin.com/browse/I18N-1424)