### PR TITLE
[Safe-I18N] [I18N-1518] Add safe translations ready notification logic

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/BranchMergeTarget.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/BranchMergeTarget.java
@@ -24,7 +24,7 @@ public class BranchMergeTarget extends BaseEntity {
   @Column(name = "targets_main")
   private boolean targetsMain;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "commit_id")
   private Commit commit;
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSender.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSender.java
@@ -10,7 +10,8 @@ public interface BranchNotificationMessageSender {
       String branchName, String username, String messageId, List<String> sourceStrings)
       throws BranchNotificationMessageSenderException;
 
-  void sendTranslatedMessage(String branchName, String username, String messageId)
+  void sendTranslatedMessage(
+      String branchName, String username, String messageId, String safeI18NCommit)
       throws BranchNotificationMessageSenderException;
 
   void sendScreenshotMissingMessage(String branchName, String messageId, String username)

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenders.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenders.java
@@ -172,7 +172,8 @@ public class BranchNotificationMessageSenders {
                           messages.getTranslationsReady(),
                           messages.getScreenshotsMissing(),
                           messages.getNoMoreStrings(),
-                          slackConfigurationProperties.isGithubPR());
+                          slackConfigurationProperties.isGithubPR(),
+                          messages.getSafeTranslationsReady());
 
                   BranchNotificationMessageSenderSlack branchNotificationMessageSenderSlack =
                       new BranchNotificationMessageSenderSlack(
@@ -225,7 +226,8 @@ public class BranchNotificationMessageSenders {
                               messages.getUpdatedStrings(),
                               messages.getNoMoreStrings(),
                               messages.getTranslationsReady(),
-                              messages.getScreenshotsMissing());
+                              messages.getScreenshotsMissing(),
+                              messages.getSafeTranslationsReady());
 
                   BranchNotificationMessageSenderPhabricator
                       branchNotificationMessageSenderPhabricator =
@@ -266,7 +268,8 @@ public class BranchNotificationMessageSenders {
                           messages.getUpdatedStrings(),
                           messages.getNoMoreStrings(),
                           messages.getTranslationsReady(),
-                          messages.getScreenshotsMissing());
+                          messages.getScreenshotsMissing(),
+                          messages.getSafeTranslationsReady());
 
                   BranchNotificationMessageSenderGithub branchNotificationMessageSenderGithub =
                       new BranchNotificationMessageSenderGithub(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersConfigurationProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersConfigurationProperties.java
@@ -141,6 +141,9 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
       String noMoreStrings = "The branch was updated and there are no more strings to translate.";
 
+      String safeTranslationsReady =
+          "Translations are ready and checked into the main branch !! :party:";
+
       public String getNewStrings() {
         return newStrings;
       }
@@ -179,6 +182,14 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
       public void setNoMoreStrings(String noMoreStrings) {
         this.noMoreStrings = noMoreStrings;
+      }
+
+      public String getSafeTranslationsReady() {
+        return safeTranslationsReady;
+      }
+
+      public void setSafeTranslationsReady(String safeTranslationsReady) {
+        this.safeTranslationsReady = safeTranslationsReady;
       }
     }
   }
@@ -252,6 +263,9 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
       String noMoreStrings = "The branch was updated and there are no more strings to translate.";
 
+      String safeTranslationsReady =
+          "Translations are ready and checked into the main branch !! :party:";
+
       public String getNewNotificationMsgFormat() {
         return newNotificationMsgFormat;
       }
@@ -306,6 +320,14 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
       public void setNoMoreStrings(String noMoreStrings) {
         this.noMoreStrings = noMoreStrings;
+      }
+
+      public String getSafeTranslationsReady() {
+        return safeTranslationsReady;
+      }
+
+      public void setSafeTranslationsReady(String safeTranslationsReady) {
+        this.safeTranslationsReady = safeTranslationsReady;
       }
     }
   }
@@ -347,6 +369,9 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
       String noMoreStrings = "The branch was updated and there are no more strings to translate.";
 
+      String safeTranslationsReady =
+          "Translations are ready and checked into the main branch !! :party:";
+
       public String getNewNotificationMsgFormat() {
         return newNotificationMsgFormat;
       }
