### PR TITLE
Downgrade log level of HEADER auth failure

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/HeaderPreAuthFilter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/HeaderPreAuthFilter.java
@@ -33,7 +33,7 @@ public class HeaderPreAuthFilter extends AbstractPreAuthenticatedProcessingFilte
       }
     }
 
-    logger.error(
+    logger.info(
         "No auth principal could be found using headers '{}' and '{}'",
         headerSecurityConfig.userIdentifyingHeader,
         headerSecurityConfig.serviceIdentifyingHeader);


### PR DESCRIPTION
Ever since moving this filter to running first, it introduces a lot of noise and it is not an error since the other fallback auth mechanisms could still work