### PR TITLE
Show Job Error Modal If Restore Job Fails

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobService.java
@@ -137,7 +137,7 @@ public class ScheduledJobService {
         .isPresent()) {
       throw new ScheduledJobException(
           "Scheduled job of type "
-              + scheduledJob.getJobType()
+              + scheduledJob.getJobType().getEnum()
               + " with repository already exists: "
               + scheduledJob.getRepository().getName());
     }

--- a/webapp/src/main/resources/public/js/components/jobs/JobErrorModal.jsx
+++ b/webapp/src/main/resources/public/js/components/jobs/JobErrorModal.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import {Alert, Modal, Button} from "react-bootstrap";
+import PropTypes from "prop-types";
+
+class JobErrorModal extends React.Component {
+    static propTypes = {
+        showModal: PropTypes.bool.isRequired,
+        errorMessage: PropTypes.string.isRequired,
+        onErrorModalClosed: PropTypes.func.isRequired,
+        title: PropTypes.string
+    };
+    render() {
+        return (
+            <Modal show={this.props.showModal} onHide={this.props.onErrorModalClosed}>
+                <Modal.Header closeButton>
+                    <Modal.Title>{this.props.title || "An Error Occurred"}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <Alert bsStyle="danger">
+                        {this.props.errorMessage}
+                    </Alert>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="secondary" onClick={this.props.onErrorModalClosed}>
+                        Cancel
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+export default JobErrorModal;

--- a/webapp/src/main/resources/public/js/components/jobs/JobInputModal.jsx
+++ b/webapp/src/main/resources/public/js/components/jobs/JobInputModal.jsx
@@ -137,8 +137,8 @@ const JobInputModal  = createReactClass({
         if (step === 0) {
             return this.state.selectedRepository &&
                 this.state.jobType &&
-                this.state.cron &&
-                validateCronExpression(this.state.cron);
+                this.state.cron
+                // validateCronExpression(this.state.cron);
         }
         if (step === 1) {
             return this.state.thirdPartyProjectId &&

--- a/webapp/src/main/resources/public/js/components/jobs/JobInputModal.jsx
+++ b/webapp/src/main/resources/public/js/components/jobs/JobInputModal.jsx
@@ -48,7 +48,7 @@ const JobInputModal  = createReactClass({
             this.state.currentStep !== 0
         ) {
             this.setState({ currentStep: 0 });
-        }
+        } 
         if (prevProps.job !== this.props.job) {
             if (this.props.job) {
                 const jobProperties = this.props.job.properties || {};
@@ -69,6 +69,10 @@ const JobInputModal  = createReactClass({
             } else {
                 this.clearModal();
             }
+        }
+
+        if (prevProps.show && !this.props.show) {
+            this.clearModal();
         }
     },
 
@@ -125,7 +129,6 @@ const JobInputModal  = createReactClass({
         e.preventDefault();
         const scheduledJobInput = this.getScheduledJobInput();
         this.props.onSubmit(scheduledJobInput);
-        this.setState({ currentStep: 0 });
     },
 
     handleCloseModal() {
@@ -137,8 +140,8 @@ const JobInputModal  = createReactClass({
         if (step === 0) {
             return this.state.selectedRepository &&
                 this.state.jobType &&
-                this.state.cron
-                // validateCronExpression(this.state.cron);
+                this.state.cron &&
+                validateCronExpression(this.state.cron);
         }
         if (step === 1) {
             return this.state.thirdPartyProjectId &&

--- a/webapp/src/main/resources/public/js/components/jobs/JobsPage.jsx
+++ b/webapp/src/main/resources/public/js/components/jobs/JobsPage.jsx
@@ -49,7 +49,7 @@ let JobsPage = createReactClass({
             }
         }
 
-        if (this.state.showJobErrorModal && state.error && state.error.response) {
+        if (!this.state.showJobErrorModal && state.error && state.error.response) {
             state.error.response.json().then(data => {
                 this.setState({ 
                     showJobErrorModal: true, 

--- a/webapp/src/main/resources/public/js/components/jobs/JobsPage.jsx
+++ b/webapp/src/main/resources/public/js/components/jobs/JobsPage.jsx
@@ -9,6 +9,7 @@ import RepositoryDropDown from "./RepositoryDropDown";
 import { Button } from "react-bootstrap";
 import JobActions from "../../actions/jobs/JobActions";
 import JobInputModal from "./JobInputModal";
+import JobErrorModal from "./JobErrorModal";
 
 let JobsPage = createReactClass({
     displayName: 'JobsPage',
@@ -19,7 +20,8 @@ let JobsPage = createReactClass({
           showScheduledJobInputModal: false,
           editingJob: null,
           isSubmitting: false,
-          errorMessage: null
+          errorMessage: null,
+          showJobErrorModal: false
       };
     },
 
@@ -38,13 +40,22 @@ let JobsPage = createReactClass({
                     this.setState({ isSubmitting: false, errorMessage: data.message });
                 })
             } else {
-                this.setState({ 
-                    showScheduledJobInputModal: false, 
-                    editingJob: null, 
-                    isSubmitting: false, 
-                    errorMessage: null 
+                this.setState({
+                    showScheduledJobInputModal: false,
+                    isSubmitting: false,
+                    editingJob: null,
+                    errorMessage: null
                 });
             }
+        }
+
+        if (this.state.showJobErrorModal && state.error && state.error.response) {
+            state.error.response.json().then(data => {
+                this.setState({ 
+                    showJobErrorModal: true, 
+                    errorMessage: data.message 
+                });
+            });
         }
     },
 
@@ -95,6 +106,10 @@ let JobsPage = createReactClass({
         this.setState({jobType: jobType})
     },
 
+    onCloseJobErrorModal() {
+        this.setState({ showJobErrorModal: false });
+    },
+
     render: function () {
         const clearLeftFix = {
             clear: 'left',
@@ -126,6 +141,13 @@ let JobsPage = createReactClass({
                 <AltContainer store={JobStore} className="mtl mbl" >
                     <JobsView jobType={this.state.jobType} openEditJobModal={this.openEditJobModal} />
                 </AltContainer>
+
+                <JobErrorModal
+                    showModal={this.state.showJobErrorModal}
+                    onErrorModalClosed={this.onCloseJobErrorModal}
+                    errorMessage={this.state.errorMessage || "An error occurred while processing the job."}
+                    title="Error Restoring Job"
+                />
             </div>
         );
     },

--- a/webapp/src/main/resources/public/js/stores/jobs/JobStore.js
+++ b/webapp/src/main/resources/public/js/stores/jobs/JobStore.js
@@ -53,6 +53,11 @@ class JobStore {
 
     restoreJobSuccess() {
         this.getAllJobs();
+        this.setError(null);
+    }
+
+    restoreJobError(error) {
+        this.setError(error);
     }
 
     setError(message) {


### PR DESCRIPTION
Following the previous PR, restoreJob could throw an exception if the repository of the job being restored already has a job running against it.

This PR:
- shows a JobErrorModal if this exception is thrown