### PR TITLE
Set request timeout on OpenAI client bean

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/ai/openai/OpenAIConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/ai/openai/OpenAIConfig.java
@@ -63,6 +63,11 @@ public class OpenAIConfig {
           "jdk.httpclient.allowRestrictedHeaders",
           allowRestrictedHeaders.stream().reduce((a, b) -> a + "," + b).get());
     }
-    return OpenAIClient.builder().apiKey(apiKey).host(host).customHeaders(customHeaders).build();
+    return OpenAIClient.builder()
+        .apiKey(apiKey)
+        .host(host)
+        .customHeaders(customHeaders)
+        .timeout(requestTimeout)
+        .build();
   }
 }


### PR DESCRIPTION
As per title, set the request timeout value on the OpenAI bean from the config.