@@ -401,6 +426,14 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
       public void setNoMoreStrings(String noMoreStrings) {
         this.noMoreStrings = noMoreStrings;
+      }
+
+      public String getSafeTranslationsReady() {
+        return safeTranslationsReady;
+      }
+
+      public void setSafeTranslationsReady(String safeTranslationsReady) {
+        this.safeTranslationsReady = safeTranslationsReady;
       }
     }
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
@@ -211,11 +211,12 @@ public class BranchNotificationService {
       return;
     }
 
+    // Safe to use orElseThrow here as negating isNotTargetingMainBranch ensures it exists
     BranchMergeTarget branchMergeTarget = branchMergeTargetOptional.orElseThrow();
 
     if (hasExceededSafeTranslationNotificationTimeout(branchMergeTarget, branchStatistic)) {
-      // Branch has been translated for the configured amount of hours and has not been checked into
-      // the repo, use old flow to unblock
+      // Branch has been translated for the configured amount of time and has not been checked into
+      // the repo, use the old flow to unblock
       meterRegistry
           .counter(
               "BranchNotificationService.handleSendBranchTranslatedMessage.branchExceededSafeTranslationNotificationWindow",
@@ -231,8 +232,8 @@ public class BranchNotificationService {
     }
 
     if (isCheckedInToTargetBranch(branchMergeTarget)) {
-      // Branch is targeting main and is checked in,  safe to tell the user / PR the
-      // translations have arrived
+      // Branch is targeting main and is checked in, safe to notify the user / PR the
+      // translations have arrived safely
       sendTranslatedMessage(
           branchNotificationMessageSender,
           branch,

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
@@ -65,7 +65,7 @@ public class BranchNotificationService {
 
   @Autowired MeterRegistry meterRegistry;
 
-  // If a branch that is tracked for safe i18n has been translated for this amount of hours then it
+  // If a branch that is tracked for safe i18n has been translated for this duration then it
   // will fall back to using the old notification flow & message to unblock the branch.
   @Value("${l10n.branchNotification.notificationFallbackTimeout:8h}")
   protected Duration notificationFallbackTimeout;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationService.java
@@ -217,7 +217,7 @@ public class BranchNotificationService {
     if (branchMergeTarget.getCommit() == null
         && branchStatistic.getTranslatedDate() != null
         && Duration.between(branchStatistic.getTranslatedDate(), ZonedDateTime.now()).toHours()
-            > branchCheckinWindowHours) {
+            >= branchCheckinWindowHours) {
       // Branch has been translated for x hours and has not been checked into the repo, use old flow
       // to unblock
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageBuilderGithub.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageBuilderGithub.java
@@ -30,6 +30,8 @@ public class BranchNotificationMessageBuilderGithub {
 
   String screenshotsMissingMsg;
 
+  String safeTranslationsReadyMsg;
+
   public BranchNotificationMessageBuilderGithub(
       BranchUrlBuilder branchUrlBuilder,
       String newNotificationMsgFormat,
@@ -38,7 +40,8 @@ public class BranchNotificationMessageBuilderGithub {
       String updatedStringMsg,
       String noMoreStringsMsg,
       String translationsReadyMsg,
-      String screenshotsMissingMsg) {
+      String screenshotsMissingMsg,
+      String safeTranslationsReadyMsg) {
     this.branchUrlBuilder = branchUrlBuilder;
     this.newNotificationMsgFormat = newNotificationMsgFormat;
     this.updatedNotificationMsgFormat = updatedNotificationMsgFormat;
@@ -47,6 +50,7 @@ public class BranchNotificationMessageBuilderGithub {
     this.noMoreStringsMsg = noMoreStringsMsg;
     this.translationsReadyMsg = translationsReadyMsg;
     this.screenshotsMissingMsg = screenshotsMissingMsg;
+    this.safeTranslationsReadyMsg = safeTranslationsReadyMsg;
   }
 
   public String getNewMessage(String branchName, List<String> sourceStrings) {
@@ -84,13 +88,17 @@ public class BranchNotificationMessageBuilderGithub {
     return noMoreStringsMsg;
   }
 
-  public String getTranslatedMessage(String branchName, GithubBranchDetails branchDetails) {
-    MessageFormat messageFormat = new MessageFormat(translationsReadyMsg);
+  public String getTranslatedMessage(
+      String branchName, GithubBranchDetails branchDetails, String safeI18NCommit) {
+    MessageFormat messageFormat =
+        new MessageFormat(safeI18NCommit != null ? safeTranslationsReadyMsg : translationsReadyMsg);
     ImmutableMap<String, Object> messageParamMap =
         ImmutableMap.<String, Object>builder()
             .put("branchName", branchName)
             .put("githubRepository", branchDetails.getRepository())
+            .put("commit", safeI18NCommit != null ? safeI18NCommit : "")
             .build();
+
     return messageFormat.format(messageParamMap);
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageSenderGithub.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageSenderGithub.java
@@ -93,7 +93,8 @@ public class BranchNotificationMessageSenderGithub implements BranchNotification
   }
 
   @Override
-  public void sendTranslatedMessage(String branchName, String username, String messageId)
+  public void sendTranslatedMessage(
+      String branchName, String username, String messageId, String safeI18NCommit)
       throws BranchNotificationMessageSenderException {
     logger.debug("sendTranslatedMessage to: {}", githubClient.getEndpoint() + "/" + branchName);
 
@@ -102,7 +103,8 @@ public class BranchNotificationMessageSenderGithub implements BranchNotification
       githubClient.addCommentToPR(
           branchDetails.getRepository(),
           branchDetails.getPrNumber(),
-          branchNotificationMessageBuilderGithub.getTranslatedMessage(branchName, branchDetails));
+          branchNotificationMessageBuilderGithub.getTranslatedMessage(
+              branchName, branchDetails, safeI18NCommit));
       updatePRLabel(
           githubClient,
           branchDetails.getRepository(),

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/noop/BranchNotificationMessageSenderNoop.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/noop/BranchNotificationMessageSenderNoop.java
@@ -34,7 +34,8 @@ public class BranchNotificationMessageSenderNoop implements BranchNotificationMe
   }
 
   @Override
-  public void sendTranslatedMessage(String branchName, String username, String messageId)
+  public void sendTranslatedMessage(
+      String branchName, String username, String messageId, String safeI18NCommit)
       throws BranchNotificationMessageSenderException {
     logger.debug("noop sendTranslatedMessage to: {}", username);
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationMessageBuilderPhabricator.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationMessageBuilderPhabricator.java
@@ -30,6 +30,8 @@ public class BranchNotificationMessageBuilderPhabricator {
 
   String screenshotsMissingMsg;
 
+  String safeTranslationsReadyMsg;
+
   public BranchNotificationMessageBuilderPhabricator(
       BranchUrlBuilder branchUrlBuilder,
       String newNotificationMsgFormat,
@@ -38,7 +40,8 @@ public class BranchNotificationMessageBuilderPhabricator {
       String updatedStringMsg,
       String noMoreStringsMsg,
       String translationsReadyMsg,
-      String screenshotsMissingMsg) {
+      String screenshotsMissingMsg,
+      String safeTranslationsReadyMsg) {
     this.branchUrlBuilder = branchUrlBuilder;
     this.newNotificationMsgFormat = newNotificationMsgFormat;
     this.updatedNotificationMsgFormat = updatedNotificationMsgFormat;
@@ -47,6 +50,7 @@ public class BranchNotificationMessageBuilderPhabricator {
     this.noMoreStringsMsg = noMoreStringsMsg;
     this.translationsReadyMsg = translationsReadyMsg;
     this.screenshotsMissingMsg = screenshotsMissingMsg;
+    this.safeTranslationsReadyMsg = safeTranslationsReadyMsg;
   }
 
   public String getNewMessage(String branchName, List<String> sourceStrings) {
@@ -86,6 +90,10 @@ public class BranchNotificationMessageBuilderPhabricator {
 
   public String getTranslatedMessage() {
     return translationsReadyMsg;
+  }
+
+  public String getSafeTranslationsReadyMsg() {
+    return safeTranslationsReadyMsg;
   }
 
   public String getScreenshotMissingMessage() {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationMessageSenderPhabricator.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationMessageSenderPhabricator.java
@@ -74,13 +74,18 @@ public class BranchNotificationMessageSenderPhabricator implements BranchNotific
   }
 
   @Override
-  public void sendTranslatedMessage(String branchName, String username, String messageId)
+  public void sendTranslatedMessage(
+      String branchName, String username, String messageId, String safeI18NCommit)
       throws BranchNotificationMessageSenderException {
     logger.debug("sendTranslatedMessage to: {}", username);
 
     try {
-      differentialRevision.addComment(
-          branchName, branchNotificationMessageBuilderPhabricator.getTranslatedMessage());
+      String message =
+          safeI18NCommit != null
+              ? branchNotificationMessageBuilderPhabricator.getSafeTranslationsReadyMsg()
+              : branchNotificationMessageBuilderPhabricator.getTranslatedMessage();
+
+      differentialRevision.addComment(branchName, message);
       differentialRevision.removeReviewer(branchName, reviewer, blockingReview);
     } catch (PhabricatorException e) {
       throw new BranchNotificationMessageSenderException(e);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageBuilderSlack.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageBuilderSlack.java
@@ -153,8 +153,7 @@ public class BranchNotificationMessageBuilderSlack {
       messageParamMap.put("githubRepository", branchDetails.getRepository());
       messageParamMap.put("owner", branchDetails.getOwner());
     }
-
-    if (safeI18NCommit != null) messageParamMap.put("commit", safeI18NCommit);
+    messageParamMap.put("commit", safeI18NCommit != null ? safeI18NCommit : "");
 
     MessageFormat messageFormat =
         new MessageFormat(safeI18NCommit != null ? safeTranslationsReadyMsg : translationsReadyMsg);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageBuilderSlack.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageBuilderSlack.java
@@ -34,6 +34,8 @@ public class BranchNotificationMessageBuilderSlack {
 
   String noMoreStringsMsg;
 
+  String safeTranslationsReadyMsg;
+
   boolean isGithubPR;
 
   public BranchNotificationMessageBuilderSlack(
@@ -43,7 +45,8 @@ public class BranchNotificationMessageBuilderSlack {
       String translationsReadyMsg,
       String screenshotsMissingMsg,
       String noMoreStringsMsg,
-      boolean isGithubPR) {
+      boolean isGithubPR,
+      String safeTranslationsReadyMsg) {
     this.branchUrlBuilder = branchUrlBuilder;
     this.newStringMsg = newStringMsg;
     this.updatedStringMsg = updatedStringMsg;
@@ -51,6 +54,7 @@ public class BranchNotificationMessageBuilderSlack {
     this.screenshotsMissingMsg = screenshotsMissingMsg;
     this.noMoreStringsMsg = noMoreStringsMsg;
     this.isGithubPR = isGithubPR;
+    this.safeTranslationsReadyMsg = safeTranslationsReadyMsg;
   }
 
   public Message getNewMessage(String channel, String pr, List<String> sourceStrings) {
@@ -75,11 +79,12 @@ public class BranchNotificationMessageBuilderSlack {
     return message;
   }
 
-  public Message getTranslatedMessage(String channel, String threadTs, String branchName) {
+  public Message getTranslatedMessage(
+      String channel, String threadTs, String branchName, String safeI18NCommit) {
     Message message = new Message();
     message.setChannel(channel);
     message.setThreadTs(threadTs);
-    message.setText(getTranslationsReadyMsg(branchName));
+    message.setText(getTranslationsReadyMsg(branchName, safeI18NCommit));
     return message;
   }
 
@@ -140,14 +145,19 @@ public class BranchNotificationMessageBuilderSlack {
         .collect(Collectors.joining(", "));
   }
 
-  protected String getTranslationsReadyMsg(String branchName) {
+  protected String getTranslationsReadyMsg(String branchName, String safeI18NCommit) {
     final ImmutableMap.Builder<String, Object> messageParamMap = ImmutableMap.builder();
     messageParamMap.put("branchName", branchName);
     if (isGithubPR) {
       GithubBranchDetails branchDetails = new GithubBranchDetails(branchName);
       messageParamMap.put("githubRepository", branchDetails.getRepository());
+      messageParamMap.put("owner", branchDetails.getOwner());
     }
-    MessageFormat messageFormat = new MessageFormat(translationsReadyMsg);
+
+    if (safeI18NCommit != null) messageParamMap.put("commit", safeI18NCommit);
+
+    MessageFormat messageFormat =
+        new MessageFormat(safeI18NCommit != null ? safeTranslationsReadyMsg : translationsReadyMsg);
     return messageFormat.format(messageParamMap.build());
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageSenderSlack.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageSenderSlack.java
@@ -95,7 +95,8 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
   }
 
   @Override
-  public void sendTranslatedMessage(String branchName, String username, String messageId)
+  public void sendTranslatedMessage(
+      String branchName, String username, String messageId, String safeI18NCommit)
       throws BranchNotificationMessageSenderException {
     logger.debug("sendTranslatedMessage to: {}", username);
 
@@ -105,7 +106,8 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
               slackChannels.getSlackChannelForDirectOrBotMessage(
                   useDirectMessage, username, userEmailPattern),
               messageId,
-              branchName);
+              branchName,
+              safeI18NCommit);
 
       ChatPostMessageResponse chatPostMessageResponse = slackClient.sendInstantMessage(message);
     } catch (SlackClientException sce) {

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenderGithubTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenderGithubTest.java
@@ -44,7 +44,7 @@ public class BranchNotificationMessageSenderGithubTest {
     when(branchNotificationMessageBuilderGithubMock.getUpdatedMessage(branchName, sourceStrings))
         .thenReturn(updatedStringMsg);
     when(branchNotificationMessageBuilderGithubMock.getTranslatedMessage(
-            branchName, githubBranchDetails))
+            branchName, githubBranchDetails, null))
         .thenReturn("Test translated message");
     when(branchNotificationMessageBuilderGithubMock.getScreenshotMissingMessage())
         .thenReturn("Test screenshot missing message");
@@ -91,7 +91,7 @@ public class BranchNotificationMessageSenderGithubTest {
   public void testTranslatedMessage() throws BranchNotificationMessageSenderException {
     when(githubClientMock.isLabelAppliedToPR("testRepo", 1, "translations-ready"))
         .thenReturn(false);
-    branchNotificationMessageSenderGithub.sendTranslatedMessage(branchName, "testUser", "1");
+    branchNotificationMessageSenderGithub.sendTranslatedMessage(branchName, "testUser", "1", null);
     verify(githubClientMock, times(1)).addCommentToPR("testRepo", 1, "Test translated message");
     verify(githubClientMock, times(1)).removeLabelFromPR("testRepo", 1, "translations-required");
     verify(githubClientMock, times(1)).addLabelToPR("testRepo", 1, "translations-ready");

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersITest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersITest.java
@@ -37,7 +37,7 @@ public class BranchNotificationMessageSendersITest extends ServiceTestBase {
         branchName, username, messageId, Arrays.asList("test 1 string", "test 2 string"));
 
     github.sendScreenshotMissingMessage(branchName, messageId, username);
-    github.sendTranslatedMessage(branchName, username, messageId);
+    github.sendTranslatedMessage(branchName, username, messageId, null);
   }
 
   @Test
@@ -58,6 +58,6 @@ public class BranchNotificationMessageSendersITest extends ServiceTestBase {
         branchName, username, messageId, Arrays.asList("test 1 string", "test 2 string"));
 
     slack.sendScreenshotMissingMessage(branchName, messageId, username);
-    slack.sendTranslatedMessage(branchName, username, messageId);
+    slack.sendTranslatedMessage(branchName, username, messageId, null);
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationServiceTest.java
@@ -2,25 +2,35 @@ package com.box.l10n.mojito.service.branch.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.box.l10n.mojito.entity.AssetContent;
 import com.box.l10n.mojito.entity.Branch;
+import com.box.l10n.mojito.entity.BranchMergeTarget;
 import com.box.l10n.mojito.entity.BranchNotification;
+import com.box.l10n.mojito.entity.BranchStatistic;
+import com.box.l10n.mojito.entity.Commit;
+import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.rest.textunit.ImportTextUnitsBatch;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
 import com.box.l10n.mojito.service.assetExtraction.AssetTextUnitToTMTextUnitRepository;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import com.box.l10n.mojito.service.assetcontent.AssetContentService;
+import com.box.l10n.mojito.service.branch.BranchMergeTargetRepository;
+import com.box.l10n.mojito.service.branch.BranchStatisticRepository;
 import com.box.l10n.mojito.service.branch.BranchStatisticService;
 import com.box.l10n.mojito.service.branch.BranchTestData;
 import com.box.l10n.mojito.service.branch.notification.noop.BranchNotificationMessageSenderNoop;
+import com.box.l10n.mojito.service.commit.CommitRepository;
 import com.box.l10n.mojito.service.tm.importer.TextUnitBatchImporterService;
 import com.box.l10n.mojito.service.tm.search.StatusFilter;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
+import com.box.l10n.mojito.service.tm.textunitdtocache.UpdateType;
 import com.box.l10n.mojito.test.TestIdWatcher;
+import jakarta.persistence.EntityManager;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -49,6 +59,14 @@ public class BranchNotificationServiceTest extends ServiceTestBase {
   @Autowired AssetTextUnitToTMTextUnitRepository assetTextUnitToTMTextUnitRepository;
 
   @Autowired QuartzPollableTaskScheduler quartzPollableTaskScheduler;
+
+  @Autowired BranchMergeTargetRepository branchMergeTargetRepository;
+
+  @Autowired CommitRepository commitRepository;
+
+  @Autowired BranchStatisticRepository branchStatisticRepository;
+
+  @Autowired EntityManager entityManager;
 
   @Rule public TestIdWatcher testIdWatcher = new TestIdWatcher();
 
@@ -233,5 +251,109 @@ public class BranchNotificationServiceTest extends ServiceTestBase {
 
     // make sure the stats are ready for whatever is done next in notification
     branchStatisticService.computeAndSaveBranchStatistics(branch);
+  }
+
+  @Test
+  public void safeTranslationNotification() throws Exception {
+    BranchTestData branchTestData = new BranchTestData(testIdWatcher);
+
+    String branch2ContentUpdated = "# string1 description\nstring1=content1\n";
+
+    AssetContent assetContentBranch2 =
+        assetContentService.createAssetContent(
+            branchTestData.getAsset(), branch2ContentUpdated, false, branchTestData.getBranch2());
+    assetExtractionService
+        .processAssetAsync(assetContentBranch2.getId(), null, null, null, null)
+        .get();
+
+    // New message must be sent first for any translated message to go out
+    waitForCondition(
+        "Branch2 new notification must be sent",
+        () ->
+            branchNotificationRepository
+                    .findByBranchAndNotifierId(branchTestData.getBranch2(), branchNotifierId)
+                    .getNewMsgSentAt()
+                != null);
+
+    // Branch is tracked for safe i18n if it has a merge target. It shouldn't send the translation
+    // until the commit exists or the translated time is over the default 8 hour mark
+    BranchMergeTarget branchMergeTarget = new BranchMergeTarget();
+    branchMergeTarget.setBranch(branchTestData.getBranch2());
+    branchMergeTarget.setTargetsMain(true);
+    branchMergeTarget = branchMergeTargetRepository.save(branchMergeTarget);
+
+    translateBranch(branchTestData.getBranch2());
+
+    // Wait for branch stats to run
+    Thread.sleep(1000);
+
+    // Make sure no translation message was sent out as the commit doesn't exist
+    assertNull(
+        branchNotificationRepository
+            .findByBranchAndNotifierId(branchTestData.getBranch2(), branchNotifierId)
+            .getTranslatedMsgSentAt());
+
+    // Create a commit, link it up and run the branch stats again
+    Commit commit = new Commit();
+    commit.setName("ffffffffffffffffffffffffffffffffffffffff");
+    commit.setAuthorEmail("mojito@example.com");
+    commit.setAuthorName("Mojito");
+    commit.setRepository(branchTestData.getBranch2().getRepository());
+    commit.setSourceCreationDate(ZonedDateTime.now());
+    commit = commitRepository.save(commit);
+    branchMergeTarget.setCommit(commit);
+    branchMergeTargetRepository.save(branchMergeTarget);
+
+    Repository repository = branchTestData.getBranch2().getRepository();
+    // Re-trigger branch stats to trigger notification job again
+    branchStatisticService.computeAndSaveBranchStatistics(
+        repository.getId(), repository.getName(), UpdateType.NEVER);
+
+    // Translated message should send as the commit exists - it is checked in
+    waitForCondition(
+        "Branch2 translated notification must be sent",
+        () ->
+            branchNotificationRepository
+                    .findByBranchAndNotifierId(branchTestData.getBranch2(), branchNotifierId)
+                    .getTranslatedMsgSentAt()
+                != null);
+
+    // Remove the commit to test the translated date window
+    branchMergeTarget.setCommit(null);
+    branchMergeTargetRepository.save(branchMergeTarget);
+    BranchNotification branchNotification =
+        branchNotificationRepository.findByBranchAndNotifierId(
+            branchTestData.getBranch2(), branchNotifierId);
+    branchNotification.setTranslatedMsgSentAt(null);
+    branchNotificationRepository.save(branchNotification);
+
+    branchStatisticService.computeAndSaveBranchStatistics(
+        repository.getId(), repository.getName(), UpdateType.NEVER);
+
+    Thread.sleep(1000);
+
+    // Make sure the translated message date sent doesn't exist anymore
+    assertNull(
+        branchNotificationRepository
+            .findByBranchAndNotifierId(branchTestData.getBranch2(), branchNotifierId)
+            .getTranslatedMsgSentAt());
+
+    BranchStatistic branchStatistic =
+        branchStatisticRepository.findByBranch(branchTestData.getBranch2());
+    branchStatistic.setTranslatedDate(ZonedDateTime.now().minusHours(10));
+    branchStatisticRepository.save(branchStatistic);
+
+    Thread.sleep(1000);
+    // Branch should use old notification logic as it has been translated for 10 hours
+    branchStatisticService.computeAndSaveBranchStatistics(
+        repository.getId(), repository.getName(), UpdateType.NEVER);
+
+    waitForCondition(
+        "Branch2 translated notification must be sent",
+        () ->
+            branchNotificationRepository
+                    .findByBranchAndNotifierId(branchTestData.getBranch2(), branchNotifierId)
+                    .getTranslatedMsgSentAt()
+                != null);
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationServiceTest.java
@@ -122,7 +122,8 @@ public class BranchNotificationServiceTest extends ServiceTestBase {
           }
 
           @Override
-          public void sendTranslatedMessage(String branchName, String username, String messageId)
+          public void sendTranslatedMessage(
+              String branchName, String username, String messageId, String safeI18NCommit)
               throws BranchNotificationMessageSenderException {
             throw new BranchNotificationMessageSenderException(exceptionMessage);
           }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import org.hibernate.Hibernate;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -250,6 +251,10 @@ public class BranchNotificationServiceTest extends ServiceTestBase {
     BranchTestData branchTestData = new BranchTestData(testIdWatcher);
     String branch2ContentUpdated = "# string1 description\nstring1=content1\n";
 
+    // Force hibernate to fetch the repository for the branch otherwise the test will fail as the
+    // meterRegistry counter will not be able to retrieve the repository name
+    Hibernate.initialize(branchTestData.getBranch2().getRepository());
+
     AssetContent assetContentBranch2 =
         assetContentService.createAssetContent(
             branchTestData.getAsset(), branch2ContentUpdated, false, branchTestData.getBranch2());
@@ -347,7 +352,7 @@ public class BranchNotificationServiceTest extends ServiceTestBase {
     BranchStatistic branchStatistic =
         branchStatisticRepository.findByBranch(branchTestData.getBranch2());
     branchStatistic.setTranslatedDate(
-        ZonedDateTime.now().minusHours(branchNotificationService.branchCheckinWindowHours));
+        ZonedDateTime.now().minus(branchNotificationService.notificationFallbackTimeout));
     branchStatisticRepository.save(branchStatistic);
     branchStatisticRepository.flush();
 


### PR DESCRIPTION
Adds a safe translations ready notification that is sent if a branch was tracked & committed to the main branch.

If the branch is tracked for main, the commit is assigned that landed the translations then the safe translations notification is sent.

If the branch is not tracked to land in main or has not been checked in to main after 8 hours of being translated, the normal translations ready notification is sent to unblock the PR / branch.