### PR TITLE
Added Glossary cache builder

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -304,6 +304,12 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing-bridge-brave</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.opennlp</groupId>
+            <artifactId>opennlp-tools</artifactId>
+            <version>2.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/StructuredBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/StructuredBlobStorage.java
@@ -48,6 +48,7 @@ public class StructuredBlobStorage {
     MULTI_BRANCH_STATE,
     TEXT_UNIT_DTOS_CACHE,
     CLOB_STORAGE_WS,
-    APPENDED_ASSET
+    APPENDED_ASSET,
+    GLOSSARY
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossary.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossary.java
@@ -15,6 +15,8 @@ import com.box.l10n.mojito.service.asset.VirtualAssetTextUnit;
 import com.box.l10n.mojito.service.asset.VirutalAssetMissingTextUnitException;
 import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
 import com.box.l10n.mojito.service.thirdparty.smartling.SmartlingTBXReader;
+import com.box.l10n.mojito.service.thirdparty.smartling.glossary.GlossaryCacheConfiguration;
+import com.box.l10n.mojito.service.thirdparty.smartling.glossary.GlossaryCacheService;
 import com.box.l10n.mojito.smartling.SmartlingClient;
 import com.box.l10n.mojito.smartling.SmartlingClientException;
 import com.box.l10n.mojito.smartling.response.GlossarySourceTerm;
@@ -59,6 +61,12 @@ public class ThirdPartyTMSSmartlingGlossary {
 
   @Autowired AssetTextUnitRepository assetTextUnitRepository;
 
+  @Autowired(required = false)
+  GlossaryCacheService glossaryCacheService;
+
+  @Autowired(required = false)
+  GlossaryCacheConfiguration glossaryCacheConfiguration;
+
   @Value("${l10n.smartling.accountId:}")
   String accountId;
 
@@ -87,6 +95,14 @@ public class ThirdPartyTMSSmartlingGlossary {
                   getTranslatedTextUnits(glossaryUID, smartlingLocale, sourceLocale);
               importLocalizedTextUnits(virtualAsset, repositoryLocale, translatedTextUnits);
             });
+    if (glossaryCacheConfiguration != null
+        && glossaryCacheConfiguration.getEnabled()
+        && glossaryCacheConfiguration.getRepositories().contains(repository.getName())) {
+      logger.debug(
+          "Glossary cache is enabled and repository {} is configured for glossary cache, updating the cache",
+          repository.getName());
+      glossaryCacheService.buildGlossaryCache();
+    }
   }
 
   public List<ThirdPartyTextUnit> getThirdPartyTextUnits(String glossaryId) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossary.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossary.java
@@ -1,11 +1,14 @@
 package com.box.l10n.mojito.service.thirdparty;
 
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
 import static com.box.l10n.mojito.service.thirdparty.ThirdPartyTMSSmartling.getSmartlingLocale;
 
 import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.AssetTextUnit;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.quartz.QuartzJobInfo;
+import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.service.asset.AssetRepository;
 import com.box.l10n.mojito.service.asset.VirtualAsset;
 import com.box.l10n.mojito.service.asset.VirtualAssetBadRequestException;
@@ -15,8 +18,10 @@ import com.box.l10n.mojito.service.asset.VirtualAssetTextUnit;
 import com.box.l10n.mojito.service.asset.VirutalAssetMissingTextUnitException;
 import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
 import com.box.l10n.mojito.service.thirdparty.smartling.SmartlingTBXReader;
+import com.box.l10n.mojito.service.thirdparty.smartling.glossary.BuildGlossaryCacheJob;
 import com.box.l10n.mojito.service.thirdparty.smartling.glossary.GlossaryCacheConfiguration;
 import com.box.l10n.mojito.service.thirdparty.smartling.glossary.GlossaryCacheService;
+import com.box.l10n.mojito.service.thirdparty.smartling.glossary.SmartlingGlossaryConfigParameter;
 import com.box.l10n.mojito.smartling.SmartlingClient;
 import com.box.l10n.mojito.smartling.SmartlingClientException;
 import com.box.l10n.mojito.smartling.response.GlossarySourceTerm;
@@ -67,6 +72,8 @@ public class ThirdPartyTMSSmartlingGlossary {
   @Autowired(required = false)
   GlossaryCacheConfiguration glossaryCacheConfiguration;
 
+  @Autowired QuartzPollableTaskScheduler quartzPollableTaskScheduler;
+
   @Value("${l10n.smartling.accountId:}")
   String accountId;
 
@@ -101,7 +108,13 @@ public class ThirdPartyTMSSmartlingGlossary {
       logger.debug(
           "Glossary cache is enabled and repository {} is configured for glossary cache, updating the cache",
           repository.getName());
-      glossaryCacheService.buildGlossaryCache();
+      QuartzJobInfo<Void, Void> quartzJobInfo =
+          QuartzJobInfo.newBuilder(BuildGlossaryCacheJob.class)
+              .withInlineInput(false)
+              .withInput(null)
+              .withScheduler(DEFAULT_SCHEDULER_NAME)
+              .build();
+      quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
     }
   }
 
