### PR TITLE
I18N-1502: Use Default RestTemplate for Execution Check

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
@@ -273,7 +273,7 @@ public class ExtractionCheckCommand extends Command {
       description = "Full git commit sha, used for setting a status on a commit in Github.")
   String commitSha;
 
-  final RestTemplate restTemplate;
+  RestTemplate restTemplate;
 
   List<ExtractionCheckNotificationSender> extractionCheckNotificationSenders = new ArrayList<>();
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
@@ -273,9 +273,13 @@ public class ExtractionCheckCommand extends Command {
       description = "Full git commit sha, used for setting a status on a commit in Github.")
   String commitSha;
 
-  @Autowired RestTemplate restTemplate;
+  final RestTemplate restTemplate;
 
   List<ExtractionCheckNotificationSender> extractionCheckNotificationSenders = new ArrayList<>();
+
+  public ExtractionCheckCommand() {
+    this.restTemplate = new RestTemplate();
+  }
 
   @Override
   protected void execute() throws CommandException {


### PR DESCRIPTION
Use the standard RestTemplate to send the stats report requests