### PR TITLE
I18N-1627 - Self Onboarding Observability and Alerting

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
@@ -110,7 +110,9 @@ public class RepositoryWS {
               repository.getCheckSLA(),
               repository.getAssetIntegrityCheckers(),
               repository.getRepositoryLocales());
+
       result = new ResponseEntity<>(createdRepo, HttpStatus.CREATED);
+      repositoryService.uptickRepositoryActionMetrics("create", createdRepo);
     } catch (RepositoryNameAlreadyUsedException e) {
       logger.debug("Cannot create the repository", e);
       result =
@@ -121,7 +123,6 @@ public class RepositoryWS {
       logger.debug("Cannot create the repository", e);
       result = new ResponseEntity(e.getMessage(), HttpStatus.CONFLICT);
     }
-
     return result;
   }
 
@@ -205,6 +206,7 @@ public class RepositoryWS {
           repository.getAssetIntegrityCheckers());
 
       result = new ResponseEntity(HttpStatus.OK);
+      repositoryService.uptickRepositoryActionMetrics("create", repoToUpdate);
 
     } catch (RepositoryNameAlreadyUsedException e) {
       logger.debug("Cannot create the repository", e);

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/scheduledjob/ScheduledJobWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/scheduledjob/ScheduledJobWS.java
@@ -2,7 +2,13 @@ package com.box.l10n.mojito.rest.scheduledjob;
 
 import com.box.l10n.mojito.entity.ScheduledJob;
 import com.box.l10n.mojito.security.Role;
-import com.box.l10n.mojito.service.scheduledjob.*;
+import com.box.l10n.mojito.service.scheduledjob.ScheduledJobDTO;
+import com.box.l10n.mojito.service.scheduledjob.ScheduledJobException;
+import com.box.l10n.mojito.service.scheduledjob.ScheduledJobManager;
+import com.box.l10n.mojito.service.scheduledjob.ScheduledJobRepository;
+import com.box.l10n.mojito.service.scheduledjob.ScheduledJobResponse;
+import com.box.l10n.mojito.service.scheduledjob.ScheduledJobService;
+import com.box.l10n.mojito.service.scheduledjob.ScheduledJobServiceAction;
 import com.box.l10n.mojito.service.security.user.UserService;
 import java.util.List;
 import java.util.Optional;

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/scheduledjob/ScheduledJobWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/scheduledjob/ScheduledJobWS.java
@@ -2,12 +2,7 @@ package com.box.l10n.mojito.rest.scheduledjob;
 
 import com.box.l10n.mojito.entity.ScheduledJob;
 import com.box.l10n.mojito.security.Role;
-import com.box.l10n.mojito.service.scheduledjob.ScheduledJobDTO;
-import com.box.l10n.mojito.service.scheduledjob.ScheduledJobException;
-import com.box.l10n.mojito.service.scheduledjob.ScheduledJobManager;
-import com.box.l10n.mojito.service.scheduledjob.ScheduledJobRepository;
-import com.box.l10n.mojito.service.scheduledjob.ScheduledJobResponse;
-import com.box.l10n.mojito.service.scheduledjob.ScheduledJobService;
+import com.box.l10n.mojito.service.scheduledjob.*;
 import com.box.l10n.mojito.service.security.user.UserService;
 import java.util.List;
 import java.util.Optional;
@@ -185,7 +180,8 @@ public class ScheduledJobWS {
           "Job '{}' for repository '{}' was manually triggered.",
           scheduledJob.getJobType().getEnum(),
           scheduledJob.getRepository().getName());
-      scheduledJobService.uptickScheduledThirdPartySyncActionMetric("trigger", scheduledJob);
+      scheduledJobService.uptickScheduledThirdPartySyncActionMetric(
+          ScheduledJobServiceAction.TRIGGER, scheduledJob);
       return ResponseEntity.status(HttpStatus.OK)
           .body(
               new ScheduledJobResponse(
@@ -234,7 +230,8 @@ public class ScheduledJobWS {
       scheduledJob.setEnabled(active);
       scheduledJobRepository.save(scheduledJob);
       scheduledJobService.uptickScheduledThirdPartySyncActionMetric(
-          active ? "enable" : "disable", scheduledJob);
+          active ? ScheduledJobServiceAction.ENABLE : ScheduledJobServiceAction.DISABLE,
+          scheduledJob);
 
       return createResponse(
           HttpStatus.OK,

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/scheduledjob/ScheduledJobWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/scheduledjob/ScheduledJobWS.java
@@ -185,7 +185,7 @@ public class ScheduledJobWS {
           "Job '{}' for repository '{}' was manually triggered.",
           scheduledJob.getJobType().getEnum(),
           scheduledJob.getRepository().getName());
-      scheduledJobService.uptickMetrics("trigger", scheduledJob);
+      scheduledJobService.uptickScheduledThirdPartySyncActionMetric("trigger", scheduledJob);
       return ResponseEntity.status(HttpStatus.OK)
           .body(
               new ScheduledJobResponse(
@@ -233,7 +233,8 @@ public class ScheduledJobWS {
 
       scheduledJob.setEnabled(active);
       scheduledJobRepository.save(scheduledJob);
-      scheduledJobService.uptickMetrics(active ? "enable" : "disable", scheduledJob);
+      scheduledJobService.uptickScheduledThirdPartySyncActionMetric(
+          active ? "enable" : "disable", scheduledJob);
 
       return createResponse(
           HttpStatus.OK,

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/scheduledjob/ScheduledJobWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/scheduledjob/ScheduledJobWS.java
@@ -185,6 +185,7 @@ public class ScheduledJobWS {
           "Job '{}' for repository '{}' was manually triggered.",
           scheduledJob.getJobType().getEnum(),
           scheduledJob.getRepository().getName());
+      scheduledJobService.uptickMetrics("trigger", scheduledJob);
       return ResponseEntity.status(HttpStatus.OK)
           .body(
               new ScheduledJobResponse(
@@ -232,6 +233,7 @@ public class ScheduledJobWS {
 
       scheduledJob.setEnabled(active);
       scheduledJobRepository.save(scheduledJob);
+      scheduledJobService.uptickMetrics(active ? "enable" : "disable", scheduledJob);
 
       return createResponse(
           HttpStatus.OK,

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
@@ -5,7 +5,13 @@ import static com.box.l10n.mojito.rest.repository.RepositorySpecification.nameEq
 import static com.box.l10n.mojito.specification.Specifications.ifParamNotNull;
 import static org.springframework.data.jpa.domain.Specification.where;
 
-import com.box.l10n.mojito.entity.*;
+import com.box.l10n.mojito.entity.AssetIntegrityChecker;
+import com.box.l10n.mojito.entity.Locale;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.entity.RepositoryStatistic;
+import com.box.l10n.mojito.entity.ScreenshotRun;
+import com.box.l10n.mojito.entity.TM;
 import com.box.l10n.mojito.entity.security.user.User;
 import com.box.l10n.mojito.security.AuditorAwareImpl;
 import com.box.l10n.mojito.service.assetintegritychecker.AssetIntegrityCheckerRepository;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
@@ -796,18 +796,28 @@ public class RepositoryService {
     logger.debug("Updated repository with name: {}", repository.getName());
   }
 
-  public void uptickRepositoryActionMetrics(String action, Repository repository) {
+  public void uptickRepositoryServiceActionMetrics(
+      Enum<RepositoryServiceAction> action, Repository repository) {
+    uptickRepositoryServiceActionMetrics(action, repository, false);
+  }
+
+  public void uptickRepositoryServiceActionMetrics(
+      Enum<RepositoryServiceAction> action,
+      Repository repository,
+      boolean hasRepositoryLocalesChanged) {
     User currentUser = auditorAwareImpl.getCurrentAuditor().orElse(null);
     meterRegistry
         .counter(
-            "Repository.action",
+            "RepositoryService.action",
             Tags.of(
                 "Action",
-                action,
+                action.name(),
                 "Repository",
                 String.valueOf(repository.getName()),
                 "User",
-                currentUser != null ? currentUser.getUsername() : null))
+                currentUser != null ? currentUser.getUsername() : null,
+                "HasRepositoryLocalesChanged",
+                String.valueOf(hasRepositoryLocalesChanged)))
         .increment();
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryServiceAction.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryServiceAction.java
@@ -1,0 +1,6 @@
+package com.box.l10n.mojito.service.repository;
+
+public enum RepositoryServiceAction {
+  CREATE,
+  UPDATE,
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobService.java
@@ -87,7 +87,7 @@ public class ScheduledJobService {
         scheduledJob.getUuid(),
         scheduledJob.getRepository().getName());
 
-    uptickMetrics("create", scheduledJob);
+    uptickScheduledThirdPartySyncActionMetric("create", scheduledJob);
     return scheduledJob;
   }
 
@@ -129,7 +129,7 @@ public class ScheduledJobService {
     scheduledJobManager.scheduleJob(updatedJob);
 
     logger.info("Job '{}' was updated.", uuid);
-    uptickMetrics("update", updatedJob);
+    uptickScheduledThirdPartySyncActionMetric("update", updatedJob);
     return updatedJob;
   }
 
@@ -138,7 +138,7 @@ public class ScheduledJobService {
     scheduledJobRepository.save(scheduledJob);
     scheduledJobManager.deleteJobFromQuartz(scheduledJob);
     logger.info("Deleted scheduled job with uuid: {}", scheduledJob.getUuid());
-    uptickMetrics("delete", scheduledJob);
+    uptickScheduledThirdPartySyncActionMetric("delete", scheduledJob);
   }
 
   public void restoreJob(ScheduledJob scheduledJob)
@@ -157,7 +157,7 @@ public class ScheduledJobService {
     scheduledJobRepository.save(scheduledJob);
     scheduledJobManager.scheduleJob(scheduledJob);
     logger.info("Restored scheduled job with uuid: {}", scheduledJob.getUuid());
-    uptickMetrics("restore", scheduledJob);
+    uptickScheduledThirdPartySyncActionMetric("restore", scheduledJob);
   }
 
   private Repository resolveRepositoryFromDTO(ScheduledJobDTO scheduledJobDTO) {
@@ -182,7 +182,7 @@ public class ScheduledJobService {
     return jobType;
   }
 
-  public void uptickMetrics(String action, ScheduledJob scheduledJob) {
+  public void uptickScheduledThirdPartySyncActionMetric(String action, ScheduledJob scheduledJob) {
     User currentUser = auditorAwareImpl.getCurrentAuditor().orElse(null);
     meterRegistry
         .counter(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobService.java
@@ -3,7 +3,11 @@ package com.box.l10n.mojito.service.scheduledjob;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.ScheduledJob;
 import com.box.l10n.mojito.entity.ScheduledJobType;
+import com.box.l10n.mojito.entity.security.user.User;
+import com.box.l10n.mojito.security.AuditorAwareImpl;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import java.util.UUID;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
@@ -20,6 +24,10 @@ public class ScheduledJobService {
   private final ScheduledJobTypeRepository scheduledJobTypeRepository;
   private final ScheduledJobManager scheduledJobManager;
   private final RepositoryRepository repositoryRepository;
+
+  @Autowired AuditorAwareImpl auditorAwareImpl;
+
+  @Autowired MeterRegistry meterRegistry;
 
   @Autowired
   public ScheduledJobService(
@@ -78,6 +86,8 @@ public class ScheduledJobService {
         "Job '{}' for repository '{}' was created.",
         scheduledJob.getUuid(),
         scheduledJob.getRepository().getName());
+
+    uptickMetrics("create", scheduledJob);
     return scheduledJob;
   }
 
@@ -119,6 +129,7 @@ public class ScheduledJobService {
     scheduledJobManager.scheduleJob(updatedJob);
 
     logger.info("Job '{}' was updated.", uuid);
+    uptickMetrics("update", updatedJob);
     return updatedJob;
   }
 
@@ -127,6 +138,7 @@ public class ScheduledJobService {
     scheduledJobRepository.save(scheduledJob);
     scheduledJobManager.deleteJobFromQuartz(scheduledJob);
     logger.info("Deleted scheduled job with uuid: {}", scheduledJob.getUuid());
+    uptickMetrics("delete", scheduledJob);
   }
 
   public void restoreJob(ScheduledJob scheduledJob)
@@ -145,6 +157,7 @@ public class ScheduledJobService {
     scheduledJobRepository.save(scheduledJob);
     scheduledJobManager.scheduleJob(scheduledJob);
     logger.info("Restored scheduled job with uuid: {}", scheduledJob.getUuid());
+    uptickMetrics("restore", scheduledJob);
   }
 
   private Repository resolveRepositoryFromDTO(ScheduledJobDTO scheduledJobDTO) {
@@ -167,5 +180,20 @@ public class ScheduledJobService {
       throw new ScheduledJobException("Job type not found: " + scheduledJobDTO.getType());
     }
     return jobType;
+  }
+
+  public void uptickMetrics(String action, ScheduledJob scheduledJob) {
+    User currentUser = auditorAwareImpl.getCurrentAuditor().orElse(null);
+    meterRegistry
+        .counter(
+            "ScheduledThirdPartySync.action",
+            Tags.of(
+                "Action",
+                action,
+                "JobType",
+                String.valueOf(scheduledJob.getJobType().getEnum()),
+                "User",
+                currentUser != null ? currentUser.getUsername() : null))
+        .increment();
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobServiceAction.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobServiceAction.java
@@ -1,0 +1,11 @@
+package com.box.l10n.mojito.service.scheduledjob;
+
+public enum ScheduledJobServiceAction {
+  CREATE,
+  UPDATE,
+  DELETE,
+  RESTORE,
+  TRIGGER,
+  DISABLE,
+  ENABLE,
+}


### PR DESCRIPTION
This PR:
- adds observability and alerting for Mojito self onboarding endpoints, for scheduled jobs and repository actions.

`stats_counts.mojito.Repository_action:`
- Tags: action, user, repository name
- Every time any action is made, Create, Update.
- This could give an indication to how much these endpoints are used.
- Allows alerting if repository locales are updated - can set up Slack channel alerts. 

`stats_counts.mojito.ScheduledThirdPartySync_action:`
- Tags: action, user, scheduled job type
- Every time any action is made, Create, Update, Delete, Restore, Enable, Disable, or Run. 
- This could give an indication to how much these endpoints are used.
- There could be alerts for Delete, Disable, or Run, maybe just a message into the i18n slack channel - for awareness if these actions were intentional or raise concerns if they were unintentional.

