### PR TITLE
[I18N-1477] Trigger PD incident again if time exceeds a threshold

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
@@ -9,6 +9,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -31,13 +32,15 @@ public class PagerDutyClient {
   private final PagerDutyRetryConfiguration retryConfiguration;
   private final String clientName;
   private final PagerDutyIncidentRepository pagerDutyIncidentRepository;
+  private final Long triggerTimeThreshold;
 
   public PagerDutyClient(
       String integrationKey,
       HttpClient httpClient,
       PagerDutyRetryConfiguration retryConfiguration,
       String clientName,
-      PagerDutyIncidentRepository pagerDutyIncidentRepository) {
+      PagerDutyIncidentRepository pagerDutyIncidentRepository,
+      Long triggerTimeThreshold) {
     if (integrationKey == null || integrationKey.isEmpty())
       throw new IllegalArgumentException("Pager Duty integration key is null or empty.");
     this.integrationKey = integrationKey;
@@ -45,6 +48,7 @@ public class PagerDutyClient {
     this.retryConfiguration = retryConfiguration;
     this.clientName = clientName;
     this.pagerDutyIncidentRepository = pagerDutyIncidentRepository;
+    this.triggerTimeThreshold = triggerTimeThreshold;
   }
 
   /**
@@ -54,10 +58,20 @@ public class PagerDutyClient {
    * cannot be serialized a PagerDutyException is thrown.
    */
   public void triggerIncident(String dedupKey, PagerDutyPayload payload) throws PagerDutyException {
-    if (pagerDutyIncidentRepository.findOpenIncident(clientName, dedupKey).isPresent()) {
-      logger.debug(
-          "Open incident exists for deduplication key: '{}', ignoring trigger request.", dedupKey);
-      return;
+    Optional<PagerDutyIncident> incidentOpt =
+        pagerDutyIncidentRepository.findOpenIncident(clientName, dedupKey);
+    if (incidentOpt.isPresent()) {
+      PagerDutyIncident incident = incidentOpt.get();
+      ZonedDateTime beforeNow =
+          ZonedDateTime.now().minus(Duration.ofMinutes(this.triggerTimeThreshold));
+      if (!incident.getTriggeredAt().isBefore(beforeNow)) {
+        // The incident was triggered within the last trigger threshold minutes, don't send another
+        // request
+        logger.info(
+            "Open incident exists for deduplication key: '{}', ignoring trigger request.",
+            dedupKey);
+        return;
+      }
     }
     sendPayload(dedupKey, payload, PagerDutyPostData.EventAction.TRIGGER);
   }
@@ -135,9 +149,10 @@ public class PagerDutyClient {
 
       int statusCode = response.statusCode();
       if (statusCode == 200 || statusCode == 202) {
-        PagerDutyIncident incident;
+        Optional<PagerDutyIncident> incidentOpt =
+            pagerDutyIncidentRepository.findOpenIncident(clientName, dedupKey);
+        PagerDutyIncident incident = incidentOpt.orElse(new PagerDutyIncident());
         if (eventAction == PagerDutyPostData.EventAction.TRIGGER) {
-          incident = new PagerDutyIncident();
           incident.setClientName(clientName);
           incident.setDedupKey(dedupKey);
           incident.setTriggeredAt(ZonedDateTime.now());

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyClient.java
@@ -32,7 +32,7 @@ public class PagerDutyClient {
   private final PagerDutyRetryConfiguration retryConfiguration;
   private final String clientName;
   private final PagerDutyIncidentRepository pagerDutyIncidentRepository;
-  private final Long triggerTimeThreshold;
+  private final Duration triggerTimeThreshold;
 
   public PagerDutyClient(
       String integrationKey,
@@ -40,7 +40,7 @@ public class PagerDutyClient {
       PagerDutyRetryConfiguration retryConfiguration,
       String clientName,
       PagerDutyIncidentRepository pagerDutyIncidentRepository,
-      Long triggerTimeThreshold) {
+      Duration triggerTimeThreshold) {
     if (integrationKey == null || integrationKey.isEmpty())
       throw new IllegalArgumentException("Pager Duty integration key is null or empty.");
     this.integrationKey = integrationKey;
@@ -62,8 +62,7 @@ public class PagerDutyClient {
         pagerDutyIncidentRepository.findOpenIncident(clientName, dedupKey);
     if (incidentOpt.isPresent()) {
       PagerDutyIncident incident = incidentOpt.get();
-      ZonedDateTime beforeNow =
-          ZonedDateTime.now().minus(Duration.ofMinutes(this.triggerTimeThreshold));
+      ZonedDateTime beforeNow = ZonedDateTime.now().minus(this.triggerTimeThreshold);
       if (!incident.getTriggeredAt().isBefore(beforeNow)) {
         // The incident was triggered within the last trigger threshold minutes, don't send another
         // request

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationService.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.pagerduty;
 
 import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -22,8 +23,8 @@ public class PagerDutyIntegrationService {
   private Map<String, PagerDutyClient> pagerDutyClients;
   private final PagerDutyIncidentRepository pagerDutyIncidentRepository;
 
-  @Value("${l10n.pagerduty.triggerTimeThreshold:30}")
-  Long triggerTimeThreshold = 30L;
+  @Value("${l10n.pagerduty.triggerTimeThreshold:30m}")
+  Duration triggerTimeThreshold = Duration.ofMinutes(30);
 
   @Autowired
   public PagerDutyIntegrationService(

--- a/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pagerduty/PagerDutyIntegrationService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -20,6 +21,9 @@ public class PagerDutyIntegrationService {
   private final PagerDutyRetryConfiguration pagerDutyRetryConfiguration;
   private Map<String, PagerDutyClient> pagerDutyClients;
   private final PagerDutyIncidentRepository pagerDutyIncidentRepository;
+
+  @Value("${l10n.pagerduty.triggerTimeThreshold:30}")
+  Long triggerTimeThreshold = 30L;
 
   @Autowired
   public PagerDutyIntegrationService(
@@ -56,6 +60,7 @@ public class PagerDutyIntegrationService {
                             HttpClient.newHttpClient(),
                             pagerDutyRetryConfiguration,
                             e.getKey(),
-                            pagerDutyIncidentRepository)));
+                            pagerDutyIncidentRepository,
+                            triggerTimeThreshold)));
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/pagerduty/PagerDutyClientTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/pagerduty/PagerDutyClientTest.java
@@ -12,15 +12,15 @@ import static org.mockito.Mockito.when;
 import com.box.l10n.mojito.entity.PagerDutyIncident;
 import java.io.IOException;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 public class PagerDutyClientTest {
@@ -31,7 +31,7 @@ public class PagerDutyClientTest {
   private HttpResponse httpResponse;
 
   private PagerDutyPayload samplePayload;
-  private PagerDutyRetryConfiguration retryConfiguration = new PagerDutyRetryConfiguration();
+  private final PagerDutyRetryConfiguration retryConfiguration = new PagerDutyRetryConfiguration();
   private PagerDutyIncidentRepository pagerDutyIncidentRepository;
 
   @BeforeEach
@@ -42,7 +42,7 @@ public class PagerDutyClientTest {
 
     pagerDutyClient =
         new PagerDutyClient(
-            "xxxyyyzzz", httpClient, retryConfiguration, "test", pagerDutyIncidentRepository);
+            "xxxyyyzzz", httpClient, retryConfiguration, "test", pagerDutyIncidentRepository, 30L);
 
     Map<String, String> customDetails = new HashMap<>();
     customDetails.put("Example Custom Details", "Example Value");
@@ -54,9 +54,7 @@ public class PagerDutyClientTest {
   @Test
   public void testNormalTriggerResolve() throws IOException, InterruptedException {
     when(httpResponse.statusCode()).thenReturn(202);
-    when(httpClient.send(
-            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
-        .thenReturn(httpResponse);
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
 
     try {
       pagerDutyClient.triggerIncident("dedpuKey", samplePayload);
@@ -69,8 +67,7 @@ public class PagerDutyClientTest {
       fail("PagerDutyClient should not throw exception when the response code is 202.");
     }
 
-    verify(httpClient, times(2))
-        .send(Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class));
+    verify(httpClient, times(2)).send(any(), any());
   }
 
   @Test
@@ -80,28 +77,22 @@ public class PagerDutyClientTest {
 
     when(httpResponse.statusCode()).thenReturn(statusCode);
     when(httpResponse.body()).thenReturn(responseBody);
-    when(httpClient.send(
-            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
-        .thenReturn(httpResponse);
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
 
     assertThrows(
         PagerDutyException.class, () -> pagerDutyClient.triggerIncident("dedpuKey", samplePayload));
 
-    verify(httpClient, times(retryConfiguration.getMaxRetries() + 1))
-        .send(Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class));
+    verify(httpClient, times(retryConfiguration.getMaxRetries() + 1)).send(any(), any());
   }
 
   @Test
   public void testRecoversFromFailedAttemptsEarly() throws IOException, InterruptedException {
     when(httpResponse.statusCode()).thenReturn(500, 202);
-    when(httpClient.send(
-            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
-        .thenReturn(httpResponse);
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
 
     try {
       pagerDutyClient.triggerIncident("dedpuKey", samplePayload);
-      verify(httpClient, times(2))
-          .send(Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class));
+      verify(httpClient, times(2)).send(any(), any());
     } catch (PagerDutyException e) {
       fail("PagerDutyClient should have recovered from failing attempts.");
     }
@@ -121,14 +112,11 @@ public class PagerDutyClientTest {
                   }
                 });
 
-    when(httpClient.send(
-            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
-        .thenReturn(httpResponse);
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
 
     try {
       pagerDutyClient.triggerIncident("dedpuKey", samplePayload);
-      verify(httpClient, times(retryConfiguration.getMaxRetries()))
-          .send(Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class));
+      verify(httpClient, times(retryConfiguration.getMaxRetries())).send(any(), any());
     } catch (PagerDutyException e) {
       fail("PagerDutyClient should have recovered from failing attempts.");
     }
@@ -136,23 +124,18 @@ public class PagerDutyClientTest {
 
   @Test
   public void ioExceptionReachesMaxRetries() throws IOException, InterruptedException {
-    when(httpClient.send(
-            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
-        .thenThrow(IOException.class);
+    when(httpClient.send(any(), any())).thenThrow(IOException.class);
 
     assertThrows(
         PagerDutyException.class, () -> pagerDutyClient.triggerIncident("dedpuKey", samplePayload));
 
-    verify(httpClient, times(retryConfiguration.getMaxRetries() + 1))
-        .send(Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class));
+    verify(httpClient, times(retryConfiguration.getMaxRetries() + 1)).send(any(), any());
   }
 
   @Test
   public void testBadRequest() throws IOException, InterruptedException {
     when(httpResponse.statusCode()).thenReturn(400);
-    when(httpClient.send(
-            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
-        .thenReturn(httpResponse);
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
 
     assertThrows(
         PagerDutyException.class, () -> pagerDutyClient.triggerIncident("dedpuKey", samplePayload));
@@ -162,16 +145,13 @@ public class PagerDutyClientTest {
         .thenReturn(Optional.of(new PagerDutyIncident()));
     assertThrows(PagerDutyException.class, () -> pagerDutyClient.resolveIncident("dedupKey"));
 
-    verify(httpClient, times(2))
-        .send(Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class));
+    verify(httpClient, times(2)).send(any(), any());
   }
 
   @Test
   public void testFailsWithoutDedupKey() throws IOException, InterruptedException {
     when(httpResponse.statusCode()).thenReturn(200);
-    when(httpClient.send(
-            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
-        .thenReturn(httpResponse);
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
 
     assertThrows(
         PagerDutyException.class, () -> pagerDutyClient.triggerIncident("", samplePayload));
@@ -181,41 +161,39 @@ public class PagerDutyClientTest {
         .thenReturn(Optional.of(new PagerDutyIncident()));
     assertThrows(PagerDutyException.class, () -> pagerDutyClient.resolveIncident(null));
 
-    verify(httpClient, never())
-        .send(Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class));
+    verify(httpClient, never()).send(any(), any());
   }
 
   @Test
   public void testFailsWithoutIntegrationKey() throws IOException, InterruptedException {
     when(httpResponse.statusCode()).thenReturn(200);
-    when(httpClient.send(
-            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
-        .thenReturn(httpResponse);
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
 
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new PagerDutyClient(
-                null, httpClient, retryConfiguration, "test", pagerDutyIncidentRepository));
+                null, httpClient, retryConfiguration, "test", pagerDutyIncidentRepository, 30L));
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new PagerDutyClient(
-                "", httpClient, retryConfiguration, "test", pagerDutyIncidentRepository));
+                "", httpClient, retryConfiguration, "test", pagerDutyIncidentRepository, 30L));
   }
 
   @Test
   public void testDoesntSendPayload() throws IOException, InterruptedException {
     when(httpResponse.statusCode()).thenReturn(200);
-    when(httpClient.send(
-            Mockito.any(HttpRequest.class), Mockito.any(HttpResponse.BodyHandler.class)))
-        .thenReturn(httpResponse);
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
+
+    PagerDutyIncident incident = new PagerDutyIncident();
+    incident.setTriggeredAt(ZonedDateTime.now());
+    when(pagerDutyIncidentRepository.findOpenIncident(any(), any()))
+        .thenReturn(Optional.of(incident));
 
     try {
       // There is an open incident, the client shouldn't send the trigger payload
-      when(pagerDutyIncidentRepository.findOpenIncident(any(), any()))
-          .thenReturn(Optional.of(new PagerDutyIncident()));
-      pagerDutyClient.triggerIncident("dedpuKey", samplePayload);
+      pagerDutyClient.triggerIncident("dedupKey", samplePayload);
 
       // There is no open incident, the client shouldn't send the resolve payload
       when(pagerDutyIncidentRepository.findOpenIncident(any(), any())).thenReturn(Optional.empty());
@@ -225,5 +203,25 @@ public class PagerDutyClientTest {
     }
 
     verify(httpClient, times(0)).send(any(), any());
+  }
+
+  @Test
+  public void testSendsPayloadAfterThreshold() throws IOException, InterruptedException {
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
+
+    PagerDutyIncident incident = new PagerDutyIncident();
+    incident.setTriggeredAt(ZonedDateTime.now().minus(Duration.ofMinutes(40)));
+    when(pagerDutyIncidentRepository.findOpenIncident(any(), any()))
+        .thenReturn(Optional.of(incident));
+
+    try {
+      // There is an open incident, older than the threshold, it should trigger
+      pagerDutyClient.triggerIncident("dedpuKey", samplePayload);
+    } catch (PagerDutyException e) {
+      fail("PagerDutyClient should not throw exception when the response code is 202.");
+    }
+
+    verify(httpClient, times(1)).send(any(), any());
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/pagerduty/PagerDutyClientTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/pagerduty/PagerDutyClientTest.java
@@ -42,7 +42,12 @@ public class PagerDutyClientTest {
 
     pagerDutyClient =
         new PagerDutyClient(
-            "xxxyyyzzz", httpClient, retryConfiguration, "test", pagerDutyIncidentRepository, 30L);
+            "xxxyyyzzz",
+            httpClient,
+            retryConfiguration,
+            "test",
+            pagerDutyIncidentRepository,
+            Duration.ofMinutes(30));
 
     Map<String, String> customDetails = new HashMap<>();
     customDetails.put("Example Custom Details", "Example Value");
@@ -173,12 +178,22 @@ public class PagerDutyClientTest {
         IllegalArgumentException.class,
         () ->
             new PagerDutyClient(
-                null, httpClient, retryConfiguration, "test", pagerDutyIncidentRepository, 30L));
+                null,
+                httpClient,
+                retryConfiguration,
+                "test",
+                pagerDutyIncidentRepository,
+                Duration.ofMinutes(30)));
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new PagerDutyClient(
-                "", httpClient, retryConfiguration, "test", pagerDutyIncidentRepository, 30L));
+                "",
+                httpClient,
+                retryConfiguration,
+                "test",
+                pagerDutyIncidentRepository,
+                Duration.ofMinutes(30)));
   }
 
   @Test


### PR DESCRIPTION
To avoid an issue with manually resolved PD incidents not triggering new incidents as Mojito believes it's still open.

- Added a threshold (default: 30 minutes) - if the PD client attempts to trigger again and the last trigger date is past the 30 minute threshold then it will send the trigger payload again
- This value can be configured under `l10n.pagerduty.triggerTimeThreshold`
- Added a test to ensure the payload is sent after the threshold
- Refactored the tests by renaming `Mockito.any(...)` -> `any()` (Doesn't affect any logic of the tests)
