### PR TITLE
AI Translate Cron Job - Unused TU Fix

### DIFF
--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -561,5 +562,7 @@ public class AITranslateCronJobTest {
             any(TMTextUnitVariantComment.Type.class),
             any(TMTextUnitVariantComment.Severity.class),
             eq("Translated via AI translation job."));
+    verify(aiTranslationService, times(3)).deleteBatch(isA(Queue.class));
+    verify(aiTranslationService, times(2)).deleteBatch(argThat(q -> !q.isEmpty()));
   }
 }


### PR DESCRIPTION
The unused text units are removed from the stream so they are never processed. This means that they are nevered added to the `textUnitsToClearPendingMT` so they are never removed from the queue. So the table is never cleared and the Job runs indefinitely

The fix peeks into the queue and explicitly adds the unused text units to the `textUnitsToClearPendingMT` queue to ensure they are removed.