### PR TITLE
Increase username limit to allow service account creation

### DIFF
--- a/webapp/src/main/resources/public/js/utils/UserStatics.js
+++ b/webapp/src/main/resources/public/js/utils/UserStatics.js
@@ -10,9 +10,9 @@ class UserStatics {
         return "HIDDEN";
     }
 
-    // max length for Forms, values greater than 40 will block the request to the ws
+    // max length for Forms, values greater than 128 will block the request to the ws
     static modalFormMaxLength() {
-        return 40;
+        return 128;
     }
 
     // authorities returned from the WS


### PR DESCRIPTION
The usernames for service accounts can get quite long. There is a limit strictly imposed on the UI. By updating this limit, it allows quicker creation of service accounts