### PR TITLE
Fix flaky testBranchSetsTranslatedDate

### DIFF
--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/BranchStatisticServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/BranchStatisticServiceTest.java
@@ -391,6 +391,9 @@ public class BranchStatisticServiceTest extends ServiceTestBase {
                   });
             });
 
+    // Run branch statistics synchronously to avoid the next waitForCondition being flaky.
+    branchStatisticService.computeAndSaveBranchStatistics(branchTestData.getBranch1());
+
     waitForCondition(
         "Branch1 must have the translated date set",
         () ->


### PR DESCRIPTION
Fix for flaky test - `testBranchSetsTranslatedDate`:

`
Error:  com.box.l10n.mojito.service.branch.BranchStatisticServiceTest.testBranchSetsTranslatedDate
Error:    Run 1: BranchStatisticServiceTest.testBranchSetsTranslatedDate:394->WSTestBase.waitForCondition:100->WSTestBase.waitForCondition:124 Branch1 must have the translated date set
Error:    Run 2: BranchStatisticServiceTest.testBranchSetsTranslatedDate:394->WSTestBase.waitForCondition:100->WSTestBase.waitForCondition:124 Branch1 must have the translated date set
`