### PR TITLE
Update Request Logging - Remove Header logging

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggerHelper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/RequestLoggerHelper.java
@@ -43,10 +43,6 @@ public class RequestLoggerHelper {
       msg.append("Query=").append(request.getQueryString()).append(" ");
     }
 
-    if (config.includesHeader()) {
-      msg.append("Headers=").append(request.getHeaderNames()).append(" ");
-    }
-
     if (config.includesPayload()) {
       String payload = getPayload(request, config);
       msg.append("Payload=").append(payload).append(" ");


### PR DESCRIPTION
The Header= logging used toString() on NamesEnumerator which merely yields a string like `NamesEnumerator@5cfa80be`, which is not helpful. The headers are logged in the payload by iterating the object