### PR TITLE
Edit Repository UI

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
@@ -759,7 +759,7 @@ public class RepositoryService {
 
     logger.debug("Update a repository with name: {}", repository.getName());
 
-    if (newName != null) {
+    if (newName != null && !repository.getName().equals(newName)) {
       // check duplicated name
       Repository existingRepository = repositoryRepository.findByName(newName);
       if (existingRepository != null && repository.getId().equals(existingRepository.getId())) {

--- a/webapp/src/main/resources/public/js/actions/RepositoryActions.js
+++ b/webapp/src/main/resources/public/js/actions/RepositoryActions.js
@@ -8,7 +8,10 @@ class RepositoryActions {
             "getAllRepositoriesError",
             "createRepository",
             "createRepositorySuccess",
-            "createRepositoryError"
+            "createRepositoryError",
+            "updateRepository",
+            "updateRepositorySuccess",
+            "updateRepositoryError"
         );
     }
 }

--- a/webapp/src/main/resources/public/js/actions/RepositoryDataSource.js
+++ b/webapp/src/main/resources/public/js/actions/RepositoryDataSource.js
@@ -11,6 +11,15 @@ const RepositoryDataSource = {
         error: RepositoryActions.createRepositoryError
     },
 
+    updateRepository: {
+        remote(state, repository) {
+            return RepositoryClient.updateRepository(repository);
+        },
+
+        success: RepositoryActions.updateRepositorySuccess,
+        error: RepositoryActions.updateRepositoryError
+    },
+
     getAllRepositories: {
         remote() {
             return RepositoryClient.getRepositories();

--- a/webapp/src/main/resources/public/js/components/repositories/Repositories.jsx
+++ b/webapp/src/main/resources/public/js/components/repositories/Repositories.jsx
@@ -175,7 +175,7 @@ let Repositories = createReactClass({
                     </div>
                 </ReactSidebarResponsive>
                 <RepositoryInputModal
-                    title={this.state.editingRepository ? " Edit Repository" : "Create Repository"}
+                    title={this.state.editingRepository ? "Edit Repository" : "Create Repository"}
                     repository={this.state.editingRepository}
                     show={this.state.isRepositoryInputModalOpen}
                     onClose={this.state.editingRepository ? this.closeEditRepositoryModal : this.closeCreateRepositoryModal}

--- a/webapp/src/main/resources/public/js/components/repositories/Repositories.jsx
+++ b/webapp/src/main/resources/public/js/components/repositories/Repositories.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import createReactClass from 'create-react-class';
-import {Button, Table} from "react-bootstrap";
+import { Button, Table } from "react-bootstrap";
 import ReactSidebarResponsive from "../misc/ReactSidebarResponsive";
 import RepositoryStore from "../../stores/RepositoryStore";
 import RepositoryHeaderColumn from "./RepositoryHeaderColumn";
@@ -21,6 +21,7 @@ let Repositories = createReactClass({
 
     getInitialState() {
         return {
+            editingRepository: null,
             repositories: RepositoryStore.getState().repositories,
             isLocaleStatsShown: false,
             activeRepoId: null,
@@ -49,12 +50,18 @@ let Repositories = createReactClass({
     },
 
     getTableRow(rowData) {
-        let repoId = rowData.id;
-        let isBlurred = this.state.isLocaleStatsShown && (this.state.activeRepoId !== repoId);
+        const repoId = rowData.id;
+        const isBlurred = this.state.isLocaleStatsShown && (this.state.activeRepoId !== repoId);
 
         return (
-            <RepositoryRow key={repoId} rowData={rowData} onLocalesButtonToggle={this.onLocalesButtonToggle}
-                           isBlurred={isBlurred} ref={"repositoryRow" + repoId}/>
+            <RepositoryRow
+                key={repoId}
+                rowData={rowData}
+                onLocalesButtonToggle={this.onLocalesButtonToggle}
+                isBlurred={isBlurred}
+                openEditRepositoryModal={this.openEditRepositoryModal}
+                ref={"repositoryRow" + repoId}
+            />
         );
     },
 
@@ -83,7 +90,7 @@ let Repositories = createReactClass({
     openCreateRepositoryModal() {
         this.setState({ 
             isRepositoryInputModalOpen: true,
-            isSubmitting: false,
+            editingRepository: null,
             errorMessage: null
         });
     },
@@ -101,20 +108,50 @@ let Repositories = createReactClass({
         RepositoryStore.createRepository(repository);
     },
 
-    render: function () {
+    openEditRepositoryModal(repository) {
+        this.setState({
+            isRepositoryInputModalOpen: true,
+            editingRepository: repository,
+            errorMessage: null
+        });
+    },
+
+    closeEditRepositoryModal() {
+        this.setState({
+            isRepositoryInputModalOpen: false,
+            editingRepository: null,
+            isSubmitting: false,
+            errorMessage: null
+        });
+    },
+
+    handleEditRepositorySubmit(repository) {
+        this.setState({ isSubmitting: true, errorMessage: null });
+        RepositoryStore.updateRepository(repository);
+    },
+
+    render() {
         let sideBarContent = "";
         if (this.state.activeRepoId) {
-            sideBarContent = <RepositoryStatistic repoId={this.state.activeRepoId}
-                                                  onCloseRequest={this.onCloseRequestedRepoLocaleStats}/>;
+            sideBarContent = (
+                <RepositoryStatistic
+                    repoId={this.state.activeRepoId}
+                    onCloseRequest={this.onCloseRequestedRepoLocaleStats}
+                />
+            );
         }
 
         return (
             <div>
-                <ReactSidebarResponsive ref="sideBar" sidebar={sideBarContent}
-                         rootClassName="side-bar-root-container"
-                         sidebarClassName="side-bar-container"
-                         contentClassName="side-bar-main-content-container"
-                         docked={this.state.isLocaleStatsShown} pullRight={true}>
+                <ReactSidebarResponsive
+                    ref="sideBar"
+                    sidebar={sideBarContent}
+                    rootClassName="side-bar-root-container"
+                    sidebarClassName="side-bar-container"
+                    contentClassName="side-bar-main-content-container"
+                    docked={this.state.isLocaleStatsShown}
+                    pullRight={true}
+                >
                     <div className="plx prx">
                         <div className="pull-right">
                             <Button bsStyle="primary" onClick={this.openCreateRepositoryModal}>
@@ -123,28 +160,26 @@ let Repositories = createReactClass({
                         </div>
                         <Table className="repo-table table-padded-sides">
                             <thead>
-                            <tr>
-                                <RepositoryHeaderColumn className="col-md-3"
-                                                        columnNameMessageId="repositories.table.header.name"/>
-                                <RepositoryHeaderColumn className="col-md-2"/>
-                                <RepositoryHeaderColumn className="col-md-3"
-                                                        columnNameMessageId="repositories.table.header.needsTranslation"/>
-                                <RepositoryHeaderColumn className="col-md-3"
-                                                        columnNameMessageId="repositories.table.header.needsReview"/>
-                                <RepositoryHeaderColumn className="col-md-1"/>
-                            </tr>
+                                <tr>
+                                    <RepositoryHeaderColumn className="col-md-3" columnNameMessageId="repositories.table.header.name" />
+                                    <RepositoryHeaderColumn className="col-md-2" />
+                                    <RepositoryHeaderColumn className="col-md-3" columnNameMessageId="repositories.table.header.needsTranslation" />
+                                    <RepositoryHeaderColumn className="col-md-3" columnNameMessageId="repositories.table.header.needsReview" />
+                                    <RepositoryHeaderColumn className="col-md-1" />
+                                </tr>
                             </thead>
                             <tbody>
-                            {this.state.repositories.map(this.getTableRow)}
+                                {this.state.repositories.map(this.getTableRow)}
                             </tbody>
                         </Table>
                     </div>
                 </ReactSidebarResponsive>
                 <RepositoryInputModal
-                    title="Create Repository"
+                    title={this.state.editingRepository ? " Edit Repository" : "Create Repository"}
+                    repository={this.state.editingRepository}
                     show={this.state.isRepositoryInputModalOpen}
-                    onClose={this.closeCreateRepositoryModal}
-                    onSubmit={this.handleCreateRepositorySubmit}
+                    onClose={this.state.editingRepository ? this.closeEditRepositoryModal : this.closeCreateRepositoryModal}
+                    onSubmit={this.state.editingRepository ? this.handleEditRepositorySubmit : this.handleCreateRepositorySubmit}
                     isSubmitting={this.state.isSubmitting}
                     errorMessage={this.state.errorMessage}
                 />

--- a/webapp/src/main/resources/public/js/components/repositories/RepositoryGeneralInput.jsx
+++ b/webapp/src/main/resources/public/js/components/repositories/RepositoryGeneralInput.jsx
@@ -12,7 +12,8 @@ const RepositoryGeneralInput = ({
     onTextInputChange,
     onSourceLocaleChange,
     locales,
-    onCheckSLAChange
+    onCheckSLAChange,
+    isEditing
 }) => (
     <div className="form-group">
         <LabeledTextInput
@@ -36,6 +37,7 @@ const RepositoryGeneralInput = ({
                 selectedLocale={sourceLocale} 
                 onSelect={onSourceLocaleChange}
                 defaultLocaleTag="en"
+                disabled={isEditing}
             />
         </div>
         <LabeledTextInput

--- a/webapp/src/main/resources/public/js/components/repositories/RepositoryInputModal.jsx
+++ b/webapp/src/main/resources/public/js/components/repositories/RepositoryInputModal.jsx
@@ -160,6 +160,7 @@ const RepositoryInputModal  = createReactClass({
                         locales={this.state.locales}
                         onSourceLocaleChange={this.handleSourceLocaleChange}
                         onCheckSLAChange={this.handleCheckSLAChange}
+                        isEditing={Boolean(this.props.repository)}
                     />
                 );
             case STEP.LOCALES:

--- a/webapp/src/main/resources/public/js/components/repositories/RepositoryInputModal.jsx
+++ b/webapp/src/main/resources/public/js/components/repositories/RepositoryInputModal.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { Button, Modal, Form } from "react-bootstrap";
 import RepositoryGeneralInput from "./RepositoryGeneralInput";
 import RepositoryLocalesInput from "./RepositoryLocalesInput";
-import { deserializeAssetIntegrityCheckers, validateAssetIntegrityCheckers, flattenRepositoryLocales } from "../../utils/RepositoryInputHelper";
+import { deserializeAssetIntegrityCheckers, serializeAssetIntegrityCheckers, validateAssetIntegrityCheckers, flattenRepositoryLocales, unflattenRepositoryLocales } from "../../utils/RepositoryInputHelper";
 import LocaleStore from "../../stores/LocaleStore";
 import LocaleActions from "../../actions/LocaleActions";
 
@@ -14,6 +14,7 @@ const STEP = {
 };
 
 const DEFAULT_INPUT_STATE = {
+    id: null,
     name: "",
     description: "",
     sourceLocale: {},
@@ -26,6 +27,7 @@ const DEFAULT_INPUT_STATE = {
 const RepositoryInputModal  = createReactClass({
     displayName: "RepositoryInputModal",
     propTypes: {
+        repository: PropTypes.object,
         title: PropTypes.string.isRequired,
         show: PropTypes.bool.isRequired,
         onClose: PropTypes.func.isRequired,
@@ -64,9 +66,31 @@ const RepositoryInputModal  = createReactClass({
         ) {
             this.setState({ currentStep: STEP.GENERAL });
         }
-        if (!this.props.show && prevProps.show) {
-            this.setState({ ...DEFAULT_INPUT_STATE });
+        if (prevProps.repository !== this.props.repository) {
+            if (this.props.repository) {
+                this.setState({
+                    id: this.props.repository.id,
+                    name: this.props.repository.name || "",
+                    description: this.props.repository.description || "",
+                    sourceLocale: this.props.repository.sourceLocale || {},
+                    checkSLA: this.props.repository.checkSLA || false,
+                    assetIntegrityCheckers: serializeAssetIntegrityCheckers(this.props.repository.assetIntegrityCheckers) || "",
+                    repositoryLocales: unflattenRepositoryLocales(this.props.repository.repositoryLocales, this.props.repository.sourceLocale) || [],
+                    currentStep: STEP.GENERAL
+                });
+            } else {
+                this.clearModal();
+            }
         }
+        if (!this.props.show && prevProps.show) {
+            this.clearModal();
+        }
+    },
+
+    clearModal() {
+        this.setState({
+            ...DEFAULT_INPUT_STATE
+        });
     },
 
     isStepValid(step) {
@@ -111,6 +135,7 @@ const RepositoryInputModal  = createReactClass({
     handleSubmit(e) {
         e.preventDefault();
         this.props.onSubmit({
+            id: this.state.id,
             name: this.state.name,
             description: this.state.description,
             sourceLocale: this.state.sourceLocale,

--- a/webapp/src/main/resources/public/js/components/repositories/RepositoryLocaleDropdown.jsx
+++ b/webapp/src/main/resources/public/js/components/repositories/RepositoryLocaleDropdown.jsx
@@ -12,7 +12,8 @@ class RepositoryLocaleDropdown extends React.Component {
                 id: PropTypes.number
             })
         ).isRequired,
-        defaultLocaleTag: PropTypes.string
+        defaultLocaleTag: PropTypes.string,
+        disabled: PropTypes.bool
     };
 
     constructor(props) {
@@ -106,6 +107,7 @@ class RepositoryLocaleDropdown extends React.Component {
                     onChange={this.handleInputChange}
                     onClick={this.handleInputClick}
                     autoComplete="off"
+                    disabled={this.props.disabled}
                 />
                 {this.state.isOpen && (
                     <ul

--- a/webapp/src/main/resources/public/js/components/repositories/RepositoryRow.jsx
+++ b/webapp/src/main/resources/public/js/components/repositories/RepositoryRow.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {Tooltip, OverlayTrigger, Label, Glyphicon} from "react-bootstrap";
+import {Tooltip, OverlayTrigger, Label, Glyphicon, Button} from "react-bootstrap";
 import {FormattedMessage, FormattedNumber} from "react-intl";
 import {Link} from "react-router";
 import RepositoryStore from "../../stores/RepositoryStore";
@@ -442,8 +442,12 @@ class RepositoryRow extends React.Component {
             <tr className={rowClass}>
                 <td className="repo-name">
                     <OverlayTrigger placement="right" overlay={descriptionTooltip}>
-                        <Link onClick={this.updateSearchParamsForRepoDefault.bind(this, repoId)}
-                              to='/workbench'>{this.props.rowData.name}</Link>
+                        <Link
+                            onClick={this.updateSearchParamsForRepoDefault.bind(this, repoId)}
+                            to="/workbench"
+                        >
+                            {this.props.rowData.name}
+                        </Link>
                     </OverlayTrigger>
                 </td>
 
@@ -451,8 +455,20 @@ class RepositoryRow extends React.Component {
                 <td>{this.getNeedsTranslationLabel()}</td>
                 <td>{this.getNeedsReviewLabel()}</td>
                 <td>
-                    <Label className="clickable label label-primary show-details-button"
-                           onClick={this.onLocalesButtonToggle}><Glyphicon glyph="option-horizontal"/></Label>
+                    <span className="flex flex-row justify-end">
+                        <Label
+                            className="clickable label label-primary"
+                            onClick={() => this.props.openEditRepositoryModal(this.props.rowData)}
+                        >
+                            Edit
+                        </Label>
+                        <Label
+                            className="clickable label label-primary show-details-button mls"
+                            onClick={this.onLocalesButtonToggle}
+                        >
+                            <Glyphicon glyph="option-horizontal" />
+                        </Label>
+                    </span>
                 </td>
             </tr>
         );

--- a/webapp/src/main/resources/public/js/sdk/RepositoryClient.js
+++ b/webapp/src/main/resources/public/js/sdk/RepositoryClient.js
@@ -5,6 +5,10 @@ class RepositoryClient extends BaseClient {
         return this.post(this.getUrl(), repository);
     }
 
+    updateRepository(repository) {
+        return this.patch(this.getUrl() + "/" + repository.id, repository);
+    }
+
     getRepositories() {
         return this.get(this.getUrl(), {});
     }

--- a/webapp/src/main/resources/public/js/stores/RepositoryStore.js
+++ b/webapp/src/main/resources/public/js/stores/RepositoryStore.js
@@ -27,6 +27,19 @@ class RepositoryStore {
         this.setError(error);
     }
 
+    updateRepository(repository) {
+        this.getInstance().updateRepository(repository);
+    }
+
+    updateRepositorySuccess() {
+        this.getAllRepositories();
+        this.setError(null);
+    }
+
+    updateRepositoryError(error) {
+        this.setError(error);
+    }
+
     setError(error) {
         this.error = error;
     }

--- a/webapp/src/main/resources/public/js/tests/RepositoryInputHelper.test.js
+++ b/webapp/src/main/resources/public/js/tests/RepositoryInputHelper.test.js
@@ -106,6 +106,17 @@ describe('unflattenRepositoryLocales', () => {
     expect(result[1].locale.locale).toBe('de');
     expect(result[0].childLocales).toEqual([]);
   });
+  it('filters out child locale if parent locale is invalid', () => {
+    const sourceLocale = { id: 1, locale: 'en' };
+    const flattened = [
+      { id: 2, locale: { id: 2, locale: 'fr' }, toBeFullyTranslated: true, parentLocale: { locale: { id: 1, locale: 'en' } } },
+      { id: 3, locale: { id: 3, locale: 'de' }, toBeFullyTranslated: false, parentLocale: { locale: { id: 42, locale: 'invalid' } } }
+    ];
+    const result = unflattenRepositoryLocales(flattened, sourceLocale);
+    expect(result.length).toBe(1);
+    expect(result[0].locale.locale).toBe('fr');
+    expect(result[0].childLocales).toEqual([]);
+  });
   it('handles empty flattened', () => {
     expect(unflattenRepositoryLocales([], { id: 1, locale: 'en' })).toEqual([]);
   });

--- a/webapp/src/main/resources/public/js/tests/RepositoryInputHelper.test.js
+++ b/webapp/src/main/resources/public/js/tests/RepositoryInputHelper.test.js
@@ -10,17 +10,20 @@ describe('deserializeAssetIntegrityCheckers', () => {
   it('returns empty array for empty string', () => {
     expect(deserializeAssetIntegrityCheckers('')).toEqual([]);
   });
+
   it('parses single pair', () => {
     expect(deserializeAssetIntegrityCheckers('js:checker1')).toEqual([
       { assetExtension: 'js', integrityCheckerType: 'checker1' }
     ]);
   });
+
   it('parses multiple pairs', () => {
     expect(deserializeAssetIntegrityCheckers('js:checker1,css:checker2')).toEqual([
       { assetExtension: 'js', integrityCheckerType: 'checker1' },
       { assetExtension: 'css', integrityCheckerType: 'checker2' }
     ]);
   });
+
   it('trims whitespace', () => {
     expect(deserializeAssetIntegrityCheckers(' js : checker1 , css : checker2 ')).toEqual([
       { assetExtension: 'js', integrityCheckerType: 'checker1' },
@@ -34,11 +37,13 @@ describe('serializeAssetIntegrityCheckers', () => {
     expect(serializeAssetIntegrityCheckers(null)).toBe('');
     expect(serializeAssetIntegrityCheckers(undefined)).toBe('');
   });
+
   it('serializes single pair', () => {
     expect(serializeAssetIntegrityCheckers([
       { assetExtension: 'js', integrityCheckerType: 'checker1' }
     ])).toBe('js:checker1');
   });
+
   it('serializes multiple pairs', () => {
     expect(serializeAssetIntegrityCheckers([
       { assetExtension: 'js', integrityCheckerType: 'checker1' },
@@ -51,10 +56,12 @@ describe('validateAssetIntegrityCheckers', () => {
   it('returns true for empty string', () => {
     expect(validateAssetIntegrityCheckers('')).toBe(true);
   });
+
   it('returns true for valid pairs', () => {
     expect(validateAssetIntegrityCheckers('js:checker1')).toBe(true);
     expect(validateAssetIntegrityCheckers('js:checker1,css:checker2')).toBe(true);
   });
+
   it('returns false for missing assetExtension or checkerType', () => {
     expect(validateAssetIntegrityCheckers('js:')).toBe(false);
     expect(validateAssetIntegrityCheckers(':checker1')).toBe(false);
@@ -88,6 +95,7 @@ describe('flattenRepositoryLocales', () => {
       { locale: 'es', toBeFullyTranslated: true }
     ]);
   });
+
   it('handles empty input', () => {
     expect(flattenRepositoryLocales([])).toEqual([]);
   });
@@ -106,6 +114,7 @@ describe('unflattenRepositoryLocales', () => {
     expect(result[1].locale.locale).toBe('de');
     expect(result[0].childLocales).toEqual([]);
   });
+
   it('filters out child locale if parent locale is invalid', () => {
     const sourceLocale = { id: 1, locale: 'en' };
     const flattened = [
@@ -117,6 +126,7 @@ describe('unflattenRepositoryLocales', () => {
     expect(result[0].locale.locale).toBe('fr');
     expect(result[0].childLocales).toEqual([]);
   });
+  
   it('handles empty flattened', () => {
     expect(unflattenRepositoryLocales([], { id: 1, locale: 'en' })).toEqual([]);
   });

--- a/webapp/src/main/resources/public/js/tests/RepositoryInputHelper.test.js
+++ b/webapp/src/main/resources/public/js/tests/RepositoryInputHelper.test.js
@@ -126,7 +126,7 @@ describe('unflattenRepositoryLocales', () => {
     expect(result[0].locale.locale).toBe('fr');
     expect(result[0].childLocales).toEqual([]);
   });
-  
+
   it('handles empty flattened', () => {
     expect(unflattenRepositoryLocales([], { id: 1, locale: 'en' })).toEqual([]);
   });

--- a/webapp/src/main/resources/public/js/tests/RepositoryInputHelper.test.js
+++ b/webapp/src/main/resources/public/js/tests/RepositoryInputHelper.test.js
@@ -1,0 +1,112 @@
+import {
+  deserializeAssetIntegrityCheckers,
+  serializeAssetIntegrityCheckers,
+  validateAssetIntegrityCheckers,
+  flattenRepositoryLocales,
+  unflattenRepositoryLocales
+} from '../utils/RepositoryInputHelper.js';
+
+describe('deserializeAssetIntegrityCheckers', () => {
+  it('returns empty array for empty string', () => {
+    expect(deserializeAssetIntegrityCheckers('')).toEqual([]);
+  });
+  it('parses single pair', () => {
+    expect(deserializeAssetIntegrityCheckers('js:checker1')).toEqual([
+      { assetExtension: 'js', integrityCheckerType: 'checker1' }
+    ]);
+  });
+  it('parses multiple pairs', () => {
+    expect(deserializeAssetIntegrityCheckers('js:checker1,css:checker2')).toEqual([
+      { assetExtension: 'js', integrityCheckerType: 'checker1' },
+      { assetExtension: 'css', integrityCheckerType: 'checker2' }
+    ]);
+  });
+  it('trims whitespace', () => {
+    expect(deserializeAssetIntegrityCheckers(' js : checker1 , css : checker2 ')).toEqual([
+      { assetExtension: 'js', integrityCheckerType: 'checker1' },
+      { assetExtension: 'css', integrityCheckerType: 'checker2' }
+    ]);
+  });
+});
+
+describe('serializeAssetIntegrityCheckers', () => {
+  it('returns empty string for non-array', () => {
+    expect(serializeAssetIntegrityCheckers(null)).toBe('');
+    expect(serializeAssetIntegrityCheckers(undefined)).toBe('');
+  });
+  it('serializes single pair', () => {
+    expect(serializeAssetIntegrityCheckers([
+      { assetExtension: 'js', integrityCheckerType: 'checker1' }
+    ])).toBe('js:checker1');
+  });
+  it('serializes multiple pairs', () => {
+    expect(serializeAssetIntegrityCheckers([
+      { assetExtension: 'js', integrityCheckerType: 'checker1' },
+      { assetExtension: 'css', integrityCheckerType: 'checker2' }
+    ])).toBe('js:checker1,css:checker2');
+  });
+});
+
+describe('validateAssetIntegrityCheckers', () => {
+  it('returns true for empty string', () => {
+    expect(validateAssetIntegrityCheckers('')).toBe(true);
+  });
+  it('returns true for valid pairs', () => {
+    expect(validateAssetIntegrityCheckers('js:checker1')).toBe(true);
+    expect(validateAssetIntegrityCheckers('js:checker1,css:checker2')).toBe(true);
+  });
+  it('returns false for missing assetExtension or checkerType', () => {
+    expect(validateAssetIntegrityCheckers('js:')).toBe(false);
+    expect(validateAssetIntegrityCheckers(':checker1')).toBe(false);
+    expect(validateAssetIntegrityCheckers('js:checker1,:checker2')).toBe(false);
+    expect(validateAssetIntegrityCheckers('js:checker1,css:')).toBe(false);
+  });
+});
+
+describe('flattenRepositoryLocales', () => {
+  it('flattens hierarchical locales', () => {
+    const input = [
+      {
+        locale: 'en',
+        toBeFullyTranslated: true,
+        childLocales: [
+          { locale: 'fr', toBeFullyTranslated: false },
+          { locale: 'de', toBeFullyTranslated: false }
+        ]
+      },
+      {
+        locale: 'es',
+        toBeFullyTranslated: true,
+        childLocales: []
+      }
+    ];
+    const result = flattenRepositoryLocales(input);
+    expect(result).toEqual([
+      { locale: 'en', toBeFullyTranslated: true },
+      { locale: 'fr', toBeFullyTranslated: false, parentLocale: { locale: 'en' } },
+      { locale: 'de', toBeFullyTranslated: false, parentLocale: { locale: 'en' } },
+      { locale: 'es', toBeFullyTranslated: true }
+    ]);
+  });
+  it('handles empty input', () => {
+    expect(flattenRepositoryLocales([])).toEqual([]);
+  });
+});
+
+describe('unflattenRepositoryLocales', () => {
+  it('reconstructs hierarchy from flattened', () => {
+    const sourceLocale = { id: 1, locale: 'en' };
+    const flattened = [
+      { id: 2, locale: { id: 2, locale: 'fr' }, toBeFullyTranslated: true, parentLocale: { locale: { id: 1, locale: 'en' } } },
+      { id: 3, locale: { id: 3, locale: 'de' }, toBeFullyTranslated: false, parentLocale: { locale: { id: 1, locale: 'en' } } }
+    ];
+    const result = unflattenRepositoryLocales(flattened, sourceLocale);
+    expect(result.length).toBe(2);
+    expect(result[0].locale.locale).toBe('fr');
+    expect(result[1].locale.locale).toBe('de');
+    expect(result[0].childLocales).toEqual([]);
+  });
+  it('handles empty flattened', () => {
+    expect(unflattenRepositoryLocales([], { id: 1, locale: 'en' })).toEqual([]);
+  });
+});

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -1248,3 +1248,11 @@ label.current-pageNumber {
 .flex {
     display: flex;
 }
+
+.flex-row {
+    flex-direction: row;
+}
+
+.justify-end {
+    justify-content: flex-end;
+}


### PR DESCRIPTION
This PR:
- allows users to update repositories via the `RepositoryInputModal`
- follows the same pattern as `JobInputModal`, handling state using `editingRepository`
- updates the backend endpoint so that if the repo to be updated has the same name as the other, it doesn't throw an error
- when editing repositories, the source locale dropdown is disabled because there should never be a case where the source locale changes after repo creation
- adds unit tests for Repository Input Helpers

Quick video demo:
https://github.com/user-attachments/assets/c192cee7-0198-44fe-92d2-096ad68a0b0a