### PR TITLE
[Safe-I18N] Send branch notifications after the branch is linked to the commit that landed the translations

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticService.java
@@ -490,7 +490,7 @@ public class BranchStatisticService {
   }
 
   @Async("statisticsTaskExecutor")
-  CompletableFuture<PollableFuture<Void>> scheduleBranchNotification(Branch branch) {
+  public CompletableFuture<PollableFuture<Void>> scheduleBranchNotification(Branch branch) {
     BranchNotificationJobInput branchNotificationJobInput = new BranchNotificationJobInput();
     branchNotificationJobInput.setBranchId(branch.getId());
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitService.java
@@ -15,6 +15,8 @@ import com.box.l10n.mojito.rest.View;
 import com.box.l10n.mojito.rest.commit.CommitWithNameNotFoundException;
 import com.box.l10n.mojito.rest.repository.RepositoryWithIdNotFoundException;
 import com.box.l10n.mojito.service.appender.AppendedAssetBlobStorage;
+import com.box.l10n.mojito.service.branch.BranchRepository;
+import com.box.l10n.mojito.service.branch.BranchStatisticService;
 import com.box.l10n.mojito.service.pullrun.PullRunRepository;
 import com.box.l10n.mojito.service.pullrun.PullRunWithNameNotFoundException;
 import com.box.l10n.mojito.service.pushrun.PushRunRepository;
@@ -56,6 +58,8 @@ public class CommitService {
   final RepositoryRepository repositoryRepository;
   final AppendedAssetBlobStorage appendedAssetBlobStorage;
   private final JdbcTemplate jdbcTemplate;
+  private final BranchStatisticService branchStatisticService;
+  private final BranchRepository branchRepository;
 
   @Value("${l10n.commit.branchAppend.batchSize:100}")
   int batchSize;
@@ -68,7 +72,9 @@ public class CommitService {
       PullRunRepository pullRunRepository,
       RepositoryRepository repositoryRepository,
       AppendedAssetBlobStorage appendedAssetBlobStorage,
-      JdbcTemplate jdbcTemplate) {
+      JdbcTemplate jdbcTemplate,
+      BranchStatisticService branchStatisticService,
+      BranchRepository branchRepository) {
     this.commitRepository = commitRepository;
     this.commitToPushRunRepository = commitToPushRunRepository;
     this.commitToPullRunRepository = commitToPullRunRepository;
@@ -77,6 +83,8 @@ public class CommitService {
     this.repositoryRepository = repositoryRepository;
     this.appendedAssetBlobStorage = appendedAssetBlobStorage;
     this.jdbcTemplate = jdbcTemplate;
+    this.branchStatisticService = branchStatisticService;
+    this.branchRepository = branchRepository;
   }
 
   /**
@@ -322,5 +330,14 @@ public class CommitService {
 
               jdbcTemplate.update(sql, params.toArray());
             });
+
+    // Send out branch notifications immediately as we can't guarantee when the next branch stats
+    // will run
+    branchIds.forEach(
+        branchId -> {
+          branchRepository
+              .findById(branchId)
+              .ifPresent(branchStatisticService::scheduleBranchNotification);
+        });
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/commit/CommitService.java
@@ -58,7 +58,7 @@ public class CommitService {
   final RepositoryRepository repositoryRepository;
   final AppendedAssetBlobStorage appendedAssetBlobStorage;
   private final JdbcTemplate jdbcTemplate;
-  private final BranchStatisticService branchStatisticService;
+  protected BranchStatisticService branchStatisticService;
   private final BranchRepository branchRepository;
 
   @Value("${l10n.commit.branchAppend.batchSize:100}")

--- a/webapp/src/test/java/com/box/l10n/mojito/service/commit/CommitServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/commit/CommitServiceTest.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.service.commit;
 
+import static org.mockito.ArgumentMatchers.any;
+
 import com.box.l10n.mojito.entity.Branch;
 import com.box.l10n.mojito.entity.BranchMergeTarget;
 import com.box.l10n.mojito.entity.Commit;
@@ -9,6 +11,7 @@ import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.service.appender.AppendedAssetBlobStorage;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import com.box.l10n.mojito.service.branch.BranchMergeTargetRepository;
+import com.box.l10n.mojito.service.branch.BranchStatisticService;
 import com.box.l10n.mojito.service.branch.BranchTestData;
 import com.box.l10n.mojito.service.pullrun.PullRunRepository;
 import com.box.l10n.mojito.service.pushrun.PushRunRepository;
@@ -22,7 +25,9 @@ import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 /**
  * @author garion
@@ -46,6 +51,8 @@ public class CommitServiceTest extends ServiceTestBase {
   @Autowired BranchMergeTargetRepository branchMergeTargetRepository;
 
   @Autowired AppendedAssetBlobStorage appendedAssetBlobStorage;
+
+  @MockBean BranchStatisticService branchStatisticServiceMock;
 
   @Test
   public void testGetCommitWithNameAndRepository() throws Exception {
@@ -529,6 +536,7 @@ public class CommitServiceTest extends ServiceTestBase {
         appendTextUnitId, List.of(branch1.getId(), branch2.getId()));
 
     commitService.associateAppendedBranchesToCommit(appendTextUnitId, newCommit);
+    Mockito.verify(branchStatisticServiceMock, Mockito.times(3)).scheduleBranchNotification(any());
 
     // The old commit should still be linked to branch1, not the new commit
     Assert.assertEquals(


### PR DESCRIPTION
Schedules the branch notification job for each branch appended after the commit was linked to the branch in the `branch_merge_target` table.