### PR TITLE
Change log level to debug for jedis retrieval log

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/redis/RedisPoolManager.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/redis/RedisPoolManager.java
@@ -132,7 +132,7 @@ public class RedisPoolManager {
   }
 
   public Jedis getJedis() {
-    LOG.info("Getting Jedis");
+    LOG.debug("Getting Jedis");
     return this.jedisPool.getResource();
   }
 


### PR DESCRIPTION
As per title, changing log level to avoid excessive logging at runtime