### PR TITLE
Remove User Tag from Statsboard Metric

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
@@ -12,8 +12,6 @@ import com.box.l10n.mojito.entity.RepositoryLocale;
 import com.box.l10n.mojito.entity.RepositoryStatistic;
 import com.box.l10n.mojito.entity.ScreenshotRun;
 import com.box.l10n.mojito.entity.TM;
-import com.box.l10n.mojito.entity.security.user.User;
-import com.box.l10n.mojito.security.AuditorAwareImpl;
 import com.box.l10n.mojito.service.assetintegritychecker.AssetIntegrityCheckerRepository;
 import com.box.l10n.mojito.service.drop.exporter.DropExporterConfig;
 import com.box.l10n.mojito.service.locale.LocaleService;
@@ -67,8 +65,6 @@ public class RepositoryService {
   @Autowired ScreenshotRunRepository screenshotRunRepository;
 
   @Autowired MeterRegistry meterRegistry;
-
-  @Autowired AuditorAwareImpl auditorAwareImpl;
 
   /**
    * Default root locale.
@@ -805,7 +801,6 @@ public class RepositoryService {
       Enum<RepositoryServiceAction> action,
       Repository repository,
       boolean hasRepositoryLocalesChanged) {
-    User currentUser = auditorAwareImpl.getCurrentAuditor().orElse(null);
     meterRegistry
         .counter(
             "RepositoryService.action",
@@ -814,8 +809,6 @@ public class RepositoryService {
                 action.name(),
                 "Repository",
                 String.valueOf(repository.getName()),
-                "User",
-                currentUser != null ? currentUser.getUsername() : null,
                 "HasRepositoryLocalesChanged",
                 String.valueOf(hasRepositoryLocalesChanged)))
         .increment();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobService.java
@@ -3,8 +3,6 @@ package com.box.l10n.mojito.service.scheduledjob;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.ScheduledJob;
 import com.box.l10n.mojito.entity.ScheduledJobType;
-import com.box.l10n.mojito.entity.security.user.User;
-import com.box.l10n.mojito.security.AuditorAwareImpl;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
@@ -24,8 +22,6 @@ public class ScheduledJobService {
   private final ScheduledJobTypeRepository scheduledJobTypeRepository;
   private final ScheduledJobManager scheduledJobManager;
   private final RepositoryRepository repositoryRepository;
-
-  @Autowired AuditorAwareImpl auditorAwareImpl;
 
   @Autowired MeterRegistry meterRegistry;
 
@@ -184,7 +180,6 @@ public class ScheduledJobService {
 
   public void uptickScheduledThirdPartySyncActionMetric(
       Enum<ScheduledJobServiceAction> action, ScheduledJob scheduledJob) {
-    User currentUser = auditorAwareImpl.getCurrentAuditor().orElse(null);
     meterRegistry
         .counter(
             "ScheduledJobService.action",
@@ -194,9 +189,7 @@ public class ScheduledJobService {
                 "JobType",
                 String.valueOf(scheduledJob.getJobType().getEnum()),
                 "Repository",
-                scheduledJob.getRepository().getName(),
-                "User",
-                currentUser != null ? currentUser.getUsername() : null))
+                scheduledJob.getRepository().getName()))
         .increment();
   }
 }


### PR DESCRIPTION
Since there could be a large number of users, this would mean that each user needs their own time series on Statsboard, which could lead to a tonne of different tags.

This PR:
- removes the User tag from Statsboard Metric for Repository Service action and Scheduled Job Service action