### PR TITLE
I18N-1553: bcp tag with locale display name tooltip

### DIFF
--- a/docs/_docs/refs/mojito-locales.md
+++ b/docs/_docs/refs/mojito-locales.md
@@ -56,7 +56,7 @@ permalink: /docs/refs/mojito-locales/
 | en-US	        | English (United States) |
 | en-ZA	        | English (South Africa) |
 | en-ZW	        | English (Zimbabwe) |
-| en-419	        | Spanish (Latin America) |
+| en-419	    | Spanish (Latin America) |
 | es-AR	        | Spanish (Argentina) |
 | es-BO	        | Spanish (Bolivia) |
 | es-CL	        | Spanish (Chile) |

--- a/docs/_docs/refs/mojito-locales.md
+++ b/docs/_docs/refs/mojito-locales.md
@@ -56,7 +56,7 @@ permalink: /docs/refs/mojito-locales/
 | en-US	        | English (United States) |
 | en-ZA	        | English (South Africa) |
 | en-ZW	        | English (Zimbabwe) |
-| en-419	    | Spanish (Latin America) |
+| es-419	    | Spanish (Latin America) |
 | es-AR	        | Spanish (Argentina) |
 | es-BO	        | Spanish (Bolivia) |
 | es-CL	        | Spanish (Chile) |

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.jsx
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.jsx
@@ -1048,9 +1048,18 @@ let TextUnit = createReactClass({
 
                         <div className="left">
                             <div style={{gridArea: "locale"}}>
-                                <Label bsStyle='primary' bsSize='large' className="clickable" onClick={this.onLocaleLabelClick}>
-                                    {this.props.textUnit.getTargetLocale()}
-                                </Label>
+                                <OverlayTrigger
+                                    placement="top"
+                                    overlay={
+                                        <Tooltip id={`locale-display-name-tooltip-${this.props.textUnit.getId()}`}>
+                                            {Locales.getDisplayName(this.props.textUnit.getTargetLocale())}
+                                        </Tooltip>
+                                    }
+                                >
+                                    <Label bsStyle='primary' bsSize='large' className="clickable" onClick={this.onLocaleLabelClick}>
+                                        {this.props.textUnit.getTargetLocale()}
+                                    </Label>
+                                </OverlayTrigger>
                             </div>
                             <div style={{gridArea: "repo"}}>
                                 {this.renderRepository()}


### PR DESCRIPTION
![Screenshot 2025-05-26 at 13 43 30](https://github.com/user-attachments/assets/4b311554-02c2-4909-96cb-6b83452716a6)

- added OverlayTrigger tooltip for each bcp tag so that the Locale.getDisplayName(...) appears on hover.