### PR TITLE
Exclude variants with AI statuses from rejected search

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
@@ -423,6 +423,10 @@ public class TextUnitSearcher {
           break;
         case REJECTED:
           conjunction.add(new NativeEqExpFix("tuv.included_in_localized_file", Boolean.FALSE));
+          conjunction.add(
+              NativeExps.notEq("tuv.status", TMTextUnitVariant.Status.MT_TRANSLATED.toString()));
+          conjunction.add(
+              NativeExps.notEq("tuv.status", TMTextUnitVariant.Status.MT_REVIEW_NEEDED.toString()));
           break;
         case REVIEW_NEEDED:
           conjunction.add(


### PR DESCRIPTION
As per title, remove text units in an AI translation state from the `REJECTED` result set.