### PR TITLE
[Safe-I18N] Fix for scenario of appending a duplicated text unit with a different comment

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.service.appender;
 import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.BaseEntity;
 import com.box.l10n.mojito.entity.Branch;
+import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.service.branch.BranchRepository;
 import com.box.l10n.mojito.service.branch.BranchStatisticService;
 import com.box.l10n.mojito.service.pushrun.PushRunRepository;
@@ -11,9 +12,10 @@ import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import joptsimple.internal.Strings;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
@@ -118,12 +120,10 @@ public class AssetAppenderService {
     // scenarios where appending a text unit with a different comment could cause po-to-mo
     // compilation failures. This also makes sure text units that already exist in the source aren't
     // being appended again.
-    HashSet<String> textUnitNamesInSourceAsset = new HashSet<>();
-
-    // Put all text unit names in the last push run into the source asset set
-    tmTextUnitRepository
-        .findAllById(textUnitIdsInLastPushRun)
-        .forEach(tmTextUnit -> textUnitNamesInSourceAsset.add(tmTextUnit.getName()));
+    Set<String> textUnitNamesInSourceAsset =
+        tmTextUnitRepository.findAllById(textUnitIdsInLastPushRun).stream()
+            .map(TMTextUnit::getName)
+            .collect(Collectors.toSet());
 
     // Fetch all branches to be appended, sorted by translated date in ascending order to ensure
     // older translated branches make it in

--- a/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
@@ -6,6 +6,7 @@ import com.box.l10n.mojito.entity.Branch;
 import com.box.l10n.mojito.service.branch.BranchRepository;
 import com.box.l10n.mojito.service.branch.BranchStatisticService;
 import com.box.l10n.mojito.service.pushrun.PushRunRepository;
+import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
@@ -45,6 +46,7 @@ public class AssetAppenderService {
   private final AppendedAssetBlobStorage appendedAssetBlobStorage;
   private final MeterRegistry meterRegistry;
   private final AssetAppenderConfig assetAppenderConfig;
+  private final TMTextUnitRepository tmTextUnitRepository;
 
   @Autowired
   public AssetAppenderService(
@@ -54,7 +56,8 @@ public class AssetAppenderService {
       PushRunRepository pushRunRepository,
       AppendedAssetBlobStorage appendedAssetBlobStorage,
       MeterRegistry meterRegistry,
-      AssetAppenderConfig assetAppenderConfig) {
+      AssetAppenderConfig assetAppenderConfig,
+      TMTextUnitRepository tmTextUnitRepository) {
     this.assetAppenderFactory = assetAppenderFactory;
     this.branchRepository = branchRepository;
     this.branchStatisticService = branchStatisticService;
@@ -62,6 +65,7 @@ public class AssetAppenderService {
     this.appendedAssetBlobStorage = appendedAssetBlobStorage;
     this.meterRegistry = meterRegistry;
     this.assetAppenderConfig = assetAppenderConfig;
+    this.tmTextUnitRepository = tmTextUnitRepository;
   }
 
   /**
@@ -104,13 +108,22 @@ public class AssetAppenderService {
 
     AbstractAssetAppender appender = assetAppender.get();
 
-    // Checks if a text unit already exists in the uploaded asset; if it does, we avoid appending
-    // it. Duplicate text units in the translated asset can cause the po-to-mo compilation process
-    // to fail.
-    HashSet<Long> textUnitIdsInSourceAsset =
-        new HashSet<>(
-            pushRunRepository.getAllTextUnitIdsFromLastPushRunByRepositoryId(
-                asset.getRepository().getId()));
+    List<Long> textUnitIdsInLastPushRun =
+        pushRunRepository.getAllTextUnitIdsFromLastPushRunByRepositoryId(
+            asset.getRepository().getId());
+
+    // The text unit name (formatted as "source --- context") is used to detect duplicates, since PO
+    // files treat the combination of msgid and context as unique identifiers for text units.
+    // Mojito generates a new text unit if the comment differs or is present. This prevents
+    // scenarios where appending a text unit with a different comment could cause po-to-mo
+    // compilation failures. This also makes sure text units that already exist in the source aren't
+    // being appended again.
+    HashSet<String> textUnitNamesInSourceAsset = new HashSet<>();
+
+    // Put all text units in the last push run into the source asset set
+    tmTextUnitRepository
+        .findAllById(textUnitIdsInLastPushRun)
+        .forEach(tmTextUnit -> textUnitNamesInSourceAsset.add(tmTextUnit.getName()));
 
     // Fetch all branches to be appended, sorted by translated date in ascending order to ensure
     // older translated branches make it in
@@ -133,7 +146,7 @@ public class AssetAppenderService {
       // Filter text units by removing ones in the last push run
       textUnitsToAppend =
           textUnitsToAppend.stream()
-              .filter(tu -> !textUnitIdsInSourceAsset.contains(tu.getTmTextUnitId()))
+              .filter(tu -> !textUnitNamesInSourceAsset.contains(tu.getName()))
               .toList();
 
       // Are we going to go over the hard limit ? If yes emit metrics and break out.
@@ -176,8 +189,8 @@ public class AssetAppenderService {
       appendedTextUnitCount += textUnitsToAppend.size();
       appendedBranches.add(branch);
       // Avoids appending duplicate text units if multiple branches add the same text unit
-      textUnitIdsInSourceAsset.addAll(
-          textUnitsToAppend.stream().map(TextUnitDTO::getTmTextUnitId).toList());
+      textUnitNamesInSourceAsset.addAll(
+          textUnitsToAppend.stream().map(TextUnitDTO::getName).toList());
     }
 
     String appendedAssetContent = appender.getAssetContent();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/appender/AssetAppenderService.java
@@ -120,7 +120,7 @@ public class AssetAppenderService {
     // being appended again.
     HashSet<String> textUnitNamesInSourceAsset = new HashSet<>();
 
-    // Put all text units in the last push run into the source asset set
+    // Put all text unit names in the last push run into the source asset set
     tmTextUnitRepository
         .findAllById(textUnitIdsInLastPushRun)
         .forEach(tmTextUnit -> textUnitNamesInSourceAsset.add(tmTextUnit.getName()));

--- a/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
@@ -15,6 +15,7 @@ import com.box.l10n.mojito.rest.asset.LocalizedAssetBody;
 import com.box.l10n.mojito.service.branch.BranchRepository;
 import com.box.l10n.mojito.service.branch.BranchStatisticService;
 import com.box.l10n.mojito.service.pushrun.PushRunRepository;
+import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -40,6 +41,7 @@ public class AssetAppenderServiceTest {
   AppendedAssetBlobStorage appendedAssetBlobStorageMock;
   MeterRegistry meterRegistryMock;
   AssetAppenderConfig assetAppenderConfigMock;
+  TMTextUnitRepository tmTextUnitRepositoryMock;
 
   String extension = "pot";
   String content = "Test source";
@@ -58,6 +60,7 @@ public class AssetAppenderServiceTest {
     appendedAssetBlobStorageMock = mock(AppendedAssetBlobStorage.class);
     meterRegistryMock = mock(MeterRegistry.class);
     assetAppenderConfigMock = mock(AssetAppenderConfig.class);
+    tmTextUnitRepositoryMock = mock(TMTextUnitRepository.class);
     assetAppenderService =
         new AssetAppenderService(
             assetAppenderFactory,
@@ -66,7 +69,8 @@ public class AssetAppenderServiceTest {
             pushRunRepositoryMock,
             appendedAssetBlobStorageMock,
             meterRegistryMock,
-            assetAppenderConfigMock);
+            assetAppenderConfigMock,
+            tmTextUnitRepositoryMock);
 
     appendCountCounterMock = Mockito.mock(Counter.class);
     when(meterRegistryMock.counter(
@@ -140,6 +144,7 @@ public class AssetAppenderServiceTest {
                       x -> {
                         TextUnitDTO textUnitDTO = new TextUnitDTO();
                         textUnitDTO.setSource(content + x);
+                        textUnitDTO.setName(content + " --- " + x);
                         textUnitDTO.setTmTextUnitId(Integer.toUnsignedLong(x));
                         return textUnitDTO;
                       })
@@ -187,6 +192,7 @@ public class AssetAppenderServiceTest {
                       x -> {
                         TextUnitDTO textUnitDTO = new TextUnitDTO();
                         textUnitDTO.setSource(content + x);
+                        textUnitDTO.setName(content + " --- " + x);
                         textUnitDTO.setTmTextUnitId(Integer.toUnsignedLong(x));
                         return textUnitDTO;
                       })
@@ -234,6 +240,7 @@ public class AssetAppenderServiceTest {
                 i -> {
                   TextUnitDTO textUnitDTO = new TextUnitDTO();
                   textUnitDTO.setSource(content + i);
+                  textUnitDTO.setName(content + " --- " + i);
                   textUnitDTO.setTmTextUnitId(Integer.toUnsignedLong(i));
                   return textUnitDTO;
                 })


### PR DESCRIPTION
Mojito creates a new text unit whenever a comment is present or modified, even if the change is minor. Currently, this can lead to a situation where a text unit exists in the source asset with or without a comment, and then a branch adds the same text unit (same msgid and msgctxt) but with a different comment. This results in duplicates, since the PO compiler ignores comments (unlike Mojito), which can cause the po-to-mo compilation to fail.

This PR aims to fix this by using the text unit name which is formatted as "source --- context", as a way to check if the text unit exists in the source asset already, if it does it won't be appended.