### PR TITLE
Inject glossary matches into translation prompts

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/LLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/LLMService.java
@@ -9,6 +9,8 @@ import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
 import com.box.l10n.mojito.rest.ai.AICheckRequest;
 import com.box.l10n.mojito.rest.ai.AICheckResponse;
 import com.box.l10n.mojito.rest.ai.AICheckResult;
+import com.box.l10n.mojito.service.thirdparty.smartling.glossary.GlossaryTerm;
+import java.util.List;
 
 public interface LLMService {
 
@@ -18,6 +20,7 @@ public interface LLMService {
   String SOURCE_LOCALE_PLACEHOLDER = "[mojito_source_locale]";
   String TARGET_LOCALE_PLACEHOLDER = "[mojito_target_locale]";
   String PLURAL_FORM_PLACEHOLDER = "[mojito_plural_form]";
+  String GLOSSARY_TERM_MATCHES_PLACEHOLDER = "[mojito_glossary_term_matches]";
 
   /**
    * Executes AI checks on the provided text units.
@@ -55,6 +58,13 @@ public interface LLMService {
     aiStringCheck.setStringName(textUnit.getName());
     aiStringCheckRepository.save(aiStringCheck);
   }
+
+  String translate(
+      TMTextUnit tmTextUnit,
+      String sourceBcp47Tag,
+      String targetBcp47Tag,
+      AIPrompt prompt,
+      List<GlossaryTerm> glossaryTerms);
 
   String translate(
       TMTextUnit tmTextUnit, String sourceBcp47Tag, String targetBcp47Tag, AIPrompt prompt);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
@@ -500,7 +500,9 @@ public class OpenAILLMService implements LLMService {
         + ", \"isDoNotTranslate\": "
         + glossaryTerm.isDoNotTranslate()
         + ", \"translation\": \""
-        + glossaryTerm.getTranslations().get(targetBcp47Tag)
+        + (glossaryTerm.isDoNotTranslate()
+            ? glossaryTerm.getText()
+            : glossaryTerm.getTranslations().get(targetBcp47Tag))
         + "\""
         + "}";
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
@@ -480,32 +480,32 @@ public class OpenAILLMService implements LLMService {
   private String mapGlossaryTermsToJsonList(
       List<GlossaryTerm> glossaryTerms, String targetBcp47Tag) {
 
-    return "["
-        + glossaryTerms.stream()
-            .map(term -> mapGlossaryTermToJsonObject(term, targetBcp47Tag))
-            .collect(Collectors.joining(", "))
-        + "]";
+    try {
+      return objectMapper.writeValueAsString(
+          glossaryTerms.stream().map(term -> mapGlossaryTermToJSON(term, targetBcp47Tag)).toList());
+    } catch (JsonProcessingException e) {
+      logger.error("Error mapping glossary terms to JSON list", e);
+      throw new AIException("Error mapping glossary terms to JSON list", e);
+    }
   }
 
-  private String mapGlossaryTermToJsonObject(GlossaryTerm glossaryTerm, String targetBcp47Tag) {
-
-    return "{"
-        + "\"text\": \""
-        + glossaryTerm.getText()
-        + "\""
-        + ", \"isExactMatch\": "
-        + glossaryTerm.isExactMatch()
-        + ", \"isCaseSensitive\": "
-        + glossaryTerm.isCaseSensitive()
-        + ", \"isDoNotTranslate\": "
-        + glossaryTerm.isDoNotTranslate()
-        + ", \"translation\": \""
-        + (glossaryTerm.isDoNotTranslate()
+  private GlossaryTermJson mapGlossaryTermToJSON(GlossaryTerm glossaryTerm, String targetBcp47Tag) {
+    return new GlossaryTermJson(
+        glossaryTerm.getText(),
+        glossaryTerm.isExactMatch(),
+        glossaryTerm.isCaseSensitive(),
+        glossaryTerm.isDoNotTranslate(),
+        glossaryTerm.isDoNotTranslate()
             ? glossaryTerm.getText()
-            : glossaryTerm.getLocaleTranslation(targetBcp47Tag))
-        + "\""
-        + "}";
+            : glossaryTerm.getLocaleTranslation(targetBcp47Tag));
   }
+
+  private record GlossaryTermJson(
+      String text,
+      boolean isExactMatch,
+      boolean isCaseSensitive,
+      boolean isDoNotTranslate,
+      String translation) {}
 
   private String processOptionalPlaceholderText(
       String promptText, String placeholder, String placeholderValue) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
@@ -502,7 +502,7 @@ public class OpenAILLMService implements LLMService {
         + ", \"translation\": \""
         + (glossaryTerm.isDoNotTranslate()
             ? glossaryTerm.getText()
-            : glossaryTerm.getTranslations().get(targetBcp47Tag))
+            : glossaryTerm.getLocaleTranslation(targetBcp47Tag))
         + "\""
         + "}";
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
@@ -21,6 +21,7 @@ import com.box.l10n.mojito.service.ai.AIStringCheckRepository;
 import com.box.l10n.mojito.service.ai.LLMPromptService;
 import com.box.l10n.mojito.service.ai.LLMService;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import com.box.l10n.mojito.service.thirdparty.smartling.glossary.GlossaryTerm;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Strings;
 import io.micrometer.core.annotation.Timed;
@@ -29,6 +30,7 @@ import io.micrometer.core.instrument.Tags;
 import jakarta.annotation.PostConstruct;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -152,6 +154,39 @@ public class OpenAILLMService implements LLMService {
   @Override
   @Timed("OpenAILLMService.translate")
   public String translate(
+      TMTextUnit tmTextUnit,
+      String sourceBcp47Tag,
+      String targetBcp47Tag,
+      AIPrompt prompt,
+      List<GlossaryTerm> matchedGlossaryTerms) {
+    logger.debug(
+        "Translating text unit {} from {} to {} using prompt {} with glossary matches {}",
+        tmTextUnit.getId(),
+        sourceBcp47Tag,
+        targetBcp47Tag,
+        prompt.getId(),
+        matchedGlossaryTerms);
+    String systemPrompt =
+        getTranslationFormattedPrompt(
+            prompt.getSystemPrompt(),
+            tmTextUnit,
+            sourceBcp47Tag,
+            targetBcp47Tag,
+            matchedGlossaryTerms);
+    String userPrompt =
+        getTranslationFormattedPrompt(
+            prompt.getUserPrompt(),
+            tmTextUnit,
+            sourceBcp47Tag,
+            targetBcp47Tag,
+            matchedGlossaryTerms);
+    return sendTranslationRequest(
+        tmTextUnit, sourceBcp47Tag, targetBcp47Tag, prompt, systemPrompt, userPrompt);
+  }
+
+  @Override
+  @Timed("OpenAILLMService.translate")
+  public String translate(
       TMTextUnit tmTextUnit, String sourceBcp47Tag, String targetBcp47Tag, AIPrompt prompt) {
     logger.debug(
         "Translating text unit {} from {} to {} using prompt {}",
@@ -161,11 +196,30 @@ public class OpenAILLMService implements LLMService {
         prompt.getId());
     String systemPrompt =
         getTranslationFormattedPrompt(
-            prompt.getSystemPrompt(), tmTextUnit, sourceBcp47Tag, targetBcp47Tag);
+            prompt.getSystemPrompt(),
+            tmTextUnit,
+            sourceBcp47Tag,
+            targetBcp47Tag,
+            Collections.emptyList());
     String userPrompt =
         getTranslationFormattedPrompt(
-            prompt.getUserPrompt(), tmTextUnit, sourceBcp47Tag, targetBcp47Tag);
+            prompt.getUserPrompt(),
+            tmTextUnit,
+            sourceBcp47Tag,
+            targetBcp47Tag,
+            Collections.emptyList());
 
+    return sendTranslationRequest(
+        tmTextUnit, sourceBcp47Tag, targetBcp47Tag, prompt, systemPrompt, userPrompt);
+  }
+
+  private String sendTranslationRequest(
+      TMTextUnit tmTextUnit,
+      String sourceBcp47Tag,
+      String targetBcp47Tag,
+      AIPrompt prompt,
+      String systemPrompt,
+      String userPrompt) {
     OpenAIClient.ChatCompletionsRequest chatCompletionsRequest =
         buildChatCompletionsRequest(
             prompt, systemPrompt, userPrompt, prompt.getContextMessages(), prompt.isJsonResponse());
@@ -367,7 +421,11 @@ public class OpenAILLMService implements LLMService {
   }
 
   protected String getTranslationFormattedPrompt(
-      String prompt, TMTextUnit tmTextUnit, String sourceBcp47Tag, String targetBcp47Tag) {
+      String prompt,
+      TMTextUnit tmTextUnit,
+      String sourceBcp47Tag,
+      String targetBcp47Tag,
+      List<GlossaryTerm> glossaryTerms) {
     String formattedPrompt = "";
     if (prompt != null) {
       formattedPrompt =
@@ -390,15 +448,68 @@ public class OpenAILLMService implements LLMService {
               tmTextUnit.getName() != null && tmTextUnit.getName().split(" --- ").length > 1
                   ? tmTextUnit.getName().split(" --- ")[1]
                   : null);
+      formattedPrompt =
+          processGlossaryTermsPlaceholderText(formattedPrompt, targetBcp47Tag, glossaryTerms);
     }
     return formattedPrompt.trim();
   }
 
+  private String processGlossaryTermsPlaceholderText(
+      String promptText, String targetBcp47Tag, List<GlossaryTerm> glossaryTerms) {
+    Pattern pattern = patternCache.get(GLOSSARY_TERM_MATCHES_PLACEHOLDER);
+    Matcher matcher = pattern.matcher(promptText);
+    if (matcher.find()) {
+      String optionalContent =
+          matcher.group(1)
+              + mapGlossaryTermsToJsonList(glossaryTerms, targetBcp47Tag)
+              + matcher.group(2);
+      if (matcher.groupCount() > 2) {
+        optionalContent += matcher.group(3);
+      }
+      promptText = matcher.replaceFirst(optionalContent);
+    } else {
+      promptText =
+          promptText.replace(
+              GLOSSARY_TERM_MATCHES_PLACEHOLDER,
+              mapGlossaryTermsToJsonList(glossaryTerms, targetBcp47Tag));
+    }
+
+    return promptText;
+  }
+
+  private String mapGlossaryTermsToJsonList(
+      List<GlossaryTerm> glossaryTerms, String targetBcp47Tag) {
+
+    return "["
+        + glossaryTerms.stream()
+            .map(term -> mapGlossaryTermToJsonObject(term, targetBcp47Tag))
+            .collect(Collectors.joining(", "))
+        + "]";
+  }
+
+  private String mapGlossaryTermToJsonObject(GlossaryTerm glossaryTerm, String targetBcp47Tag) {
+
+    return "{"
+        + "\"text\": \""
+        + glossaryTerm.getText()
+        + "\""
+        + ", \"isExactMatch\": "
+        + glossaryTerm.isExactMatch()
+        + ", \"isCaseSensitive\": "
+        + glossaryTerm.isCaseSensitive()
+        + ", \"isDoNotTranslate\": "
+        + glossaryTerm.isDoNotTranslate()
+        + ", \"translation\": \""
+        + glossaryTerm.getTranslations().get(targetBcp47Tag)
+        + "\""
+        + "}";
+  }
+
   private String processOptionalPlaceholderText(
       String promptText, String placeholder, String placeholderValue) {
+    Pattern pattern = patternCache.get(placeholder);
+    Matcher matcher = pattern.matcher(promptText);
     if (placeholderValue != null && !placeholderValue.isEmpty()) {
-      Pattern pattern = patternCache.get(placeholder);
-      Matcher matcher = pattern.matcher(promptText);
       if (matcher.find()) {
         String optionalContent = matcher.group(1) + placeholderValue + matcher.group(2);
         if (matcher.groupCount() > 2) {
@@ -406,14 +517,18 @@ public class OpenAILLMService implements LLMService {
         }
         promptText = matcher.replaceFirst(optionalContent);
       }
-    } else {
-      // Remove the entire template block from the prompt if we have no value for the placeholder,
+    } else if (matcher.find()) {
+      // Remove the entire optional template block from the prompt if we have no value for the
+      // placeholder,
       // also removing new line characters if they exist immediately after the template ends
       String regex =
           "\\{\\{optional: [^\\{\\}]*"
               + Pattern.quote(placeholder)
               + "[^\\{\\}]*\\}\\}\\s*(?:\\r?\\n)?";
       promptText = promptText.replaceAll(regex, "");
+    } else if (placeholderValue != null) {
+      // Replace any instances not in an optional block
+      promptText = promptText.replace(placeholder, placeholderValue);
     }
     return promptText;
   }
@@ -468,9 +583,15 @@ public class OpenAILLMService implements LLMService {
         "\\{\\{optional: ([^\\{\\}]*)"
             + Pattern.quote(CONTEXT_STRING_PLACEHOLDER)
             + "([^\\{\\}]*)\\}\\}(\\s*(?:\\r?\\n)?)";
+    String glossaryTermMatchesPattern =
+        "\\{\\{optional: ([^\\{\\}]*)"
+            + Pattern.quote(GLOSSARY_TERM_MATCHES_PLACEHOLDER)
+            + "([^\\{\\}]*)\\}\\}(\\s*(?:\\r?\\n)?)";
     patternCache.put(COMMENT_STRING_PLACEHOLDER, Pattern.compile(commentPattern));
     patternCache.put(PLURAL_FORM_PLACEHOLDER, Pattern.compile(pluralFormPattern));
     patternCache.put(CONTEXT_STRING_PLACEHOLDER, Pattern.compile(contextPattern));
+    patternCache.put(
+        GLOSSARY_TERM_MATCHES_PLACEHOLDER, Pattern.compile(glossaryTermMatchesPattern));
     llmTranslateRetryConfig =
         Retry.backoff(retryMaxAttempts, Duration.ofSeconds(retryMinDurationSeconds))
             .maxBackoff(Duration.ofSeconds(retryMaxBackoffDurationSeconds))

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -13,6 +13,8 @@ import com.box.l10n.mojito.entity.TmTextUnitPendingMT;
 import com.box.l10n.mojito.rest.ai.AIException;
 import com.box.l10n.mojito.service.ai.LLMService;
 import com.box.l10n.mojito.service.ai.RepositoryLocaleAIPromptRepository;
+import com.box.l10n.mojito.service.thirdparty.smartling.glossary.GlossaryCacheService;
+import com.box.l10n.mojito.service.thirdparty.smartling.glossary.GlossaryTerm;
 import com.box.l10n.mojito.service.tm.AddTMTextUnitCurrentVariantResult;
 import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
@@ -97,6 +99,9 @@ public class AITranslateCronJob implements Job {
   @Autowired JdbcTemplate jdbcTemplate;
 
   @Autowired TextUnitSearcher textUnitSearcher;
+
+  @Autowired(required = false)
+  GlossaryCacheService glossaryCacheService;
 
   @Value("${l10n.ai.translation.job.threads:1}")
   int threads;
@@ -195,9 +200,23 @@ public class AITranslateCronJob implements Job {
                   tmTextUnit.getId(),
                   targetLocale.getBcp47Tag(),
                   repositoryLocaleAIPrompt.getAiPrompt().getId());
-              aiTranslations.add(
-                  executeTranslationPrompt(
-                      tmTextUnit, repository, targetLocale, repositoryLocaleAIPrompt));
+              if (aiTranslationConfiguration.getRepositorySettings(repository.getName()) != null
+                  && aiTranslationConfiguration
+                      .getRepositorySettings(repository.getName())
+                      .isInjectGlossaryMatches()) {
+                aiTranslations.add(
+                    executeGlossaryMatchTranslationPrompt(
+                        tmTextUnit,
+                        repository,
+                        targetLocale,
+                        repositoryLocaleAIPrompt,
+                        glossaryCacheService.getGlossaryTermsInText(tmTextUnit.getContent())));
+              } else {
+                aiTranslations.add(
+                    executeTranslationPrompt(
+                        tmTextUnit, repository, targetLocale, repositoryLocaleAIPrompt));
+              }
+
             } else {
               if (repositoryLocaleAIPrompt != null && repositoryLocaleAIPrompt.isDisabled()) {
                 logger.debug(
@@ -287,6 +306,27 @@ public class AITranslateCronJob implements Job {
     return createAITranslationDTO(tmTextUnit, targetLocale, translation);
   }
 
+  private AITranslation executeGlossaryMatchTranslationPrompt(
+      TMTextUnit tmTextUnit,
+      Repository repository,
+      Locale targetLocale,
+      RepositoryLocaleAIPrompt repositoryLocaleAIPrompt,
+      List<GlossaryTerm> glossaryTerms) {
+    String translation =
+        llmService.translate(
+            tmTextUnit,
+            repository.getSourceLocale().getBcp47Tag(),
+            targetLocale.getBcp47Tag(),
+            repositoryLocaleAIPrompt.getAiPrompt(),
+            glossaryTerms);
+    meterRegistry
+        .counter(
+            "AITranslateCronJob.translate.success",
+            Tags.of("repository", repository.getName(), "locale", targetLocale.getBcp47Tag()))
+        .increment();
+    return createAITranslationDTO(tmTextUnit, targetLocale, translation);
+  }
+
   private AITranslation createAITranslationDTO(
       TMTextUnit tmTextUnit, Locale locale, String translation) {
     AITranslation aiTranslation = new AITranslation();
@@ -348,6 +388,10 @@ public class AITranslateCronJob implements Job {
 
         logger.info("Processing {} pending MTs", pendingMTs.size());
         Queue<TmTextUnitPendingMT> textUnitsToClearPendingMT = new ConcurrentLinkedQueue<>();
+        if (glossaryCacheService != null) {
+          // Load glossary cache from blob storage to ensure it's up to date
+          glossaryCacheService.loadGlossaryCache();
+        }
         List<Long> unusedIds = getUnusedIds(pendingMTs);
         List<CompletableFuture<Void>> futures =
             pendingMTs.stream()

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -210,7 +210,14 @@ public class AITranslateCronJob implements Job {
                         repository,
                         targetLocale,
                         repositoryLocaleAIPrompt,
-                        glossaryCacheService.getGlossaryTermsInText(tmTextUnit.getContent())));
+                        glossaryCacheService
+                            .getGlossaryTermsInText(tmTextUnit.getContent())
+                            .stream()
+                            .filter(
+                                term ->
+                                    term.getLocaleTranslation(targetLocale.getBcp47Tag()) != null
+                                        || term.isDoNotTranslate())
+                            .collect(Collectors.toList())));
               } else {
                 aiTranslations.add(
                     executeTranslationPrompt(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationConfiguration.java
@@ -40,12 +40,22 @@ public class AITranslationConfiguration {
      */
     private boolean reuseSourceOnLanguageMatch = false;
 
+    private boolean injectGlossaryMatches = false;
+
     public Boolean isReuseSourceOnLanguageMatch() {
       return reuseSourceOnLanguageMatch;
     }
 
     public void setReuseSourceOnLanguageMatch(Boolean reuseSourceOnLanguageMatch) {
       this.reuseSourceOnLanguageMatch = reuseSourceOnLanguageMatch;
+    }
+
+    public Boolean isInjectGlossaryMatches() {
+      return injectGlossaryMatches;
+    }
+
+    public void setInjectGlossaryMatches(Boolean injectGlossaryMatches) {
+      this.injectGlossaryMatches = injectGlossaryMatches;
     }
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCache.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCache.java
@@ -51,4 +51,8 @@ public class GlossaryCache implements Serializable {
   public int size() {
     return cache.size();
   }
+
+  public boolean containsKey(String key) {
+    return cache.containsKey(key);
+  }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilder.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheBuilder.java
@@ -79,13 +79,13 @@ public class GlossaryCacheBuilder {
   }
 
   protected void processTerm(GlossaryTerm glossaryTerm, GlossaryCache glossaryCache) {
-    int termWordCount = wordCountService.getEnglishWordCount(glossaryTerm.getTerm());
+    int termWordCount = wordCountService.getEnglishWordCount(glossaryTerm.getText());
     if (termWordCount > glossaryCache.getMaxNGramSize()) {
       logger.debug("Setting glossary cache max ngram size to {}", termWordCount);
       glossaryCache.setMaxNGramSize(termWordCount);
     }
-    logger.debug("Adding term to glossary cache: {}", glossaryTerm.getTerm());
-    glossaryCache.add(stemmer.stem(glossaryTerm.getTerm()), glossaryTerm);
+    logger.debug("Adding term to glossary cache: {}", glossaryTerm.getText());
+    glossaryCache.add(stemmer.stem(glossaryTerm.getText()), glossaryTerm);
   }
 
   List<GlossaryTerm> retrieveTranslationsForGlossaryTerms(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
@@ -44,7 +44,7 @@ public class GlossaryCacheService {
 
     List<String> tokens = List.of(stemmerService.stem(text).split(" "));
 
-    List<Match> matches = findGlossaryMatches(tokens);
+    List<Match> matches = findGlossaryMatches(tokens, text);
     matches = resolveOverlaps(matches);
 
     matches.removeIf(
@@ -62,7 +62,7 @@ public class GlossaryCacheService {
    * @param tokens
    * @return list of {@link Match} objects representing the matches found
    */
-  private List<Match> findGlossaryMatches(List<String> tokens) {
+  private List<Match> findGlossaryMatches(List<String> tokens, String originalText) {
     List<Match> matches = new ArrayList<>();
     for (int length = 1; length <= glossaryCache.getMaxNGramSize(); length++) {
       for (int start = 0; start <= tokens.size() - length; start++) {
@@ -71,7 +71,7 @@ public class GlossaryCacheService {
           List<GlossaryTerm> hits = glossaryCache.get(nGram);
           if (!hits.isEmpty()) {
             if (hits.size() > 1) {
-              matches.add(handleMatchCollision(hits, nGram, start, length));
+              matches.add(handleMatchCollision(hits, originalText, start, length));
             } else {
               matches.add(new Match(start, start + length, hits.getFirst()));
             }
@@ -89,9 +89,9 @@ public class GlossaryCacheService {
    *
    * <p>If no direct match is found, return the first stemmed match.
    */
-  private Match handleMatchCollision(List<GlossaryTerm> hits, String nGram, int start, int length) {
+  private Match handleMatchCollision(List<GlossaryTerm> hits, String text, int start, int length) {
     for (GlossaryTerm hit : hits) {
-      if (hit.getText().equalsIgnoreCase(nGram)) {
+      if (text.toLowerCase().contains(hit.getText().toLowerCase())) {
         return new Match(start, start + length, hit);
       }
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
@@ -99,7 +99,8 @@ public class GlossaryCacheService {
   }
 
   /**
-   * Resolve overlapping matches by prioritizing longer, more specific phrases.
+   * Resolve overlapping matches by prioritizing longer, more specific phrases that fully overlap
+   * other matching terms.
    *
    * @param matches
    * @return list of {@link Match} objects with overlaps resolved
@@ -120,6 +121,8 @@ public class GlossaryCacheService {
       }
 
       if (!fullyOverlaps) {
+        // This match is not fully covered by a previous larger match so it can be added to the
+        // final matches
         finalMatches.add(match);
         for (int i = match.start; i < match.end; i++) {
           coveredIndices.add(i);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheService.java
@@ -1,6 +1,10 @@
 package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -38,9 +42,92 @@ public class GlossaryCacheService {
       loadGlossaryCache();
     }
 
-    // TODO (mallen): Need to handle multiple matches, case sensitive, exact match checking here in
-    // a follow-up PR
-    return glossaryCache.get(stemmerService.stem(text));
+    List<String> tokens = List.of(stemmerService.stem(text).split(" "));
+
+    List<Match> matches = findGlossaryMatches(tokens);
+    matches = resolveOverlaps(matches);
+
+    matches.removeIf(
+        match ->
+            (match.term.isCaseSensitive() && !text.contains(match.term.getText()))
+                || (match.term.isExactMatch()
+                    && !text.toLowerCase().contains(match.term.getText().toLowerCase())));
+
+    return matches.stream().map(match -> match.term).toList();
+  }
+
+  /**
+   * Find all glossary matches in the provided tokens.
+   *
+   * @param tokens
+   * @return list of {@link Match} objects representing the matches found
+   */
+  private List<Match> findGlossaryMatches(List<String> tokens) {
+    List<Match> matches = new ArrayList<>();
+    for (int length = 1; length <= glossaryCache.getMaxNGramSize(); length++) {
+      for (int start = 0; start <= tokens.size() - length; start++) {
+        String nGram = String.join(" ", tokens.subList(start, start + length));
+        if (glossaryCache.containsKey(nGram)) {
+          List<GlossaryTerm> hits = glossaryCache.get(nGram);
+          if (!hits.isEmpty()) {
+            if (hits.size() > 1) {
+              matches.add(handleMatchCollision(hits, nGram, start, length));
+            } else {
+              matches.add(new Match(start, start + length, hits.getFirst()));
+            }
+          }
+        }
+      }
+    }
+
+    return matches;
+  }
+
+  /**
+   * Handle match collisions by checking if the nGram matches any of the matched terms directly (as
+   * they've already been stem matched).
+   *
+   * <p>If no direct match is found, return the first stemmed match.
+   */
+  private Match handleMatchCollision(List<GlossaryTerm> hits, String nGram, int start, int length) {
+    for (GlossaryTerm hit : hits) {
+      if (hit.getText().equalsIgnoreCase(nGram)) {
+        return new Match(start, start + length, hit);
+      }
+    }
+    return new Match(start, start + length, hits.getFirst());
+  }
+
+  /**
+   * Resolve overlapping matches by prioritizing longer, more specific phrases.
+   *
+   * @param matches
+   * @return list of {@link Match} objects with overlaps resolved
+   */
+  private List<Match> resolveOverlaps(List<Match> matches) {
+    matches.sort(Comparator.comparingInt((Match m) -> m.end - m.start).reversed());
+    Set<Integer> coveredIndices = new HashSet<>();
+    List<Match> finalMatches = new ArrayList<>();
+
+    for (Match match : matches) {
+      boolean fullyOverlaps = true;
+
+      for (int i = match.start; i < match.end; i++) {
+        if (!coveredIndices.contains(i)) {
+          fullyOverlaps = false;
+          break;
+        }
+      }
+
+      if (!fullyOverlaps) {
+        finalMatches.add(match);
+        for (int i = match.start; i < match.end; i++) {
+          coveredIndices.add(i);
+        }
+      }
+    }
+
+    return finalMatches;
   }
 
   public void buildGlossaryCache() {
@@ -50,5 +137,22 @@ public class GlossaryCacheService {
 
   public void loadGlossaryCache() {
     glossaryCache = glossaryCacheBlobStorage.getGlossaryCache().orElseGet(GlossaryCache::new);
+  }
+
+  /**
+   * Data structure to hold the start and end indices of a match, along with the matched term.
+   *
+   * <p>This is used to resolve overlapping matches in the text.
+   */
+  private static class Match {
+    final int start;
+    final int end;
+    final GlossaryTerm term;
+
+    Match(int start, int end, GlossaryTerm term) {
+      this.start = start;
+      this.end = end;
+      this.term = term;
+    }
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
@@ -7,7 +7,7 @@ import java.util.Map;
 public class GlossaryTerm implements Serializable {
 
   private Long tmTextUnitId;
-  private String term;
+  private String text;
   private Map<String, String> translations;
   private boolean isExactMatch;
   private boolean isCaseSensitive;
@@ -16,12 +16,12 @@ public class GlossaryTerm implements Serializable {
   public GlossaryTerm() {}
 
   public GlossaryTerm(
-      String term,
+      String text,
       boolean isExactMatch,
       boolean isCaseSensitive,
       boolean isDoNotTranslate,
       Long tmTextUnitId) {
-    this.term = term;
+    this.text = text;
     this.isExactMatch = isExactMatch;
     this.isCaseSensitive = isCaseSensitive;
     this.isDoNotTranslate = isDoNotTranslate;
@@ -41,8 +41,8 @@ public class GlossaryTerm implements Serializable {
     translations.get(bcp47Tag);
   }
 
-  public String getTerm() {
-    return term;
+  public String getText() {
+    return text;
   }
 
   public Map<String, String> getTranslations() {
@@ -65,8 +65,8 @@ public class GlossaryTerm implements Serializable {
     this.tmTextUnitId = tmTextUnitId;
   }
 
-  public void setTerm(String term) {
-    this.term = term;
+  public void setText(String text) {
+    this.text = text;
   }
 
   public void setTranslations(Map<String, String> translations) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
@@ -37,8 +37,8 @@ public class GlossaryTerm implements Serializable {
     translations.put(bcp47Tag, translation);
   }
 
-  public void getLocaleTranslation(String bcp47Tag) {
-    translations.get(bcp47Tag);
+  public String getLocaleTranslation(String bcp47Tag) {
+    return translations.get(bcp47Tag);
   }
 
   public String getText() {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryTerm.java
@@ -84,4 +84,22 @@ public class GlossaryTerm implements Serializable {
   public void setDoNotTranslate(boolean doNotTranslate) {
     isDoNotTranslate = doNotTranslate;
   }
+
+  public String toString() {
+    return "GlossaryTerm{"
+        + "tmTextUnitId="
+        + tmTextUnitId
+        + ", text='"
+        + text
+        + '\''
+        + ", translations="
+        + translations
+        + ", isExactMatch="
+        + isExactMatch
+        + ", isCaseSensitive="
+        + isCaseSensitive
+        + ", isDoNotTranslate="
+        + isDoNotTranslate
+        + '}';
+  }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMServiceTest.java
@@ -849,6 +849,39 @@ class OpenAILLMServiceTest {
   }
 
   @Test
+  void testPromptTemplatingJsonInPromptGlossaryMatchesDNT() {
+    String promptText =
+        """
+           Translate the following source string from [mojito_source_locale] to [mojito_target_locale]:
+           Source string: [mojito_source_string]
+           {{{optional: "comment": "[mojito_comment_string]",}} {{optional: "context": "[mojito_context_string]",}} {{optional: "plural_form": "[mojito_plural_form]"}}}
+           {{optional: The glossary matches are: [mojito_glossary_term_matches]. }}
+           """;
+
+    PluralForm one = new PluralForm();
+    one.setName("one");
+    TMTextUnit tmTextUnit = new TMTextUnit();
+    tmTextUnit.setId(1L);
+    tmTextUnit.setContent("Hello");
+    tmTextUnit.setComment("A friendly greeting");
+    tmTextUnit.setPluralForm(one);
+    GlossaryTerm glossaryTerm = new GlossaryTerm();
+    glossaryTerm.setText("Hello");
+    glossaryTerm.setDoNotTranslate(true);
+    glossaryTerm.setTranslations(Collections.singletonMap("fr", null));
+    String prompt =
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.singletonList(glossaryTerm));
+    assertEquals(
+        """
+                         Translate the following source string from en to fr:
+                         Source string: Hello
+                         {"comment": "A friendly greeting", "plural_form": "one"}
+                         The glossary matches are: [{"text": "Hello", "isExactMatch": false, "isCaseSensitive": false, "isDoNotTranslate": true, "translation": "Hello"}].""",
+        prompt);
+  }
+
+  @Test
   void testPromptTemplatingInlineSentence() {
     String promptText =
         """

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMServiceTest.java
@@ -19,8 +19,10 @@ import com.box.l10n.mojito.rest.ai.AIException;
 import com.box.l10n.mojito.service.ai.AIStringCheckRepository;
 import com.box.l10n.mojito.service.ai.LLMPromptService;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import com.box.l10n.mojito.service.thirdparty.smartling.glossary.GlossaryTerm;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -588,6 +590,7 @@ class OpenAILLMServiceTest {
         """
          Translate the following source string from [mojito_source_locale] to [mojito_target_locale]:
          Source string: [mojito_source_string]
+         Glossary matches: [mojito_glossary_term_matches]
          {{optional: Comment: [mojito_comment_string]}}
          {{optional: Context: [mojito_context_string]}}
          {{optional: Plural form: [mojito_plural_form]}}
@@ -602,11 +605,13 @@ class OpenAILLMServiceTest {
     tmTextUnit.setName("Hello --- some.id");
     tmTextUnit.setPluralForm(one);
     String prompt =
-        openAILLMService.getTranslationFormattedPrompt(promptText, tmTextUnit, "en", "fr");
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
     assertEquals(
         """
          Translate the following source string from en to fr:
          Source string: Hello
+         Glossary matches: []
          Comment: A friendly greeting
          Context: some.id
          Plural form: one""",
@@ -633,7 +638,8 @@ class OpenAILLMServiceTest {
     tmTextUnit.setName("Hello");
     tmTextUnit.setPluralForm(one);
     String prompt =
-        openAILLMService.getTranslationFormattedPrompt(promptText, tmTextUnit, "en", "fr");
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
     assertEquals(
         """
              Translate the following source string from en to fr:
@@ -660,7 +666,8 @@ class OpenAILLMServiceTest {
     tmTextUnit.setComment("A friendly greeting");
     tmTextUnit.setName("Hello --- some.id");
     String prompt =
-        openAILLMService.getTranslationFormattedPrompt(promptText, tmTextUnit, "en", "fr");
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
     assertEquals(
         """
                  Translate the following source string from en to fr:
@@ -689,7 +696,8 @@ class OpenAILLMServiceTest {
     tmTextUnit.setName("Hello --- some.id");
     tmTextUnit.setPluralForm(one);
     String prompt =
-        openAILLMService.getTranslationFormattedPrompt(promptText, tmTextUnit, "en", "fr");
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
     assertEquals(
         """
              Translate the following source string from en to fr:
@@ -716,7 +724,8 @@ class OpenAILLMServiceTest {
     tmTextUnit.setName("Hello --- some.id");
     tmTextUnit.setPluralForm(one);
     String prompt =
-        openAILLMService.getTranslationFormattedPrompt(promptText, tmTextUnit, "en", "fr");
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
     assertEquals(
         """
              Translate the following source string from en to fr:
@@ -742,7 +751,8 @@ class OpenAILLMServiceTest {
     tmTextUnit.setComment("A friendly greeting");
     tmTextUnit.setPluralForm(one);
     String prompt =
-        openAILLMService.getTranslationFormattedPrompt(promptText, tmTextUnit, "en", "fr");
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
     assertEquals(
         """
              Translate the following source string from en to fr:
@@ -769,7 +779,8 @@ class OpenAILLMServiceTest {
     tmTextUnit.setName("Hello --- some.id");
     tmTextUnit.setPluralForm(one);
     String prompt =
-        openAILLMService.getTranslationFormattedPrompt(promptText, tmTextUnit, "en", "fr");
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
     assertEquals(
         """
              Translate the following source string from en to fr:
@@ -795,12 +806,45 @@ class OpenAILLMServiceTest {
     tmTextUnit.setComment("A friendly greeting");
     tmTextUnit.setPluralForm(one);
     String prompt =
-        openAILLMService.getTranslationFormattedPrompt(promptText, tmTextUnit, "en", "fr");
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
     assertEquals(
         """
                  Translate the following source string from en to fr:
                  Source string: Hello
                  {"comment": "A friendly greeting", "plural_form": "one"}""",
+        prompt);
+  }
+
+  @Test
+  void testPromptTemplatingJsonInPromptGlossaryMatches() {
+    String promptText =
+        """
+       Translate the following source string from [mojito_source_locale] to [mojito_target_locale]:
+       Source string: [mojito_source_string]
+       {{{optional: "comment": "[mojito_comment_string]",}} {{optional: "context": "[mojito_context_string]",}} {{optional: "plural_form": "[mojito_plural_form]"}}}
+       {{optional: The glossary matches are: [mojito_glossary_term_matches]. }}
+       """;
+
+    PluralForm one = new PluralForm();
+    one.setName("one");
+    TMTextUnit tmTextUnit = new TMTextUnit();
+    tmTextUnit.setId(1L);
+    tmTextUnit.setContent("Hello");
+    tmTextUnit.setComment("A friendly greeting");
+    tmTextUnit.setPluralForm(one);
+    GlossaryTerm glossaryTerm = new GlossaryTerm();
+    glossaryTerm.setText("Hello");
+    glossaryTerm.setTranslations(Collections.singletonMap("fr", "Bonjour"));
+    String prompt =
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.singletonList(glossaryTerm));
+    assertEquals(
+        """
+                     Translate the following source string from en to fr:
+                     Source string: Hello
+                     {"comment": "A friendly greeting", "plural_form": "one"}
+                     The glossary matches are: [{"text": "Hello", "isExactMatch": false, "isCaseSensitive": false, "isDoNotTranslate": false, "translation": "Bonjour"}].""",
         prompt);
   }
 
@@ -822,12 +866,81 @@ class OpenAILLMServiceTest {
     tmTextUnit.setName("Hello");
     tmTextUnit.setPluralForm(one);
     String prompt =
-        openAILLMService.getTranslationFormattedPrompt(promptText, tmTextUnit, "en", "fr");
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
     assertEquals(
         """
                  Translate the following source string from en to fr:
                  Source string: Hello
                  The comment is: A friendly greeting. The plural form is: one.""",
+        prompt);
+  }
+
+  @Test
+  void testPromptTemplatingGlossaryMatchesInlineSentence() {
+    String promptText =
+        """
+                     Translate the following source string from [mojito_source_locale] to [mojito_target_locale]:
+                     Source string: [mojito_source_string]
+                     {{optional: The comment is: [mojito_comment_string]. }}{{optional: The context is: [mojito_context_string]. }}{{optional: The plural form is: [mojito_plural_form]. }}
+                     {{optional: The glossary matches are: [mojito_glossary_term_matches]. }}
+                     """;
+
+    PluralForm one = new PluralForm();
+    one.setName("one");
+    TMTextUnit tmTextUnit = new TMTextUnit();
+    tmTextUnit.setId(1L);
+    tmTextUnit.setContent("Hello");
+    tmTextUnit.setComment(null);
+    tmTextUnit.setName("Hello");
+    tmTextUnit.setPluralForm(null);
+    GlossaryTerm glossaryTerm = new GlossaryTerm();
+    glossaryTerm.setText("Hello");
+    glossaryTerm.setTranslations(Collections.singletonMap("fr", "Bonjour"));
+    String prompt =
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.singletonList(glossaryTerm));
+    assertEquals(
+        """
+                Translate the following source string from en to fr:
+                Source string: Hello
+                The glossary matches are: [{"text": "Hello", "isExactMatch": false, "isCaseSensitive": false, "isDoNotTranslate": false, "translation": "Bonjour"}].""",
+        prompt);
+  }
+
+  @Test
+  void testPromptTemplatingMultipleGlossaryMatches() {
+    String promptText =
+        """
+                         Translate the following source string from [mojito_source_locale] to [mojito_target_locale]:
+                         Source string: [mojito_source_string]
+                         {{optional: The comment is: [mojito_comment_string]. }}{{optional: The context is: [mojito_context_string]. }}{{optional: The plural form is: [mojito_plural_form]. }}
+                         {{optional: The glossary matches are: [mojito_glossary_term_matches]. }}
+                         """;
+
+    PluralForm one = new PluralForm();
+    one.setName("one");
+    TMTextUnit tmTextUnit = new TMTextUnit();
+    tmTextUnit.setId(1L);
+    tmTextUnit.setContent("Hello");
+    tmTextUnit.setComment(null);
+    tmTextUnit.setName("Hello");
+    tmTextUnit.setPluralForm(null);
+    GlossaryTerm glossaryTerm = new GlossaryTerm();
+    glossaryTerm.setText("Hello");
+    glossaryTerm.setTranslations(Collections.singletonMap("fr", "Bonjour"));
+    GlossaryTerm glossaryTerm2 = new GlossaryTerm();
+    glossaryTerm2.setText("Another term");
+    glossaryTerm2.setCaseSensitive(true);
+    glossaryTerm2.setTranslations(Collections.singletonMap("fr", "Another term translation"));
+    String prompt =
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", List.of(glossaryTerm, glossaryTerm2));
+    assertEquals(
+        """
+                    Translate the following source string from en to fr:
+                    Source string: Hello
+                    The glossary matches are: [{"text": "Hello", "isExactMatch": false, "isCaseSensitive": false, "isDoNotTranslate": false, "translation": "Bonjour"}, {"text": "Another term", "isExactMatch": false, "isCaseSensitive": true, "isDoNotTranslate": false, "translation": "Another term translation"}].""",
         prompt);
   }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMServiceTest.java
@@ -844,7 +844,7 @@ class OpenAILLMServiceTest {
                      Translate the following source string from en to fr:
                      Source string: Hello
                      {"comment": "A friendly greeting", "plural_form": "one"}
-                     The glossary matches are: [{"text": "Hello", "isExactMatch": false, "isCaseSensitive": false, "isDoNotTranslate": false, "translation": "Bonjour"}].""",
+                     The glossary matches are: [{"text":"Hello","isExactMatch":false,"isCaseSensitive":false,"isDoNotTranslate":false,"translation":"Bonjour"}].""",
         prompt);
   }
 
@@ -877,7 +877,7 @@ class OpenAILLMServiceTest {
                          Translate the following source string from en to fr:
                          Source string: Hello
                          {"comment": "A friendly greeting", "plural_form": "one"}
-                         The glossary matches are: [{"text": "Hello", "isExactMatch": false, "isCaseSensitive": false, "isDoNotTranslate": true, "translation": "Hello"}].""",
+                         The glossary matches are: [{"text":"Hello","isExactMatch":false,"isCaseSensitive":false,"isDoNotTranslate":true,"translation":"Hello"}].""",
         prompt);
   }
 
@@ -937,7 +937,7 @@ class OpenAILLMServiceTest {
         """
                 Translate the following source string from en to fr:
                 Source string: Hello
-                The glossary matches are: [{"text": "Hello", "isExactMatch": false, "isCaseSensitive": false, "isDoNotTranslate": false, "translation": "Bonjour"}].""",
+                The glossary matches are: [{"text":"Hello","isExactMatch":false,"isCaseSensitive":false,"isDoNotTranslate":false,"translation":"Bonjour"}].""",
         prompt);
   }
 
@@ -973,7 +973,7 @@ class OpenAILLMServiceTest {
         """
                     Translate the following source string from en to fr:
                     Source string: Hello
-                    The glossary matches are: [{"text": "Hello", "isExactMatch": false, "isCaseSensitive": false, "isDoNotTranslate": false, "translation": "Bonjour"}, {"text": "Another term", "isExactMatch": false, "isCaseSensitive": true, "isDoNotTranslate": false, "translation": "Another term translation"}].""",
+                    The glossary matches are: [{"text":"Hello","isExactMatch":false,"isCaseSensitive":false,"isDoNotTranslate":false,"translation":"Bonjour"},{"text":"Another term","isExactMatch":false,"isCaseSensitive":true,"isDoNotTranslate":false,"translation":"Another term translation"}].""",
         prompt);
   }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/glossary/GlossaryCacheServiceTest.java
@@ -1,0 +1,121 @@
+package com.box.l10n.mojito.service.thirdparty.smartling.glossary;
+
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class GlossaryCacheServiceTest {
+
+  private final GlossaryCacheBlobStorage glossaryCacheBlobStorage =
+      Mockito.mock(GlossaryCacheBlobStorage.class);
+  private final StemmerService stemmerService = new StemmerService();
+  private final GlossaryCacheBuilder glossaryCacheBuilder =
+      Mockito.mock(GlossaryCacheBuilder.class);
+  private final GlossaryCacheService glossaryCacheService =
+      new GlossaryCacheService(glossaryCacheBlobStorage, glossaryCacheBuilder, stemmerService);
+
+  private final String exactMatch = "exact match";
+  private final String caseSensitive = "Case sensitive";
+  private final String doNotTranslate = "Do not translate";
+  private final String termMatch = "term match";
+  private final String matchChain = "match chain";
+
+  @BeforeEach
+  public void setUp() {
+    Map<String, List<GlossaryTerm>> map = new HashMap<>();
+    map.put(
+        stemmerService.stem(exactMatch),
+        List.of(new GlossaryTerm(exactMatch, true, false, false, 1L)));
+    map.put(
+        stemmerService.stem(caseSensitive),
+        List.of(new GlossaryTerm(caseSensitive, true, true, false, 2L)));
+    map.put(
+        stemmerService.stem(doNotTranslate),
+        List.of(new GlossaryTerm(doNotTranslate, false, false, true, 3L)));
+    map.put(
+        stemmerService.stem(termMatch),
+        List.of(new GlossaryTerm(termMatch, false, false, false, 4L)));
+    map.put(
+        stemmerService.stem(matchChain),
+        List.of(new GlossaryTerm(matchChain, false, false, false, 5L)));
+    GlossaryCache glossaryCache = new GlossaryCache();
+    glossaryCache.setMaxNGramSize(10);
+    glossaryCache.setCache(map);
+
+    when(glossaryCacheBlobStorage.getGlossaryCache()).thenReturn(Optional.of(glossaryCache));
+  }
+
+  @Test
+  void testExactMatchMatching() {
+
+    List<GlossaryTerm> result = glossaryCacheService.getGlossaryTermsInText(exactMatch);
+
+    Assertions.assertEquals(1, result.size());
+    Assertions.assertEquals(exactMatch, result.getFirst().getText());
+  }
+
+  @Test
+  void testGlossaryTermsAreNotRetrievedForTextWithNoMatch() {
+
+    List<GlossaryTerm> result = glossaryCacheService.getGlossaryTermsInText("no match");
+
+    Assertions.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testCaseSensitiveMatching() {
+    List<GlossaryTerm> result = glossaryCacheService.getGlossaryTermsInText(caseSensitive);
+
+    Assertions.assertEquals(1, result.size());
+    Assertions.assertEquals(caseSensitive, result.getFirst().getText());
+  }
+
+  @Test
+  void testOverlappingGlossaryTermsAreResolvedByLongestMatch() {
+
+    GlossaryCache glossaryCache = glossaryCacheBlobStorage.getGlossaryCache().get();
+    glossaryCache.add(
+        stemmerService.stem("longer match"),
+        new GlossaryTerm("longer match", false, false, false, 7L));
+    glossaryCache.add(
+        stemmerService.stem("match"), new GlossaryTerm("match", false, false, false, 8L));
+
+    List<GlossaryTerm> result = glossaryCacheService.getGlossaryTermsInText("longer match");
+
+    Assertions.assertEquals(1, result.size());
+    Assertions.assertEquals("longer match", result.getFirst().getText());
+  }
+
+  @Test
+  void testChainedMatchesAreBothReturned() {
+    List<GlossaryTerm> result = glossaryCacheService.getGlossaryTermsInText("term match chain");
+
+    Assertions.assertEquals(2, result.size());
+    Assertions.assertTrue(result.stream().anyMatch(term -> term.getText().equals(termMatch)));
+    Assertions.assertTrue(result.stream().anyMatch(term -> term.getText().equals(matchChain)));
+  }
+
+  @Test
+  void testCaseSensitiveOverridesExactMatchIfBothConfigured() {
+    List<GlossaryTerm> result = glossaryCacheService.getGlossaryTermsInText("Case Sensitive");
+
+    Assertions.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testEmptyListReturnedIfNoGlossaryInBlobStorage() {
+    when(glossaryCacheBlobStorage.getGlossaryCache()).thenReturn(Optional.empty());
+    glossaryCacheService.loadGlossaryCache();
+
+    Assertions.assertNotNull(glossaryCacheService.getGlossaryTermsInText(""));
+  }
+
+  // TODO(mallen): Test whitespace matching, emojis etc
+}


### PR DESCRIPTION
Adds functionality to inject glossary term matches and their relevant translation into a translation AI prompt, to allow AI prompts to utilise Glossary translations as part of the translation process.