### PR TITLE
Workbench Page - Total Text Units - Add Loader

### DIFF
--- a/webapp/src/main/resources/public/js/actions/workbench/SearchCountDataSource.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/SearchCountDataSource.js
@@ -1,0 +1,25 @@
+import TextUnitClient from "../../sdk/TextUnitClient";
+import WorkbenchActions from "./WorkbenchActions";
+import { buildTextUnitSearchParameters } from "./TextUnitSearchParameterUtils";
+
+const SearchCountDataSource = {
+    getCount: {
+        remote(searchResultsStoreState, searchParams) {
+            const { returnEmpty, textUnitSearcherParameters } = buildTextUnitSearchParameters(searchParams);
+
+            if (returnEmpty) {
+                return Promise.resolve({ totalCount: null });
+            }
+
+            return TextUnitClient.getTextUnitCount(textUnitSearcherParameters).then((countResponse) => {
+                return { totalCount: countResponse.textUnitCount };
+            });
+        },
+
+        success: WorkbenchActions.searchCountReceivedSuccess,
+        error: WorkbenchActions.searchCountReceivedError
+    }
+};
+
+export default SearchCountDataSource;
+

--- a/webapp/src/main/resources/public/js/actions/workbench/SearchDataSource.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/SearchDataSource.js
@@ -1,93 +1,17 @@
-import SearchParamsStore from "../../stores/workbench/SearchParamsStore";
 import TextUnitClient from "../../sdk/TextUnitClient";
-import TextUnitSearcherParameters from "../../sdk/TextUnitSearcherParameters";
 import WorkbenchActions from "./WorkbenchActions";
+import { buildTextUnitSearchParameters } from "./TextUnitSearchParameterUtils";
 
 const SearchDataSource = {
     performSearch: {
         remote(searchResultsStoreState, searchParams) {
-            let returnEmpty = false;
-
-            const repositoryIds = searchParams.repoIds;
-
-            const bcp47Tags = searchParams.bcp47Tags;
-
-            const textUnitSearcherParameters = new TextUnitSearcherParameters();
-
-            if (!SearchParamsStore.isReadyForSearching(searchParams)) {
-                returnEmpty = true;
-            }
-
-            if (searchParams.searchText) {
-
-                if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.SOURCE) {
-                    textUnitSearcherParameters.source(searchParams.searchText);
-                } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.TARGET) {
-                    textUnitSearcherParameters.target(searchParams.searchText);
-                } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.ASSET) {
-                    textUnitSearcherParameters.assetPath(searchParams.searchText);
-                } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.PLURAL_FORM_OTHER) {
-                    textUnitSearcherParameters.pluralFormOther(searchParams.searchText);
-                } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.TM_TEXT_UNIT_ID) {
-                    textUnitSearcherParameters.tmTextUnitIds([parseInt(searchParams.searchText) || 0]);
-                } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.LOCATION_USAGE) {
-                    textUnitSearcherParameters.locationUsage(searchParams.searchText);
-                } else {
-                    textUnitSearcherParameters.name(searchParams.searchText);
-                }
-
-                textUnitSearcherParameters.searchType(searchParams.searchType.toUpperCase());
-            }
-
-            if (searchParams.status) {
-                textUnitSearcherParameters.statusFilter(searchParams.status);
-            }
-
-            if (!searchParams.used && !searchParams.unUsed) {
-                returnEmpty = true;
-            } else if (searchParams.used && !searchParams.unUsed) {
-                textUnitSearcherParameters.usedFilter(textUnitSearcherParameters.USED);
-            } else if (!searchParams.used && searchParams.unUsed) {
-                textUnitSearcherParameters.usedFilter(textUnitSearcherParameters.UNUSED);
-            }
-
-            if (!searchParams.translate && !searchParams.doNotTranslate) {
-                returnEmpty = true;
-            } else if (searchParams.translate && !searchParams.doNotTranslate) {
-                textUnitSearcherParameters.doNotTranslateFilter(false);
-            } else if (!searchParams.translate && searchParams.doNotTranslate) {
-                textUnitSearcherParameters.doNotTranslateFilter(true);
-            }
-
-            if (searchParams.tmTextUnitCreatedBefore) {
-                textUnitSearcherParameters.tmTextUnitCreatedBefore(searchParams.tmTextUnitCreatedBefore);
-            }
-
-            if (searchParams.tmTextUnitCreatedAfter) {
-                textUnitSearcherParameters.tmTextUnitCreatedAfter(searchParams.tmTextUnitCreatedAfter);
-            }
-
-            // eslint-disable-next-line eqeqeq
-            if (searchParams.tmTextUnitIds != null && searchParams.tmTextUnitIds.length > 0) {
-                textUnitSearcherParameters.tmTextUnitIds(searchParams.tmTextUnitIds);
-            }
-
-            // eslint-disable-next-line eqeqeq
-            if (searchParams.branchId != null) {
-                textUnitSearcherParameters.branchId(searchParams.branchId);
-            }
-
-            // ask for one extra text unit to know if there are more text units
-            const limit = searchParams.pageSize + 1;
-
-            textUnitSearcherParameters.repositoryIds(repositoryIds).localeTags(bcp47Tags).offset(searchParams.pageOffset).limit(limit);
+            const { returnEmpty, textUnitSearcherParameters, limit } = buildTextUnitSearchParameters(searchParams);
 
             if (returnEmpty) {
                 return Promise.resolve({ textUnits: [], hasMore: false });
             }
 
