### PR TITLE
Clean-up warnings of TextUnit page

### DIFF
--- a/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.jsx
@@ -504,7 +504,7 @@ class BranchesSearchResults extends React.Component {
     render() {
         if (this.props.branchesSearchParamStore.isSpinnerShown) {
             return (
-                <div class="branch-spinner mtl mbl">
+                <div className="branch-spinner mtl mbl">
                     <DelayedSpinner />
                 </div>
             );

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
@@ -788,7 +788,7 @@ let SearchResults = createReactClass({
     render() {
         if (this.state.isSearching) {
             return (
-                <div class="branch-spinner mtl mbl">
+                <div className="branch-spinner mtl mbl">
                     <DelayedSpinner />
                 </div>
             );

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.jsx
@@ -458,7 +458,6 @@ let TextUnit = createReactClass({
                 glyphTitle = this.props.intl.formatMessage({id: "textUnit.reviewModal.translationNeeded"});
                 tooltipDescriptor = "Translation Needed";
             }
-            console.log({tooltipDescriptor})
 
             ui = (
                 <Glyphicon
@@ -475,7 +474,7 @@ let TextUnit = createReactClass({
                     <OverlayTrigger
                         placement="top"
                         overlay={
-                            <Tooltip className="text-center">
+                            <Tooltip id={`status-description-tooltip-${this.props.textUnit.getId()}`} className="text-center">
                                 {tooltipDescriptor}
                             </Tooltip>
                         }


### PR DESCRIPTION
* Remove log statement
* Add id to tooltip to remove warning
* Use `className` instead of `class`