### PR TITLE
Fix flaky `testEnableDisableJob` test

### DIFF
--- a/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
@@ -157,14 +157,18 @@ public class ScheduledJobManagerTest extends ServiceTestBase {
     scheduledJobRepository.save(scheduledJob);
 
     Thread.sleep(JOB_WAIT_TIME_MS);
-    // Set the end date as null again, the job could have been running when we set it to disabled
+    // Set the end date as null again, the job could've been running when we set it to disabled
     // above
     scheduledJob = getTestJob();
     scheduledJob.setEndDate(null);
     scheduledJobRepository.save(scheduledJob);
+
+    // Safe to now get the start time, it wasn't safe to retrieve it right after setting the job to
+    // disabled as there was a window for it to start before the enabled status was fully updated.
     ZonedDateTime start = getTestJob().getStartDate();
-    // Give enough time for the job to run, make sure end date is not set and the start date doesn't
-    // change
+
+    // Wait for the job to run, make sure the end date is still null and the start date hasn't
+    // changed
     Thread.sleep(JOB_WAIT_TIME_MS);
     assertNull(scheduledJob.getEndDate());
     assertEquals(start, getTestJob().getStartDate());

--- a/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
@@ -151,24 +151,25 @@ public class ScheduledJobManagerTest extends ServiceTestBase {
 
   @Test
   public void testEnableDisableJob() throws Exception {
+    // Disable the job
     ScheduledJob scheduledJob = getTestJob();
     scheduledJob.setEnabled(false);
-    scheduledJob.setEndDate(null);
     scheduledJobRepository.save(scheduledJob);
 
+    // Wait as the job could have been executing when we disabled it
     Thread.sleep(JOB_WAIT_TIME_MS);
-    // Set the end date as null again, the job could've been running when we set it to disabled
-    // above
+
+    // The job should not be executing, set the end date to null to observe it doesn't change after
+    // letting it run again
     scheduledJob = getTestJob();
     scheduledJob.setEndDate(null);
     scheduledJobRepository.save(scheduledJob);
 
-    // Safe to now get the start time, it wasn't safe to retrieve it right after setting the job to
-    // disabled as there was a window for it to start before the enabled status was fully updated.
+    // Get the current start time of the job
     ZonedDateTime start = getTestJob().getStartDate();
 
-    // Wait for the job to run, make sure the end date is still null and the start date hasn't
-    // changed
+    // Pause again to see if the job does anything new
+    // Check that the job hasn't changed the end date and that the start time is the same
     Thread.sleep(JOB_WAIT_TIME_MS);
     assertNull(scheduledJob.getEndDate());
     assertEquals(start, getTestJob().getStartDate());

--- a/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
@@ -159,22 +159,24 @@ public class ScheduledJobManagerTest extends ServiceTestBase {
     // Wait as the job could have been executing when we disabled it
     Thread.sleep(JOB_WAIT_TIME_MS);
 
-    // The job should not be executing, set the end date to null to observe it doesn't change after
-    // letting it run again
+    // The job should not be executing now - set the end date to null which will be checked later on
+    // to ensure it doesn't change as the job is disabled
     scheduledJob = getTestJob();
     scheduledJob.setEndDate(null);
     scheduledJobRepository.save(scheduledJob);
 
-    // Get the current start time of the job
+    // Get the current start time of the job to check it doesn't change later on
     ZonedDateTime start = getTestJob().getStartDate();
 
     // Pause again to see if the job does anything new
-    // Check that the job hasn't changed the end date and that the start time is the same
     Thread.sleep(JOB_WAIT_TIME_MS);
+
+    // Check that the job hasn't changed the end date and that the start time is the same (fully
+    // disabled)
     assertNull(scheduledJob.getEndDate());
     assertEquals(start, getTestJob().getStartDate());
 
-    // Enable the job and ensure the end date is present
+    // Enable the job and ensure the end date gets changed
     scheduledJob.setEnabled(true);
     scheduledJobRepository.save(scheduledJob);
     Thread.sleep(JOB_WAIT_TIME_MS);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
@@ -159,8 +159,8 @@ public class ScheduledJobManagerTest extends ServiceTestBase {
     // Wait as the job could have been executing when we disabled it
     Thread.sleep(JOB_WAIT_TIME_MS);
 
-    // The job should not be executing now - set the end date to null which will be checked later on
-    // to ensure it doesn't change as the job is disabled
+    // The job should not be executing now - set the end date to null to test there is no future job
+    // runs
     scheduledJob = getTestJob();
     scheduledJob.setEndDate(null);
     scheduledJobRepository.save(scheduledJob);
@@ -168,11 +168,11 @@ public class ScheduledJobManagerTest extends ServiceTestBase {
     // Get the current start time of the job to check it doesn't change later on
     ZonedDateTime start = getTestJob().getStartDate();
 
-    // Pause again to see if the job does anything new
+    // Wait again to see if a job runs
     Thread.sleep(JOB_WAIT_TIME_MS);
 
-    // Check that the job hasn't changed the end date and that the start time is the same (fully
-    // disabled)
+    // Check that the job hasn't changed the end date and that the start time is the same
+    // As the job is disabled, these fields should not have changed
     assertNull(scheduledJob.getEndDate());
     assertEquals(start, getTestJob().getStartDate());
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.service.scheduledjob;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -154,9 +155,18 @@ public class ScheduledJobManagerTest extends ServiceTestBase {
     scheduledJob.setEnabled(false);
     scheduledJob.setEndDate(null);
     scheduledJobRepository.save(scheduledJob);
-    ZonedDateTime start = getTestJob().getStartDate();
-    // Let the job run
+
     Thread.sleep(JOB_WAIT_TIME_MS);
+    // Set the end date as null again, the job could have been running when we set it to disabled
+    // above
+    scheduledJob = getTestJob();
+    scheduledJob.setEndDate(null);
+    scheduledJobRepository.save(scheduledJob);
+    ZonedDateTime start = getTestJob().getStartDate();
+    // Give enough time for the job to run, make sure end date is not set and the start date doesn't
+    // change
+    Thread.sleep(JOB_WAIT_TIME_MS);
+    assertNull(scheduledJob.getEndDate());
     assertEquals(start, getTestJob().getStartDate());
 
     // Enable the job and ensure the end date is present


### PR DESCRIPTION
Fix flaky test that occasionally caused the following failure:

`Run 1: ScheduledJobManagerTest.testEnableDisableJob:160 expected:<2025-04-08T14:01:06.204937Z> but was:<2025-04-08T14:01:10.004698Z>`

`Run 2: ScheduledJobManagerTest.testEnableDisableJob:160 expected:<2025-04-08T14:03:42.003188Z> but was:<2025-04-08T14:03:46.003127Z>`