### PR TITLE
Added metric to track Pending MT queue size

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Lists;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -103,7 +102,9 @@ public class AITranslateCronJob implements Job {
             meterRegistry
                 .timer("AITranslateCronJob.timeToMT", Tags.of("repository", repository.getName()))
                 .record(
-                    Duration.between(JSR310Migration.dateTimeNow(), pendingMT.getCreatedDate()));
+                    JSR310Migration.getMillis(JSR310Migration.dateTimeNow())
+                        - JSR310Migration.getMillis(pendingMT.getCreatedDate()),
+                    TimeUnit.MILLISECONDS);
           } else {
             logger.debug(
                 "Text unit with name: {} should not be translated, skipping AI translation.",

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -310,6 +310,9 @@ public class AITranslateCronJob implements Job {
     List<TmTextUnitPendingMT> pendingMTs;
     try {
       do {
+        meterRegistry
+            .counter("AITranslateCronJob.pendingMT.queueSize")
+            .increment(tmTextUnitPendingMTRepository.count());
         pendingMTs =
             tmTextUnitPendingMTRepository.findBatch(aiTranslationConfiguration.getBatchSize());
         logger.info("Processing {} pending MTs", pendingMTs.size());


### PR DESCRIPTION
PR to log the size of the AI translation queue as the job processes TUs and update `timeToMT` metric recording to use milliseconds.