### PR TITLE
[Safe-I18N] Fix possibility of AssetAppenderService appending duplicate text units 

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
@@ -104,9 +104,8 @@ public class AssetAppenderService {
 
     AbstractAssetAppender appender = assetAppender.get();
 
-    // Used to check if a text unit already exists in the pushed up asset - if it is we don't
-    // append it. Having duplicate source text units causes the compilation step from po to mo to
-    // fail.
+    // Checks if a text unit already exists in the uploaded asset; if it does, we avoid appending
+    // it. Duplicate source text units can cause the po-to-mo compilation process to fail.
     HashSet<Long> lastPushRunTextUnits =
         new HashSet<>(
             pushRunRepository.getAllTextUnitIdsFromLastPushRunByRepositoryId(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
@@ -104,6 +104,9 @@ public class AssetAppenderService {
 
     AbstractAssetAppender appender = assetAppender.get();
 
+    // Used to check if a text unit already exists in the pushed up asset - if it is we don't
+    // append it. Having duplicate source text units causes the compilation step from po to mo to
+    // fail.
     HashSet<Long> lastPushRunTextUnits =
         new HashSet<>(
             pushRunRepository.getAllTextUnitIdsFromLastPushRunByRepositoryId(
@@ -172,6 +175,9 @@ public class AssetAppenderService {
 
       appendedTextUnitCount += textUnitsToAppend.size();
       appendedBranches.add(branch);
+      // Avoids appending duplicate text units if multiple branches add the same text unit
+      lastPushRunTextUnits.addAll(
+          textUnitsToAppend.stream().map(TextUnitDTO::getTmTextUnitId).toList());
     }
 
     String appendedAssetContent = appender.getAssetContent();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
@@ -107,7 +107,7 @@ public class AssetAppenderService {
     // Checks if a text unit already exists in the uploaded asset; if it does, we avoid appending
     // it. Duplicate text units in the translated asset can cause the po-to-mo compilation process
     // to fail.
-    HashSet<Long> lastPushRunTextUnits =
+    HashSet<Long> textUnitIdsInSourceAsset =
         new HashSet<>(
             pushRunRepository.getAllTextUnitIdsFromLastPushRunByRepositoryId(
                 asset.getRepository().getId()));
@@ -133,7 +133,7 @@ public class AssetAppenderService {
       // Filter text units by removing ones in the last push run
       textUnitsToAppend =
           textUnitsToAppend.stream()
-              .filter(tu -> !lastPushRunTextUnits.contains(tu.getTmTextUnitId()))
+              .filter(tu -> !textUnitIdsInSourceAsset.contains(tu.getTmTextUnitId()))
               .toList();
 
       // Are we going to go over the hard limit ? If yes emit metrics and break out.
@@ -176,7 +176,7 @@ public class AssetAppenderService {
       appendedTextUnitCount += textUnitsToAppend.size();
       appendedBranches.add(branch);
       // Avoids appending duplicate text units if multiple branches add the same text unit
-      lastPushRunTextUnits.addAll(
+      textUnitIdsInSourceAsset.addAll(
           textUnitsToAppend.stream().map(TextUnitDTO::getTmTextUnitId).toList());
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
@@ -105,7 +105,8 @@ public class AssetAppenderService {
     AbstractAssetAppender appender = assetAppender.get();
 
     // Checks if a text unit already exists in the uploaded asset; if it does, we avoid appending
-    // it. Duplicate source text units can cause the po-to-mo compilation process to fail.
+    // it. Duplicate text units in the translated asset can cause the po-to-mo compilation process
+    // to fail.
     HashSet<Long> lastPushRunTextUnits =
         new HashSet<>(
             pushRunRepository.getAllTextUnitIdsFromLastPushRunByRepositoryId(

--- a/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -129,17 +130,25 @@ public class AssetAppenderServiceTest {
               branches.add(branch);
             });
 
-    List<TextUnitDTO> textUnits =
-        IntStream.range(1, 3)
-            .mapToObj(
-                i -> {
-                  TextUnitDTO textUnitDTO = new TextUnitDTO();
-                  textUnitDTO.setSource(content + i);
-                  return textUnitDTO;
-                })
-            .toList();
+    AtomicInteger i = new AtomicInteger(1);
+    branches.forEach(
+        branch -> {
+          // Return 2 unique text units for each branch
+          List<TextUnitDTO> textUnits =
+              IntStream.range(i.get(), i.get() + 2)
+                  .mapToObj(
+                      x -> {
+                        TextUnitDTO textUnitDTO = new TextUnitDTO();
+                        textUnitDTO.setSource(content + x);
+                        textUnitDTO.setTmTextUnitId(Integer.toUnsignedLong(x));
+                        return textUnitDTO;
+                      })
+                  .toList();
 
-    when(branchStatisticServiceMock.getTextUnitDTOsForBranch(any())).thenReturn(textUnits);
+          when(branchStatisticServiceMock.getTextUnitDTOsForBranch(branch)).thenReturn(textUnits);
+          i.addAndGet(2);
+        });
+
     when(branchRepositoryMock.findBranchesForAppending(any())).thenReturn(branches);
 
     assetAppenderService.appendBranchTextUnitsToSource(
@@ -168,20 +177,28 @@ public class AssetAppenderServiceTest {
               branches.add(branch);
             });
 
-    // Return 2 text units each time per branch to be appended
-    List<TextUnitDTO> textUnits =
-        IntStream.range(1, 3)
-            .mapToObj(
-                i -> {
-                  TextUnitDTO textUnitDTO = new TextUnitDTO();
-                  textUnitDTO.setSource(content + i);
-                  return textUnitDTO;
-                })
-            .toList();
+    AtomicInteger i = new AtomicInteger(1);
+    branches.forEach(
+        branch -> {
+          // Return unique text units for each branch
+          List<TextUnitDTO> textUnits =
+              IntStream.range(i.get(), i.get() + 2)
+                  .mapToObj(
+                      x -> {
+                        TextUnitDTO textUnitDTO = new TextUnitDTO();
+                        textUnitDTO.setSource(content + x);
+                        textUnitDTO.setTmTextUnitId(Integer.toUnsignedLong(x));
+                        return textUnitDTO;
+                      })
+                  .toList();
+
+          when(branchStatisticServiceMock.getTextUnitDTOsForBranch(branch)).thenReturn(textUnits);
+          i.addAndGet(2);
+        });
 
     assetAppenderService.DEFAULT_APPEND_LIMIT = 10;
 
-    when(branchStatisticServiceMock.getTextUnitDTOsForBranch(any())).thenReturn(textUnits);
+    //    when(branchStatisticServiceMock.getTextUnitDTOsForBranch(any())).thenReturn(textUnits);
     when(branchRepositoryMock.findBranchesForAppending(any())).thenReturn(branches);
 
     assetAppenderService.appendBranchTextUnitsToSource(
@@ -194,5 +211,46 @@ public class AssetAppenderServiceTest {
     verify(appendCountCounterMock, times(1)).increment(10);
     verify(exceedCountCounterMock, times(1)).increment(14);
     verify(exceedBranchCountCounterMock, times(1)).increment(7);
+  }
+
+  @Test
+  public void testDontAppendDuplicateTextUnits() {
+    POTAssetAppender potAssetAppenderMock = mock(POTAssetAppender.class);
+    when(assetAppenderFactory.fromExtension(extension, content))
+        .thenReturn(Optional.of(potAssetAppenderMock));
+
+    List<Branch> branches = new ArrayList<>();
+
+    IntStream.range(1, 4)
+        .forEach(
+            i -> {
+              Branch branch = new Branch();
+              branch.setName("branch" + i);
+              branches.add(branch);
+            });
+
+    List<TextUnitDTO> textUnits =
+        IntStream.range(1, 3)
+            .mapToObj(
+                i -> {
+                  TextUnitDTO textUnitDTO = new TextUnitDTO();
+                  textUnitDTO.setSource(content + i);
+                  textUnitDTO.setTmTextUnitId(Integer.toUnsignedLong(i));
+                  return textUnitDTO;
+                })
+            .toList();
+
+    // For every branch, return the same 2 text units for appending
+    when(branchStatisticServiceMock.getTextUnitDTOsForBranch(any())).thenReturn(textUnits);
+    when(branchRepositoryMock.findBranchesForAppending(any())).thenReturn(branches);
+
+    assetAppenderService.appendBranchTextUnitsToSource(
+        asset, localizedAssetBody.getAppendBranchTextUnitsId(), content);
+
+    verify(potAssetAppenderMock, times(3)).appendTextUnits(any());
+    verify(meterRegistryMock, times(2)).counter(Mockito.anyString(), isA(Iterable.class));
+    // Make sure the appended count is only 2 as the text units were duplicates
+    verify(appendCountCounterMock, times(1)).increment(2);
+    verify(appendBranchCountCounterMock, times(1)).increment(3);
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
@@ -198,7 +198,6 @@ public class AssetAppenderServiceTest {
 
     assetAppenderService.DEFAULT_APPEND_LIMIT = 10;
 
-    //    when(branchStatisticServiceMock.getTextUnitDTOsForBranch(any())).thenReturn(textUnits);
     when(branchRepositoryMock.findBranchesForAppending(any())).thenReturn(branches);
 
     assetAppenderService.appendBranchTextUnitsToSource(


### PR DESCRIPTION
If multiple branches have added the same text unit it would have been appended over and over to the source asset. The translated asset won't compile to `mo` if there are duplicate text units. This PR adds the appended text units to the local push run text units set after each branch append.