### PR TITLE
Update SmartlingTBXReader to extract Smartling glossary term configuration information

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossary.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossary.java
@@ -467,10 +467,7 @@ public class ThirdPartyTMSSmartlingGlossary {
     if (glossarySourceTerm.getVariations() != null
         && !glossarySourceTerm.getVariations().isEmpty()) {
       commentBuilder.append(" --- Variations: ");
-      for (String variation : glossarySourceTerm.getVariations()) {
-        commentBuilder.append(variation).append(", ");
-      }
-      commentBuilder.delete(commentBuilder.length() - 2, commentBuilder.length());
+      commentBuilder.append(String.join(", ", glossarySourceTerm.getVariations()));
     }
 
     commentBuilder.append(" --- Case Sensitive: ").append(glossarySourceTerm.isCaseSensitive());

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingTBXReader.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingTBXReader.java
@@ -185,6 +185,8 @@ public class SmartlingTBXReader {
           name = reader.getLocalName();
           if ("term".equals(name)) {
             processTerm();
+          } else if ("termNote".equals(name)) {
+            processTermNote();
           }
           break;
         case XMLStreamConstants.END_ELEMENT:
@@ -259,5 +261,14 @@ public class SmartlingTBXReader {
           break;
       }
     }
+  }
+
+  private void processTermNote() throws XMLStreamException {
+    String propertyName = reader.getAttributeValue(null, "type");
+    if (Util.isEmpty(propertyName)) {
+      throw new OkapiIOException("Missing or empty type attribute.");
+    }
+    Property termNote = new Property(propertyName, reader.getElementText(), true);
+    cent.setProperty(termNote);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossarySourceTerm.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossarySourceTerm.java
@@ -1,6 +1,8 @@
 package com.box.l10n.mojito.smartling.response;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 public class GlossarySourceTerm {
 
@@ -18,7 +20,8 @@ public class GlossarySourceTerm {
   String synonyms;
   String termText;
   String termUid;
-  String variations;
+  boolean archived;
+  List<String> variations = new ArrayList<>();
 
   public String getAntonyms() {
     return antonyms;
@@ -132,11 +135,19 @@ public class GlossarySourceTerm {
     this.termUid = termUid;
   }
 
-  public String getVariations() {
+  public List<String> getVariations() {
     return variations;
   }
 
-  public void setVariations(String variations) {
+  public void setVariations(List<String> variations) {
     this.variations = variations;
+  }
+
+  public boolean isArchived() {
+    return archived;
+  }
+
+  public void setArchived(boolean archived) {
+    this.archived = archived;
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossaryTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossaryTest.java
@@ -56,6 +56,8 @@ public class ThirdPartyTMSSmartlingGlossaryTest {
   private static final String SCHOOL_TEXT_UNIT_ID = "bd3a096a-ab4f-49ac-b033-099086cfe271";
   public static final String HOUSE_TEXT_UNIT_ID = "8300f245-5072-4918-a59b-4d1cdf5c8cf2";
   public static final String FIELD_TEXT_UNIT_ID = "b35b5435-16ca-4fa3-95cd-8527420c9240";
+  private static final String FOOTBALL_TEXT_UNIT_ID = "b35b5435-16ca-4123-95cd-8527420c9278";
+
   @Rule public TestIdWatcher testIdWatcher = new TestIdWatcher();
 
   @Mock VirtualAssetService mockVirtualAssetService;
@@ -199,21 +201,30 @@ public class ThirdPartyTMSSmartlingGlossaryTest {
         virtualAssetTextUnits.stream()
                 .filter(
                     virtualAssetTextUnit ->
-                        virtualAssetTextUnit.getComment().equals("school comment"))
+                        virtualAssetTextUnit
+                            .getComment()
+                            .equals(
+                                "school comment --- Case Sensitive: false --- Exact Match: true --- Do Not Translate: false"))
                 .count()
             == 1);
     assertTrue(
         virtualAssetTextUnits.stream()
                 .filter(
                     virtualAssetTextUnit ->
-                        virtualAssetTextUnit.getComment().equals("house comment"))
+                        virtualAssetTextUnit
+                            .getComment()
+                            .equals(
+                                "house comment --- Variations: home, abode --- Case Sensitive: true --- Exact Match: false --- Do Not Translate: false"))
                 .count()
             == 1);
     assertTrue(
         virtualAssetTextUnits.stream()
                 .filter(
                     virtualAssetTextUnit ->
-                        virtualAssetTextUnit.getComment().equals("field comment --- POS: noun"))
+                        virtualAssetTextUnit
+                            .getComment()
+                            .equals(
+                                "field comment --- POS: noun --- Case Sensitive: false --- Exact Match: false --- Do Not Translate: true"))
                 .count()
             == 1);
   }
@@ -304,6 +315,12 @@ public class ThirdPartyTMSSmartlingGlossaryTest {
                             && textUnit.getName().equals(FIELD_TEXT_UNIT_ID))
                 .count()
             == 1);
+    assertTrue(
+        thirdPartyTextUnits.stream()
+            .noneMatch(
+                textUnit ->
+                    textUnit.getId().equals(FOOTBALL_TEXT_UNIT_ID)
+                        && textUnit.getName().equals(FOOTBALL_TEXT_UNIT_ID)));
     assertEquals(
         3,
         thirdPartyTextUnits.stream()

--- a/webapp/src/test/resources/com/box/l10n/mojito/service/thirdparty/Test_Glossary.tbx
+++ b/webapp/src/test/resources/com/box/l10n/mojito/service/thirdparty/Test_Glossary.tbx
@@ -18,6 +18,9 @@
 				<langSet xml:lang="en-US">
 					<tig>
 						<term>house</term>
+						<term>home</term>
+						<term>abode</term>
+						<termNote type="caseSensitive">true</termNote>
 					</tig>
 				</langSet>
 				<langSet xml:lang="fr-FR">
@@ -31,6 +34,7 @@
 				<langSet xml:lang="en-US">
 					<tig>
 						<term>school</term>
+						<termNote type="exactMatch">true</termNote>
 					</tig>
 				</langSet>
 				<langSet xml:lang="fr-FR">
@@ -46,6 +50,7 @@
 					<tig>
 						<term>field</term>
 						<termNote type="partOfSpeech">noun</termNote>
+						<termNote type="doNotTranslate">true</termNote>
 					</tig>
 				</langSet>
 				<langSet xml:lang="fr-FR">
@@ -55,6 +60,20 @@
 					</tig>
 				</langSet>
 			</termEntry>
+            <termEntry id="b35b5435-16ca-4123-95cd-8527420c9278">
+                <descrip type="definition">football comment</descrip>
+                <langSet xml:lang="en-US">
+                    <tig>
+                        <term>football</term>
+                        <termNote type="archived">true</termNote>
+                    </tig>
+                </langSet>
+                <langSet xml:lang="fr-FR">
+                    <tig>
+                        <term>le foot</term>
+                    </tig>
+                </langSet>
+            </termEntry>
 		</body>
 	</text>
 </martif>


### PR DESCRIPTION
This PR updates the SmartlingTBXReader to extract Smartling specific glossary term matching configuration which are stored in the `.tbx` as `termNote` fields, then encodes the settings into the TU comment so that it is readable by end users.