-            return Promise.all([TextUnitClient.getTextUnits(textUnitSearcherParameters), TextUnitClient.getTextUnitCount(textUnitSearcherParameters)]).then(([textUnits, countResponse]) => {
-
+            return TextUnitClient.getTextUnits(textUnitSearcherParameters).then((textUnits) => {
                 let hasMore = false;
 
                 if (textUnits.length === limit) {
@@ -95,7 +19,7 @@ const SearchDataSource = {
                     textUnits = textUnits.slice(0, limit - 1);
                 }
 
-                return { textUnits, hasMore, totalCount: countResponse.textUnitCount };
+                return { textUnits, hasMore };
             });
 
         },

--- a/webapp/src/main/resources/public/js/actions/workbench/TextUnitSearchParameterUtils.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/TextUnitSearchParameterUtils.js
@@ -1,0 +1,81 @@
+import SearchParamsStore from "../../stores/workbench/SearchParamsStore";
+import TextUnitSearcherParameters from "../../sdk/TextUnitSearcherParameters";
+
+export function buildTextUnitSearchParameters(oldSearchParams) {
+    const searchParams = { ...oldSearchParams };
+    let returnEmpty = false;
+
+    const repositoryIds = searchParams.repoIds;
+
+    const bcp47Tags = searchParams.bcp47Tags;
+
+    const textUnitSearcherParameters = new TextUnitSearcherParameters();
+
+    if (!SearchParamsStore.isReadyForSearching(searchParams)) {
+        returnEmpty = true;
+    }
+
+    if (searchParams.searchText) {
+        if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.SOURCE) {
+            textUnitSearcherParameters.source(searchParams.searchText);
+        } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.TARGET) {
+            textUnitSearcherParameters.target(searchParams.searchText);
+        } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.ASSET) {
+            textUnitSearcherParameters.assetPath(searchParams.searchText);
+        } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.PLURAL_FORM_OTHER) {
+            textUnitSearcherParameters.pluralFormOther(searchParams.searchText);
+        } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.TM_TEXT_UNIT_ID) {
+            textUnitSearcherParameters.tmTextUnitIds([parseInt(searchParams.searchText) || 0]);
+        } else if (searchParams.searchAttribute === SearchParamsStore.SEARCH_ATTRIBUTES.LOCATION_USAGE) {
+            textUnitSearcherParameters.locationUsage(searchParams.searchText);
+        } else {
+            textUnitSearcherParameters.name(searchParams.searchText);
+        }
+
+        textUnitSearcherParameters.searchType(searchParams.searchType.toUpperCase());
+    }
+
+    if (searchParams.status) {
+        textUnitSearcherParameters.statusFilter(searchParams.status);
+    }
+
+    if (!searchParams.used && !searchParams.unUsed) {
+        returnEmpty = true;
+    } else if (searchParams.used && !searchParams.unUsed) {
+        textUnitSearcherParameters.usedFilter(textUnitSearcherParameters.USED);
+    } else if (!searchParams.used && searchParams.unUsed) {
+        textUnitSearcherParameters.usedFilter(textUnitSearcherParameters.UNUSED);
+    }
+
+    if (!searchParams.translate && !searchParams.doNotTranslate) {
+        returnEmpty = true;
+    } else if (searchParams.translate && !searchParams.doNotTranslate) {
+        textUnitSearcherParameters.doNotTranslateFilter(false);
+    } else if (!searchParams.translate && searchParams.doNotTranslate) {
+        textUnitSearcherParameters.doNotTranslateFilter(true);
+    }
+
+    if (searchParams.tmTextUnitCreatedBefore) {
+        textUnitSearcherParameters.tmTextUnitCreatedBefore(searchParams.tmTextUnitCreatedBefore);
+    }
+
+    if (searchParams.tmTextUnitCreatedAfter) {
+        textUnitSearcherParameters.tmTextUnitCreatedAfter(searchParams.tmTextUnitCreatedAfter);
+    }
+
+    // eslint-disable-next-line eqeqeq
+    if (searchParams.tmTextUnitIds != null && searchParams.tmTextUnitIds.length > 0) {
+        textUnitSearcherParameters.tmTextUnitIds(searchParams.tmTextUnitIds);
+    }
+
+    // eslint-disable-next-line eqeqeq
+    if (searchParams.branchId != null) {
+        textUnitSearcherParameters.branchId(searchParams.branchId);
+    }
+
+    // ask for one extra text unit to know if there are more text units
+    const limit = searchParams.pageSize + 1;
+
+    textUnitSearcherParameters.repositoryIds(repositoryIds).localeTags(bcp47Tags).offset(searchParams.pageOffset).limit(limit);
+    return { returnEmpty, textUnitSearcherParameters, limit };
+}

