### PR TITLE
Only cleanup jobs when scheduler is enabled

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzConfig.java
@@ -45,9 +45,9 @@ public class QuartzConfig {
    */
   @PostConstruct
   void startSchedulers() throws SchedulerException {
-    removeOutdatedJobs();
     int delay = 2;
     if (schedulerEnabled) {
+      removeOutdatedJobs();
       for (Scheduler scheduler : schedulerManager.getSchedulers()) {
         logger.info("Starting scheduler: {}", scheduler.getSchedulerName());
         scheduler.startDelayed(delay);


### PR DESCRIPTION
Resolves issue where if Mojito is deployed in an API/Worker node deployment restarts of the API node removes some Quartz triggers.

Only nodes with Quartz schedulers enabled will delete outdated triggers/jobs.