@@ -482,15 +495,22 @@ public class ThirdPartyTMSSmartlingGlossary {
     }
     if (glossarySourceTerm.getVariations() != null
         && !glossarySourceTerm.getVariations().isEmpty()) {
-      commentBuilder.append(" --- Variations: ");
+      commentBuilder.append(
+          String.format(" --- %s: ", SmartlingGlossaryConfigParameter.VARIATIONS));
       commentBuilder.append(String.join(", ", glossarySourceTerm.getVariations()));
     }
 
-    commentBuilder.append(" --- Case Sensitive: ").append(glossarySourceTerm.isCaseSensitive());
+    commentBuilder
+        .append(String.format(" --- %s: ", SmartlingGlossaryConfigParameter.CASE_SENSITIVE))
+        .append(glossarySourceTerm.isCaseSensitive());
 
-    commentBuilder.append(" --- Exact Match: ").append(glossarySourceTerm.isExactMatch());
+    commentBuilder
+        .append(String.format(" --- %s: ", SmartlingGlossaryConfigParameter.EXACT_MATCH))
+        .append(glossarySourceTerm.isExactMatch());
 
-    commentBuilder.append(" --- Do Not Translate: ").append(glossarySourceTerm.isDoNotTranslate());
+    commentBuilder
+        .append(String.format(" --- %s: ", SmartlingGlossaryConfigParameter.DO_NOT_TRANSLATE))
+        .append(glossarySourceTerm.isDoNotTranslate());
 
     return commentBuilder.toString();
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingTBXReader.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingTBXReader.java
@@ -139,6 +139,10 @@ public class SmartlingTBXReader {
         Property partOfSpeech = new Property("partOfSpeech", reader.getElementText(), true);
         cent.setProperty(partOfSpeech);
         break;
+      case "archived":
+        Property archived = new Property("archived", reader.getElementText(), true);
+        cent.setProperty(archived);
+        break;
       default:
         break;
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/BuildGlossaryCacheJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/BuildGlossaryCacheJob.java
@@ -1,0 +1,28 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import com.box.l10n.mojito.quartz.QuartzPollableJob;
+import org.quartz.DisallowConcurrentExecution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(value = "l10n.glossary.cache.enabled", havingValue = "true")
+@DisallowConcurrentExecution
+public class BuildGlossaryCacheJob extends QuartzPollableJob<Void, Void> {
+
+  static Logger logger = LoggerFactory.getLogger(BuildGlossaryCacheJob.class);
+
+  @Autowired GlossaryCacheService cacheService;
+
+  @Override
+  public Void call(Void input) throws Exception {
+    logger.debug("Triggering BuildGlossaryCacheJob");
+    cacheService.buildGlossaryCache();
+    logger.debug("Finished BuildGlossaryCacheJob");
+    return null;
+  }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/BuildGlossaryCacheJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/BuildGlossaryCacheJob.java
@@ -24,5 +24,4 @@ public class BuildGlossaryCacheJob extends QuartzPollableJob<Void, Void> {
     logger.debug("Finished BuildGlossaryCacheJob");
     return null;
   }
-
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCache.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCache.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,7 +10,7 @@ public class GlossaryCache implements Serializable {
 
   private int maxNGramSize = 1;
 
-  private Map<String, List<GlossaryTerm>> glossaryCache = new HashMap<>();
+  private Map<String, List<GlossaryTerm>> cache = new HashMap<>();
 
   public int getMaxNGramSize() {
     return maxNGramSize;
@@ -19,19 +20,21 @@ public class GlossaryCache implements Serializable {
     this.maxNGramSize = maxNGramSize;
   }
 
-  public Map<String, List<GlossaryTerm>> getGlossaryCache() {
-    return glossaryCache;
+  public Map<String, List<GlossaryTerm>> getCache() {
+    return cache;
   }
 
-  public void setGlossaryCache(Map<String, List<GlossaryTerm>> glossaryCache) {
-    this.glossaryCache = glossaryCache;
+  public void setCache(Map<String, List<GlossaryTerm>> cache) {
+    this.cache = cache;
   }
 
-  public void addToGlossaryCache(String key, GlossaryTerm glossaryTerms) {
-    if (glossaryCache.containsKey(key)) {
-      glossaryCache.get(key).add(glossaryTerms);
+  public void addToGlossaryCache(String key, GlossaryTerm glossaryTerm) {
+    if (cache.containsKey(key)) {
+      cache.get(key).add(glossaryTerm);
     } else {
-      glossaryCache.put(key, List.of(glossaryTerms));
+      List<GlossaryTerm> terms = new ArrayList<>();
+      terms.add(glossaryTerm);
+      cache.put(key, terms);
     }
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCache.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCache.java
@@ -1,0 +1,37 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GlossaryCache implements Serializable {
+
+  private int maxNGramSize = 1;
+
+  private Map<String, List<GlossaryTerm>> glossaryCache = new HashMap<>();
+
+  public int getMaxNGramSize() {
+    return maxNGramSize;
+  }
+
+  public void setMaxNGramSize(int maxNGramSize) {
+    this.maxNGramSize = maxNGramSize;
+  }
+
+  public Map<String, List<GlossaryTerm>> getGlossaryCache() {
+    return glossaryCache;
+  }
+
+  public void setGlossaryCache(Map<String, List<GlossaryTerm>> glossaryCache) {
+    this.glossaryCache = glossaryCache;
+  }
+
+  public void addToGlossaryCache(String key, GlossaryTerm glossaryTerms) {
+    if (glossaryCache.containsKey(key)) {
+      glossaryCache.get(key).add(glossaryTerms);
+    } else {
+      glossaryCache.put(key, List.of(glossaryTerms));
+    }
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCache.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCache.java
@@ -28,7 +28,7 @@ public class GlossaryCache implements Serializable {
     this.cache = cache;
   }
 
-  public void addToGlossaryCache(String key, GlossaryTerm glossaryTerm) {
+  public void add(String key, GlossaryTerm glossaryTerm) {
     if (cache.containsKey(key)) {
       cache.get(key).add(glossaryTerm);
     } else {
@@ -36,5 +36,19 @@ public class GlossaryCache implements Serializable {
       terms.add(glossaryTerm);
       cache.put(key, terms);
     }
+  }
+
+  /**
+   * Get the list of glossary terms for a given .
+   *
+   * @param key
+   * @return
+   */
+  public List<GlossaryTerm> get(String key) {
+    return cache.getOrDefault(key, new ArrayList<>());
+  }
+
+  public int size() {
+    return cache.size();
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBlobStorage.java
@@ -1,0 +1,39 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.service.blobstorage.Retention;
+import com.box.l10n.mojito.service.blobstorage.StructuredBlobStorage;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(value = "l10n.glossary.cache.enabled", havingValue = "true")
+public class GlossaryCacheBlobStorage {
+
+  private final StructuredBlobStorage structuredBlobStorage;
+  private final String glossaryCacheName = "smartling-glossary-cache";
+
+  ObjectMapper objectMapper;
+
+  public GlossaryCacheBlobStorage(
+      ObjectMapper objectMapper, StructuredBlobStorage structuredBlobStorage) {
+
+    this.objectMapper = objectMapper;
+    this.structuredBlobStorage = structuredBlobStorage;
+  }
+
+  public void putGlossaryCache(GlossaryCache glossaryCache) {
+    structuredBlobStorage.put(
+        StructuredBlobStorage.Prefix.GLOSSARY,
+        glossaryCacheName,
+        objectMapper.writeValueAsStringUnchecked(glossaryCache),
+        Retention.PERMANENT);
+  }
+
+  public Optional<GlossaryCache> getGlossaryCache() {
+    Optional<String> glossaryJson =
+        structuredBlobStorage.getString(StructuredBlobStorage.Prefix.GLOSSARY, glossaryCacheName);
+    return glossaryJson.map(s -> objectMapper.readValueUnchecked(s, GlossaryCache.class));
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilder.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilder.java
@@ -1,0 +1,199 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import com.box.l10n.mojito.service.WordCountService;
+import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
+import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
+import com.box.l10n.mojito.service.tm.search.UsedFilter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(value = "l10n.glossary.cache.enabled", havingValue = "true")
+public class GlossaryCacheBuilder {
+
+  static Logger logger = LoggerFactory.getLogger(GlossaryCacheBuilder.class);
+  @Autowired GlossaryCacheConfiguration glossaryCacheConfiguration;
+
+  @Autowired GlossaryCacheBlobStorage blobStorage;
+
+  @Autowired TextUnitSearcher textUnitSearcher;
+
+  @Autowired WordCountService wordCountService;
+
+  @Autowired StemmerService stemmer;
+
+  private static final Map<String, Pattern> CONFIG_PATTERNS = new HashMap<>();
+
+  // TODO(mallen): Standardize this so that same value is used here and in pull glossary sync
+  private List<String> smartlingConfigParameters =
+      List.of("Variations", "Exact Match", "Do Not Translate", "Case Sensitive");
+
+  public void buildCache() {
+    if (glossaryCacheConfiguration.getEnabled()) {
+      logger.info("Building Glossary Cache");
+      if (glossaryCacheConfiguration.getRepositories() == null
+          || glossaryCacheConfiguration.getRepositories().isEmpty()) {
+        logger.warn("No repositories configured for Glossary cache builder, skipping cache build");
+        return;
+      }
+      GlossaryCache glossaryCache = buildGlossaryCache();
+      logger.info(
+          "Glossary Cache build completed with {} terms", glossaryCache.getGlossaryCache().size());
+      blobStorage.putGlossaryCache(glossaryCache);
+    }
+  }
+
+  private GlossaryCache buildGlossaryCache() {
+    GlossaryCache glossaryCache = new GlossaryCache();
+    glossaryCache.setMaxNGramSize(0);
+    glossaryCache.setGlossaryCache(new HashMap<>());
+
+    List<GlossaryTerm> glossaryTerms = retrieveTranslationsForGlossaryTerms(getSourceTerms());
+
+    for (GlossaryTerm glossaryTerm : glossaryTerms) {
+      processTerm(glossaryTerm, glossaryCache);
+    }
+    return glossaryCache;
+  }
+
+  private void processTerm(GlossaryTerm glossaryTerm, GlossaryCache glossaryCache) {
+    int termWordCount = wordCountService.getEnglishWordCount(glossaryTerm.getTerm());
+    if (termWordCount > glossaryCache.getMaxNGramSize()) {
+      logger.debug("Setting glossary cache max ngram size to {}", termWordCount);
+      glossaryCache.setMaxNGramSize(termWordCount);
+    }
+    logger.debug("Adding term to glossary cache: {}", glossaryTerm.getTerm());
+    glossaryCache.addToGlossaryCache(stemmer.stem(glossaryTerm.getTerm()), glossaryTerm);
+  }
+
+  private List<GlossaryTerm> retrieveTranslationsForGlossaryTerms(
+      Map<Long, List<GlossaryTerm>> glossaryTermMap) {
+    TextUnitSearcherParameters textUnitSearcherParameters;
+    List<TextUnitDTO> textUnitDTOs;
+
+    textUnitSearcherParameters = new TextUnitSearcherParameters();
+    textUnitSearcherParameters.setRepositoryNames(glossaryCacheConfiguration.getRepositories());
+    textUnitSearcherParameters.setUsedFilter(UsedFilter.USED);
+    textUnitSearcherParameters.setRootLocaleExcluded(true);
+    textUnitDTOs = textUnitSearcher.search(textUnitSearcherParameters);
+
+    for (TextUnitDTO textUnitDTO : textUnitDTOs) {
+      List<GlossaryTerm> glossaryTerms = glossaryTermMap.get(textUnitDTO.getTmTextUnitId());
+      if (glossaryTerms != null) {
+        for (GlossaryTerm glossaryTerm : glossaryTerms) {
+          logger.debug(
+              "Adding translation for glossary term (tmTextUnitId: {})",
+              glossaryTerm.getTmTextUnitId());
+          glossaryTerm.addLocaleTranslation(textUnitDTO.getTargetLocale(), textUnitDTO.getTarget());
+        }
+      }
+    }
+
+    return glossaryTermMap.values().stream().flatMap(List::stream).collect(Collectors.toList());
+  }
+
+  private Map<Long, List<GlossaryTerm>> getSourceTerms() {
+    TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
+    textUnitSearcherParameters.setRepositoryNames(glossaryCacheConfiguration.getRepositories());
+    textUnitSearcherParameters.setUsedFilter(UsedFilter.USED);
+    textUnitSearcherParameters.setForRootLocale(true);
+
+    List<TextUnitDTO> textUnitDTOs = textUnitSearcher.search(textUnitSearcherParameters);
+    return textUnitDTOs.stream()
+        .map(this::mapTextUnitDTOToGlossaryTerms)
+        .flatMap(List::stream)
+        .collect(Collectors.groupingBy(GlossaryTerm::getTmTextUnitId));
+  }
+
+  /**
+   * Maps a TextUnitDTO to a list of GlossaryTerm objects. A glossary source term can have
+   * variations, which are handled as individual @link GlossaryTerm objects.
+   *
+   * @param textUnitDTO
+   * @return list of GlossaryTerm objects
+   */
+  private List<GlossaryTerm> mapTextUnitDTOToGlossaryTerms(TextUnitDTO textUnitDTO) {
+    List<GlossaryTerm> glossaryTerms = new ArrayList<>();
+    String comment = textUnitDTO.getComment();
+    boolean caseSensitive = getSmartlingTermCaseSensitive(comment);
+    boolean doNotTranslate = getSmartlingTermDoNotTranslate(comment);
+    boolean exactMatch = getSmartlingTermExactMatch(comment);
+    List<String> variations = getSmartlingTermVariations(comment);
+
+    GlossaryTerm glossaryTerm =
+        new GlossaryTerm(
+            textUnitDTO.getSource(),
+            exactMatch,
+            caseSensitive,
+            doNotTranslate,
+            textUnitDTO.getTmTextUnitId());
+    glossaryTerms.add(glossaryTerm);
+
+    for (String variation : variations) {
+      GlossaryTerm variationTerm =
+          new GlossaryTerm(
+              variation, exactMatch, caseSensitive, doNotTranslate, textUnitDTO.getTmTextUnitId());
+      glossaryTerms.add(variationTerm);
+    }
+
+    return glossaryTerms;
+  }
+
+  private Boolean getSmartlingTermCaseSensitive(String comment) {
+    return Boolean.parseBoolean(extractProperty(comment, CONFIG_PATTERNS.get("Case Sensitive")));
+  }
+
+  private Boolean getSmartlingTermDoNotTranslate(String comment) {
+    return Boolean.parseBoolean(extractProperty(comment, CONFIG_PATTERNS.get("Do Not Translate")));
+  }
+
+  private Boolean getSmartlingTermExactMatch(String comment) {
+    return Boolean.parseBoolean(extractProperty(comment, CONFIG_PATTERNS.get("Exact Match")));
+  }
+
+  private List<String> getSmartlingTermVariations(String comment) {
+    String variations = extractProperty(comment, CONFIG_PATTERNS.get("Variations"));
+    if (variations != null) {
+      return Arrays.asList(variations.split("\\s*,\\s*"));
+    }
+    return Collections.emptyList();
+  }
+
+  public String extractProperty(String input, Pattern pattern) {
+    Matcher matcher = pattern.matcher(input);
+    if (matcher.find()) {
+      return matcher.group(1).trim();
+    }
+    return null;
+  }
+
+  public List<String> extractVariations(String comment) {
+    String variations = extractProperty(comment, CONFIG_PATTERNS.get("Variations"));
+    if (variations != null) {
+      return Arrays.asList(variations.split("\\s*,\\s*"));
+    }
+    return Collections.emptyList();
+  }
+
+  @PostConstruct
+  public void init() {
+    // Initialize the regex patterns for each smartling config parameter
+    for (String param : smartlingConfigParameters) {
+      CONFIG_PATTERNS.put(param, Pattern.compile(" --- " + param + ":\\s*([^---]*)"));
+    }
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilder.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilder.java
@@ -51,16 +51,13 @@ public class GlossaryCacheBuilder {
         return;
       }
       GlossaryCache glossaryCache = buildGlossaryCache();
-      logger.info(
-          "Glossary Cache build completed with {} terms", glossaryCache.getGlossaryCache().size());
+      logger.info("Glossary Cache build completed with {} terms", glossaryCache.getCache().size());
       blobStorage.putGlossaryCache(glossaryCache);
     }
   }
 
   private GlossaryCache buildGlossaryCache() {
     GlossaryCache glossaryCache = new GlossaryCache();
-    glossaryCache.setMaxNGramSize(0);
-    glossaryCache.setGlossaryCache(new HashMap<>());
 
     List<GlossaryTerm> glossaryTerms = retrieveTranslationsForGlossaryTerms(getSourceTerms());
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilder.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilder.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+// TODO: (mallen) convert this to be run by a Quartz job that disallows concurrent execution
 @Component
 @ConditionalOnProperty(value = "l10n.glossary.cache.enabled", havingValue = "true")
 public class GlossaryCacheBuilder {
@@ -74,7 +75,7 @@ public class GlossaryCacheBuilder {
       glossaryCache.setMaxNGramSize(termWordCount);
     }
     logger.debug("Adding term to glossary cache: {}", glossaryTerm.getTerm());
-    glossaryCache.addToGlossaryCache(stemmer.stem(glossaryTerm.getTerm()), glossaryTerm);
+    glossaryCache.add(stemmer.stem(glossaryTerm.getTerm()), glossaryTerm);
   }
 
   private List<GlossaryTerm> retrieveTranslationsForGlossaryTerms(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheConfiguration.java
@@ -1,0 +1,30 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("l10n.glossary.cache")
+public class GlossaryCacheConfiguration {
+
+  List<String> repositories;
+
+  Boolean enabled = false;
+
+  public List<String> getRepositories() {
+    return repositories;
+  }
+
+  public void setRepositories(List<String> repositories) {
+    this.repositories = repositories;
+  }
+
+  public Boolean getEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheConfiguration.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -8,7 +9,7 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties("l10n.glossary.cache")
 public class GlossaryCacheConfiguration {
 
-  List<String> repositories;
+  List<String> repositories = new ArrayList<>();
 
   Boolean enabled = false;
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
@@ -1,6 +1,5 @@
 package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
 
-import java.util.Arrays;
 import java.util.List;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +30,8 @@ public class GlossaryCacheService {
       loadGlossaryCache();
     }
 
-    // TODO (mallen): Need to handle multiple matches, case sensitive, exact match checking here
+    // TODO (mallen): Need to handle multiple matches, case sensitive, exact match checking here in
+    // a follow-up PR
     return glossaryCache.get(stemmerService.stem(text));
   }
 
@@ -42,14 +42,6 @@ public class GlossaryCacheService {
 
   public void loadGlossaryCache() {
     glossaryCache = glossaryCacheBlobStorage.getGlossaryCache().orElseGet(GlossaryCache::new);
-  }
-
-  private String stemTerms(String terms) {
-    return String.join(
-        " ",
-        Arrays.stream(terms.toLowerCase().split("\\s+"))
-            .map(stemmerService::stem)
-            .toArray(String[]::new));
   }
 
   @PostConstruct

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
@@ -1,0 +1,59 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(value = "l10n.glossary.cache.enabled", havingValue = "true")
+public class GlossaryCacheService {
+
+  @Autowired GlossaryCacheBlobStorage glossaryCacheBlobStorage;
+
+  @Autowired GlossaryCacheBuilder glossaryCacheBuilder;
+
+  @Autowired StemmerService stemmerService;
+
+  private GlossaryCache glossaryCache;
+
+  /**
+   * Get the list of glossary terms matches the for provided text.
+   *
+   * @param text
+   * @return
+   */
+  public List<GlossaryTerm> getGlossaryTermsInText(String text) {
+    if (glossaryCache.size() == 0) {
+      // If the cache is empty, load it from blob storage
+      loadGlossaryCache();
+    }
+
+    // TODO (mallen): Need to handle multiple matches, case sensitive, exact match checking here
+    return glossaryCache.get(stemmerService.stem(text));
+  }
+
+  public void buildGlossaryCache() {
+    glossaryCacheBuilder.buildCache();
+    loadGlossaryCache();
+  }
+
+  public void loadGlossaryCache() {
+    glossaryCache = glossaryCacheBlobStorage.getGlossaryCache().orElseGet(GlossaryCache::new);
+  }
+
+  private String stemTerms(String terms) {
+    return String.join(
+        " ",
+        Arrays.stream(terms.toLowerCase().split("\\s+"))
+            .map(stemmerService::stem)
+            .toArray(String[]::new));
+  }
+
+  @PostConstruct
+  private void init() {
+    loadGlossaryCache();
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
@@ -19,7 +19,7 @@ public class GlossaryCacheService {
   private GlossaryCache glossaryCache;
 
   /**
-   * Get the list of glossary terms matches the for provided text.
+   * Get the list of glossary terms matches for the provided text.
    *
    * @param text
    * @return

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
@@ -1,16 +1,19 @@
 package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class GlossaryTerm {
+public class GlossaryTerm implements Serializable {
 
-  private final Long tmTextUnitId;
-  private final String term;
-  private final Map<String, String> translations;
-  private final boolean isExactMatch;
-  private final boolean isCaseSensitive;
-  private final boolean isDoNotTranslate;
+  private Long tmTextUnitId;
+  private String term;
+  private Map<String, String> translations;
+  private boolean isExactMatch;
+  private boolean isCaseSensitive;
+  private boolean isDoNotTranslate;
+
+  public GlossaryTerm() {}
 
   public GlossaryTerm(
       String term,
@@ -56,5 +59,29 @@ public class GlossaryTerm {
 
   public boolean isDoNotTranslate() {
     return isDoNotTranslate;
+  }
+
+  public void setTmTextUnitId(Long tmTextUnitId) {
+    this.tmTextUnitId = tmTextUnitId;
+  }
+
+  public void setTerm(String term) {
+    this.term = term;
+  }
+
+  public void setTranslations(Map<String, String> translations) {
+    this.translations = translations;
+  }
+
+  public void setExactMatch(boolean exactMatch) {
+    isExactMatch = exactMatch;
+  }
+
+  public void setCaseSensitive(boolean caseSensitive) {
+    isCaseSensitive = caseSensitive;
+  }
+
+  public void setDoNotTranslate(boolean doNotTranslate) {
+    isDoNotTranslate = doNotTranslate;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
@@ -1,0 +1,60 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GlossaryTerm {
+
+  private final Long tmTextUnitId;
+  private final String term;
+  private final Map<String, String> translations;
+  private final boolean isExactMatch;
+  private final boolean isCaseSensitive;
+  private final boolean isDoNotTranslate;
+
+  public GlossaryTerm(
+      String term,
+      boolean isExactMatch,
+      boolean isCaseSensitive,
+      boolean isDoNotTranslate,
+      Long tmTextUnitId) {
+    this.term = term;
+    this.isExactMatch = isExactMatch;
+    this.isCaseSensitive = isCaseSensitive;
+    this.isDoNotTranslate = isDoNotTranslate;
+    this.translations = new HashMap<>();
+    this.tmTextUnitId = tmTextUnitId;
+  }
+
+  public Long getTmTextUnitId() {
+    return tmTextUnitId;
+  }
+
+  public void addLocaleTranslation(String bcp47Tag, String translation) {
+    translations.put(bcp47Tag, translation);
+  }
+
+  public void getLocaleTranslation(String bcp47Tag) {
+    translations.get(bcp47Tag);
+  }
+
+  public String getTerm() {
+    return term;
+  }
+
+  public Map<String, String> getTranslations() {
+    return translations;
+  }
+
+  public boolean isExactMatch() {
+    return isExactMatch;
+  }
+
+  public boolean isCaseSensitive() {
+    return isCaseSensitive;
+  }
+
+  public boolean isDoNotTranslate() {
+    return isDoNotTranslate;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/SmartlingGlossaryConfigParameter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/SmartlingGlossaryConfigParameter.java
@@ -1,0 +1,18 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+public enum SmartlingGlossaryConfigParameter {
+  VARIATIONS("Variations"),
+  CASE_SENSITIVE("Case Sensitive"),
+  EXACT_MATCH("Exact Match"),
+  DO_NOT_TRANSLATE("Do Not Translate");
+
+  private String name;
+
+  SmartlingGlossaryConfigParameter(String name) {
+    this.name = name;
+  }
+
+  public String toString() {
+    return name;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/StemmerService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/StemmerService.java
@@ -1,0 +1,27 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import java.util.Arrays;
+import opennlp.tools.stemmer.PorterStemmer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(value = "l10n.glossary.cache.enabled", havingValue = "true")
+public class StemmerService {
+
+  private final PorterStemmer stemmer = new PorterStemmer();
+
+  /**
+   * Stems the input text using the Porter stemming algorithm.
+   *
+   * <p>Input text is converted to lowercase and split into words.
+   *
+   * @param text the input text to stem
+   * @return the stemmed text
+   */
+  public String stem(String text) {
+    return String.join(
+        " ",
+        Arrays.stream(text.toLowerCase().split("\\s+")).map(stemmer::stem).toArray(String[]::new));
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilderTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilderTest.java
@@ -1,0 +1,168 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.box.l10n.mojito.service.WordCountService;
+import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class GlossaryCacheBuilderTest {
+
+  @Mock GlossaryCacheConfiguration glossaryCacheConfiguration;
+
+  @Mock GlossaryCacheBlobStorage blobStorage;
+
+  @Mock TextUnitSearcher textUnitSearcher;
+
+  @Mock WordCountService wordCountService;
+
+  @Mock StemmerService stemmer;
+
+  GlossaryCacheBuilder glossaryCacheBuilder;
+
+  @BeforeEach
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    glossaryCacheBuilder = spy(new GlossaryCacheBuilder());
+    glossaryCacheBuilder.glossaryCacheConfiguration = glossaryCacheConfiguration;
+    glossaryCacheBuilder.blobStorage = blobStorage;
+    glossaryCacheBuilder.textUnitSearcher = textUnitSearcher;
+    glossaryCacheBuilder.wordCountService = wordCountService;
+    glossaryCacheBuilder.stemmer = stemmer;
+    glossaryCacheBuilder.init();
+  }
+
+  @Test
+  void testBlobStorageNotUpdatedIfNoConfiguredRepos() {
+    when(glossaryCacheConfiguration.getEnabled()).thenReturn(true);
+    when(glossaryCacheConfiguration.getRepositories()).thenReturn(Collections.emptyList());
+
+    glossaryCacheBuilder.buildCache();
+
+    verify(blobStorage, never()).putGlossaryCache(any());
+  }
+
+  @Test
+  void testCacheIsStoredInBlobStorageOnBuild() {
+    when(glossaryCacheConfiguration.getEnabled()).thenReturn(true);
+    when(glossaryCacheConfiguration.getRepositories()).thenReturn(List.of("repo1"));
+
+    GlossaryCache glossaryCache = mock(GlossaryCache.class);
+    doReturn(glossaryCache).when(glossaryCacheBuilder).buildGlossaryCache();
+
+    glossaryCacheBuilder.buildCache();
+
+    verify(blobStorage).putGlossaryCache(glossaryCache);
+  }
+
+  @Test
+  void testMaxNGramSizeIsUpdated() {
+    GlossaryCache glossaryCache = new GlossaryCache();
+    GlossaryTerm glossaryTerm = new GlossaryTerm("term", false, false, false, 1L);
+
+    when(wordCountService.getEnglishWordCount("term")).thenReturn(5);
+
+    glossaryCacheBuilder.processTerm(glossaryTerm, glossaryCache);
+
+    Assertions.assertEquals(5, glossaryCache.getMaxNGramSize());
+
+    when(wordCountService.getEnglishWordCount("term")).thenReturn(10);
+
+    glossaryCacheBuilder.processTerm(glossaryTerm, glossaryCache);
+
+    // Max Ngram size should be updated to 10
+    Assertions.assertEquals(10, glossaryCache.getMaxNGramSize());
+
+    when(wordCountService.getEnglishWordCount("term")).thenReturn(5);
+
+    glossaryCacheBuilder.processTerm(glossaryTerm, glossaryCache);
+
+    // Max ngram should remain as 10
+    Assertions.assertEquals(10, glossaryCache.getMaxNGramSize());
+  }
+
+  @Test
+  void testStemmedTermUsedAsKey() {
+    GlossaryCache glossaryCache = new GlossaryCache();
+    GlossaryTerm glossaryTerm = new GlossaryTerm("term", false, false, false, 1L);
+
+    when(stemmer.stem("term")).thenReturn("stemmedTerm");
+
+    glossaryCacheBuilder.processTerm(glossaryTerm, glossaryCache);
+
+    Assertions.assertTrue(glossaryCache.getCache().containsKey("stemmedTerm"));
+    Assertions.assertTrue(glossaryCache.getCache().get("stemmedTerm").contains(glossaryTerm));
+  }
+
+  @Test
+  void testTranslationsAreRetrievedForGlossaryTerms() {
+    Map<Long, List<GlossaryTerm>> glossaryTermMap = new HashMap<>();
+    GlossaryTerm glossaryTerm = new GlossaryTerm("term", false, false, false, 1L);
+    glossaryTermMap.put(1L, List.of(glossaryTerm));
+
+    TextUnitDTO textUnitDTO = new TextUnitDTO();
+    textUnitDTO.setTmTextUnitId(1L);
+    textUnitDTO.setTargetLocale("fr");
+    textUnitDTO.setTarget("terme");
+
+    when(textUnitSearcher.search(any())).thenReturn(List.of(textUnitDTO));
+
+    List<GlossaryTerm> result =
+        glossaryCacheBuilder.retrieveTranslationsForGlossaryTerms(glossaryTermMap);
+
+    Assertions.assertEquals(1, result.size());
+    Assertions.assertEquals("terme", glossaryTerm.getTranslations().get("fr"));
+  }
+
+  @Test
+  void testSourceTermVariationsMaintainGlossaryTermConfig() {
+    TextUnitDTO textUnitDTO = new TextUnitDTO();
+    textUnitDTO.setTmTextUnitId(1L);
+    textUnitDTO.setSource("source");
+    textUnitDTO.setComment("--- Variations: beginning,start --- Case Sensitive: true");
+
+    when(textUnitSearcher.search(any())).thenReturn(List.of(textUnitDTO));
+
+    Map<Long, List<GlossaryTerm>> result = glossaryCacheBuilder.getSourceTerms();
+
+    Assertions.assertEquals(1, result.size());
+    Assertions.assertTrue(result.containsKey(1L));
+    Assertions.assertEquals(3, result.get(1L).size());
+    for (GlossaryTerm glossaryTerm : result.get(1L)) {
+      Assertions.assertTrue(glossaryTerm.isCaseSensitive());
+      Assertions.assertFalse(glossaryTerm.isExactMatch());
+      Assertions.assertFalse(glossaryTerm.isDoNotTranslate());
+    }
+  }
+
+  @Test
+  void testSourceTermVariationsAreGroupedByTmTextUnitIds() {
+    TextUnitDTO textUnitDTO = new TextUnitDTO();
+    textUnitDTO.setTmTextUnitId(1L);
+    textUnitDTO.setSource("source");
+    textUnitDTO.setComment("--- Variations: beginning,start");
+
+    when(textUnitSearcher.search(any())).thenReturn(List.of(textUnitDTO));
+
+    Map<Long, List<GlossaryTerm>> result = glossaryCacheBuilder.getSourceTerms();
+
+    Assertions.assertEquals(1, result.size());
+    Assertions.assertTrue(result.containsKey(1L));
+    Assertions.assertEquals(3, result.get(1L).size());
+  }
+}


### PR DESCRIPTION
Adds a cache builder to create a quick lookup cache of glossary terms. Glossary terms are stored in a map with their stemmed text as the key, due to term variations multiple terms may match for the same key.

Additional processing to be done in the lookup on GlossaryCacheService to handle term configuration matching.