--- a/webapp/src/main/resources/public/js/actions/workbench/WorkbenchActions.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/WorkbenchActions.js
@@ -7,6 +7,8 @@ class WorkbenchActions {
             "searchParamsChanged",
             "searchResultsReceivedSuccess",
             "searchResultsReceivedError",
+            "searchCountReceivedSuccess",
+            "searchCountReceivedError",
             "saveTextUnit",
             "saveTextUnitSuccess",
             "saveTextUnitError",

--- a/webapp/src/main/resources/public/js/components/common/DelayedSpinner.jsx
+++ b/webapp/src/main/resources/public/js/components/common/DelayedSpinner.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import Spinner from "./Spinner";
 
-const DelayedSpinner = () => {
+const DelayedSpinner = ({ className }) => {
     const [showSpinner, setShowSpinner] = useState(false);
 
     useEffect(() => {
@@ -11,7 +11,7 @@ const DelayedSpinner = () => {
         return () => clearTimeout(timer);
     });
 
-    return showSpinner && <Spinner />;
+    return showSpinner && <Spinner className={className}/>;
 };
 
 export default DelayedSpinner;

--- a/webapp/src/main/resources/public/js/components/common/Spinner.jsx
+++ b/webapp/src/main/resources/public/js/components/common/Spinner.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Spinner = () => {
-  return <span className="glyphicon glyphicon-refresh spinning"/>
+const Spinner = ({ className }) => {
+  return <span className={`glyphicon glyphicon-refresh spinning ${className}`}/>
 };
 
 export default Spinner;

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
@@ -97,6 +97,9 @@ let SearchResults = createReactClass({
 
             /** @type {Number} The number of textunits according to the filter */
             filteredItemCount: SearchResultsStore.getState().filteredItemCount,
+
+            /** @type {Boolean} if the count request is still pending */
+            isCountRequestPending: SearchResultsStore.getState().isCountRequestPending,
         };
     },
 
@@ -370,6 +373,7 @@ let SearchResults = createReactClass({
             errorObject: resultsStoreState.errorObject,
             textUnitInEditMode: this.state.textUnitInEditMode,
             filteredItemCount: resultsStoreState.filteredItemCount,
+            isCountRequestPending: resultsStoreState.isCountRequestPending
         });
     },
 
@@ -563,6 +567,18 @@ let SearchResults = createReactClass({
         );
     },
 
+    getTextUnitCount(filteredItemCount, isCountRequestPending) {
+        if (!filteredItemCount) {
+            return null
+        }
+
+        if (isCountRequestPending) {
+            return <div>Total text units: &nbsp; <DelayedSpinner /></div>;
+        }
+
+        return <div>Total text units: { filteredItemCount }</div>;
+    },
+
     /**
      * @returns {JSX} Depending on the state of the component, this function returns the JSX for the
      * workbench toolbar.
@@ -573,6 +589,7 @@ let SearchResults = createReactClass({
         const isSearching = this.state.isSearching;
         const noMoreResults = this.state.noMoreResults;
         const filteredItemCount = this.state.filteredItemCount;
+        const isCountRequestPending = this.state.isCountRequestPending;
         const isFirstPage = this.state.currentPageNumber <= 1;
         const selectedTextUnits = this.getSelectedTextUnits();
         const numberOfSelectedTextUnits = selectedTextUnits.length;
@@ -661,7 +678,7 @@ let SearchResults = createReactClass({
                                 gap: "15px",
                             }}
                         >
-                            {filteredItemCount && <div>Total text units: { filteredItemCount }</div>}
+                            {this.getTextUnitCount(filteredItemCount, isCountRequestPending)}
                             <AltContainer store={ViewModeStore}>
                                 <ViewModeDropdown
                                     onModeSelected={(mode) =>

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.jsx
@@ -573,7 +573,7 @@ let SearchResults = createReactClass({
         }
 
         if (isCountRequestPending) {
-            return <div>Total text units: &nbsp; <DelayedSpinner /></div>;
+            return <div>Total text units: <DelayedSpinner className='mlxs' /></div>;
         }
 
         return <div>Total text units: { filteredItemCount }</div>;


### PR DESCRIPTION
## Problem:
The count requests takes longer than expected and given the previous implementation, blocks the user from using the page

## Solution
By isolating the request for the count, we can show a spinner while the results are being curated.
This does not block the user but does still show the counts eventually