### PR TITLE
Fix bug where null placeholders aren't removed from prompt if not in optional block

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMService.java
@@ -546,9 +546,10 @@ public class OpenAILLMService implements LLMService {
       promptText = matcher.replaceFirst(optionalContent);
     } else if (matcher.find()) {
       promptText = removeOptionalBlock(promptText, placeholder);
-    } else if (placeholderValue != null) {
+    } else {
       // Replace any instances not in an optional block
-      promptText = promptText.replace(placeholder, placeholderValue);
+      promptText =
+          promptText.replace(placeholder, placeholderValue != null ? placeholderValue : "");
     }
     return promptText;
   }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/openai/OpenAILLMServiceTest.java
@@ -1003,6 +1003,32 @@ class OpenAILLMServiceTest {
   }
 
   @Test
+  void testPromptTemplatingNullPlaceholder() {
+    String promptText =
+        """
+                 Translate the following source string from [mojito_source_locale] to [mojito_target_locale]:
+                 Source string: [mojito_source_string]
+                 The comment is: [mojito_comment_string]. The context is: [mojito_context_string]. The plural form is: [mojito_plural_form].
+                 """;
+
+    TMTextUnit tmTextUnit = new TMTextUnit();
+    tmTextUnit.setId(1L);
+    tmTextUnit.setContent("Hello");
+    tmTextUnit.setComment(null);
+    tmTextUnit.setName("Hello");
+    tmTextUnit.setPluralForm(null);
+    String prompt =
+        openAILLMService.getTranslationFormattedPrompt(
+            promptText, tmTextUnit, "en", "fr", Collections.emptyList());
+    assertEquals(
+        """
+                 Translate the following source string from en to fr:
+                 Source string: Hello
+                 The comment is: . The context is: . The plural form is: .""",
+        prompt);
+  }
+
+  @Test
   void testPromptTemplatingOptionalGlossaryStaticOthers() {
     String promptText =
         """


### PR DESCRIPTION
As per title, if a placeholder value is null and it is not wrapped by an optional block then it does not get stripped from the template output.

Fixed this issue and added a unit test to catch it if it was to re-appear in future.