### PR TITLE
Append branches translated in the past 30 days

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchRepository.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.service.branch;
 
 import com.box.l10n.mojito.entity.Branch;
 import com.box.l10n.mojito.entity.Repository;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -37,6 +38,7 @@ public interface BranchRepository
         INNER JOIN BranchStatistic bs ON bs.branch = b
         INNER JOIN BranchMergeTarget bmt ON b = bmt.branch
         WHERE bs.translatedDate IS NOT NULL
+        AND bs.translatedDate >= :cutoffDate
         AND bs.forTranslationCount = 0
         AND bs.totalCount > 0
         AND bmt.targetsMain = true
@@ -44,5 +46,6 @@ public interface BranchRepository
         AND b.deleted = false
         ORDER BY bs.translatedDate ASC
         """)
-  List<Branch> findBranchesForAppending(@Param("repository") Repository repository);
+  List<Branch> findBranchesForAppending(
+      @Param("repository") Repository repository, @Param("cutoffDate") ZonedDateTime cutoffDate);
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/appender/AssetAppenderServiceTest.java
@@ -21,6 +21,7 @@ import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -108,6 +109,7 @@ public class AssetAppenderServiceTest {
     asset.setRepository(localRepository);
 
     assetAppenderService.DEFAULT_APPEND_LIMIT = 1000;
+    assetAppenderService.branchesTranslatedMaxAge = Duration.ofDays(30);
   }
 
   @Test
@@ -117,7 +119,7 @@ public class AssetAppenderServiceTest {
     assetAppenderService.appendBranchTextUnitsToSource(
         asset, localizedAssetBody.getAppendBranchTextUnitsId(), content);
 
-    verify(branchRepositoryMock, times(0)).findBranchesForAppending(any());
+    verify(branchRepositoryMock, times(0)).findBranchesForAppending(any(), any());
   }
 
   @Test
@@ -156,7 +158,7 @@ public class AssetAppenderServiceTest {
           i.addAndGet(2);
         });
 
-    when(branchRepositoryMock.findBranchesForAppending(any())).thenReturn(branches);
+    when(branchRepositoryMock.findBranchesForAppending(any(), any())).thenReturn(branches);
 
     assetAppenderService.appendBranchTextUnitsToSource(
         asset, localizedAssetBody.getAppendBranchTextUnitsId(), content);
@@ -206,7 +208,7 @@ public class AssetAppenderServiceTest {
 
     assetAppenderService.DEFAULT_APPEND_LIMIT = 10;
 
-    when(branchRepositoryMock.findBranchesForAppending(any())).thenReturn(branches);
+    when(branchRepositoryMock.findBranchesForAppending(any(), any())).thenReturn(branches);
 
     assetAppenderService.appendBranchTextUnitsToSource(
         asset, localizedAssetBody.getAppendBranchTextUnitsId(), content);
@@ -250,7 +252,7 @@ public class AssetAppenderServiceTest {
 
     // For every branch, return the same 2 text units for appending
     when(branchStatisticServiceMock.getTextUnitDTOsForBranch(any())).thenReturn(textUnits);
-    when(branchRepositoryMock.findBranchesForAppending(any())).thenReturn(branches);
+    when(branchRepositoryMock.findBranchesForAppending(any(), any())).thenReturn(branches);
 
     assetAppenderService.appendBranchTextUnitsToSource(
         asset, localizedAssetBody.getAppendBranchTextUnitsId(), content);


### PR DESCRIPTION
Branches are deleted after 3 month which is too much time to be appending text units to the source asset during Safe i18n. This PR makes sure only branches that were translated in the last 30 days are appended to the source asset.

The duration is configurable using: `l10n.asset-appender.branches.translated-max-age`