### PR TITLE
[Safe-I18N] Append once for parallel pulls & use cache for synchronous pulls

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommand.java
@@ -336,7 +336,6 @@ public class PullCommand extends Command {
       LocalizedAssetBody localizedAsset =
           getLocalizedAsset(
               repository, sourceFileMatch, repositoryLocale, outputBcp47tag, filterOptions);
-      localizedAsset.setAppendBranchTextUnitsId(appendBranchTextUnits);
       writeLocalizedAssetToTargetDirectory(localizedAsset, sourceFileMatch);
     } else {
       consoleWriter

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
@@ -218,7 +218,7 @@ public class AssetWS {
     if (localizedAssetBody.getAppendBranchTextUnitsId() != null) {
       normalizedContent =
           assetAppenderService.appendBranchTextUnitsToSource(
-              asset, localizedAssetBody, normalizedContent);
+              asset, localizedAssetBody.getAppendBranchTextUnitsId(), normalizedContent);
     }
 
     String generateLocalized =
@@ -306,6 +306,18 @@ public class AssetWS {
     Repository repository = asset.getRepository();
     if (assetMetricsConfigurationsProperties.getAssetMetrics().containsKey(repository.getName())) {
       recordAppendMetrics(repository);
+    }
+
+    if (multiLocalizedAssetBody.getAppendTextUnitsId() != null) {
+      // Set the source to the appended asset - For each locale under the repository / locale
+      // mapping, a localized asset body is created which will use this source content. Each
+      // localized asset body sends up their source content for localization so there is no need to
+      // put it through the appender service again
+      multiLocalizedAssetBody.setSourceContent(
+          assetAppenderService.appendBranchTextUnitsToSource(
+              asset,
+              multiLocalizedAssetBody.getAppendTextUnitsId(),
+              multiLocalizedAssetBody.getSourceContent()));
     }
 
     QuartzJobInfo<MultiLocalizedAssetBody, MultiLocalizedAssetBody> quartzJobInfo =

--- a/webapp/src/main/java/com/box/l10n/mojito/service/appender/AppendedAssetBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/appender/AppendedAssetBlobStorage.java
@@ -5,6 +5,7 @@ import com.box.l10n.mojito.service.blobstorage.Retention;
 import com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -52,6 +53,11 @@ public class AppendedAssetBlobStorage {
         getSourceArtifactName(jobId),
         content,
         Retention.PERMANENT);
+  }
+
+  public Optional<String> getAppendedSource(String jobId) {
+    return structuredBlobStorage.getString(
+        StructuredBlobStorage.Prefix.APPENDED_ASSET, getSourceArtifactName(jobId));
   }
 
   private String getBranchesName(String jobId) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/GenerateLocalizedAssetJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/GenerateLocalizedAssetJob.java
@@ -64,7 +64,7 @@ public class GenerateLocalizedAssetJob
       if (localizedAssetBody.getAppendBranchTextUnitsId() != null) {
         normalizedContent =
             assetAppenderService.appendBranchTextUnitsToSource(
-                asset, localizedAssetBody, normalizedContent);
+                asset, localizedAssetBody.getAppendBranchTextUnitsId(), normalizedContent);
       }
 
       String generateLocalized;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/GenerateMultiLocalizedAssetJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/GenerateMultiLocalizedAssetJob.java
@@ -89,7 +89,6 @@ public class GenerateMultiLocalizedAssetJob
     localizedAssetBody.setInheritanceMode(multiLocalizedAssetBody.getInheritanceMode());
     localizedAssetBody.setPullRunName(multiLocalizedAssetBody.getPullRunName());
     localizedAssetBody.setStatus(multiLocalizedAssetBody.getStatus());
-    localizedAssetBody.setAppendBranchTextUnitsId(multiLocalizedAssetBody.getAppendTextUnitsId());
     return localizedAssetBody;
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
@@ -107,7 +107,8 @@ public class AssetAppenderServiceTest {
   public void testNoAppendWhenNoAppender() {
     when(assetAppenderFactory.fromExtension(any(), any())).thenReturn(Optional.empty());
 
-    assetAppenderService.appendBranchTextUnitsToSource(asset, localizedAssetBody, content);
+    assetAppenderService.appendBranchTextUnitsToSource(
+        asset, localizedAssetBody.getAppendBranchTextUnitsId(), content);
 
     verify(branchRepositoryMock, times(0)).findBranchesForAppending(any());
   }
@@ -141,7 +142,8 @@ public class AssetAppenderServiceTest {
     when(branchStatisticServiceMock.getTextUnitDTOsForBranch(any())).thenReturn(textUnits);
     when(branchRepositoryMock.findBranchesForAppending(any())).thenReturn(branches);
 
-    assetAppenderService.appendBranchTextUnitsToSource(asset, localizedAssetBody, content);
+    assetAppenderService.appendBranchTextUnitsToSource(
+        asset, localizedAssetBody.getAppendBranchTextUnitsId(), content);
 
     verify(potAssetAppenderMock, times(3)).appendTextUnits(any());
     verify(meterRegistryMock, times(2)).counter(Mockito.anyString(), isA(Iterable.class));
@@ -182,7 +184,8 @@ public class AssetAppenderServiceTest {
     when(branchStatisticServiceMock.getTextUnitDTOsForBranch(any())).thenReturn(textUnits);
     when(branchRepositoryMock.findBranchesForAppending(any())).thenReturn(branches);
 
-    assetAppenderService.appendBranchTextUnitsToSource(asset, localizedAssetBody, content);
+    assetAppenderService.appendBranchTextUnitsToSource(
+        asset, localizedAssetBody.getAppendBranchTextUnitsId(), content);
 
     verify(potAssetAppenderMock, times(5)).appendTextUnits(any());
 


### PR DESCRIPTION
During a pull using the parallel flag it would append to the source asset for every locale under the repository, this change only does it once at the `multiLocalizedAssetBody` level. Doing the pull for every locale meant there were duplicated metrics emitted and multiple writes to the same S3 location.

If the append step was already done for an `appendTextUnitId` then the source will be retrieved from S3 to avoid the issue of running multiple appends. (This happens in a synchronous pull as the first locale localize request will do the append step and subsequent localize requests for the other locales will use that appended source).

Also moved the push run filtering above the conditional check for if we will go over the limit to ensure text units that won't be appended aren't being accounted for.