### PR TITLE
Alter Scheduled Job Audited to Nullable

### DIFF
--- a/webapp/src/main/resources/db/migration/V80__alter_scheduled_job_aud_null.sql
+++ b/webapp/src/main/resources/db/migration/V80__alter_scheduled_job_aud_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scheduled_job_aud MODIFY COLUMN deleted BIT DEFAULT 0;


### PR DESCRIPTION
Scheduled Job Audited Table should not have NOT NULL fields because it sets all fields to null when showing that that record has been deleted.