### PR TITLE
[Safe-I18N] Move append logic for parallel pulls to initial PollableTask

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
@@ -308,18 +308,6 @@ public class AssetWS {
       recordAppendMetrics(repository);
     }
 
-    if (multiLocalizedAssetBody.getAppendTextUnitsId() != null) {
-      // Set the source to the appended asset - For each locale under the repository / locale
-      // mapping, a localized asset body is created which will use this source content. Each
-      // localized asset body sends up their source content for localization so there is no need to
-      // put it through the appender service again
-      multiLocalizedAssetBody.setSourceContent(
-          assetAppenderService.appendBranchTextUnitsToSource(
-              asset,
-              multiLocalizedAssetBody.getAppendTextUnitsId(),
-              multiLocalizedAssetBody.getSourceContent()));
-    }
-
     QuartzJobInfo<MultiLocalizedAssetBody, MultiLocalizedAssetBody> quartzJobInfo =
         QuartzJobInfo.newBuilder(GenerateMultiLocalizedAssetJob.class)
             .withInlineInput(false)


### PR DESCRIPTION
Move the append logic for parallel pulls to the  `GenerateMultiLocalizedAssetJob` Pollable Task to ensure the CLI isn't blocked waiting for the append step.