### PR TITLE
Use the tmTextUnitVariant rather than current variant when setting variant comment

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -246,7 +246,7 @@ public class AITranslateCronJob implements Job {
               aiTranslation.isIncludedInLocalizedFile(),
               aiTranslation.getCreatedDate());
       tmTextUnitVariantCommentService.addComment(
-          result.getTmTextUnitCurrentVariant().getId(),
+          result.getTmTextUnitCurrentVariant().getTmTextUnitVariant().getId(),
           TMTextUnitVariantComment.Type.AI_TRANSLATION,
           TMTextUnitVariantComment.Severity.INFO,
           "Translated via AI translation job.");

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
@@ -200,6 +200,10 @@ public class AITranslateCronJobTest {
     TMTextUnitCurrentVariant tmTextUnitCurrentVariant = new TMTextUnitCurrentVariant();
     tmTextUnitCurrentVariant.setLocale(english);
     tmTextUnitCurrentVariant.setId(1L);
+    TMTextUnitVariant tmTextUnitVariant = new TMTextUnitVariant();
+    tmTextUnitVariant.setLocale(english);
+    tmTextUnitVariant.setId(1L);
+    tmTextUnitCurrentVariant.setTmTextUnitVariant(tmTextUnitVariant);
     when(repository.getId()).thenReturn(1L);
     when(repository.getName()).thenReturn("testRepo");
     when(repository.getRepositoryLocales())


### PR DESCRIPTION
Fixes bug where comment is added to invalid variant on translation creation.