### PR TITLE
Fix AITranslateCronJob head of queue blocking

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/TmTextUnitPendingMT.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/TmTextUnitPendingMT.java
@@ -15,6 +15,9 @@ public class TmTextUnitPendingMT extends BaseEntity {
   @Column(name = "created_date")
   private ZonedDateTime createdDate;
 
+  @Column(name = "processing_started_at")
+  private ZonedDateTime processingStartedAt;
+
   public ZonedDateTime getCreatedDate() {
     return createdDate;
   }
@@ -29,5 +32,13 @@ public class TmTextUnitPendingMT extends BaseEntity {
 
   public void setTmTextUnitId(Long tmTextUnitId) {
     this.tmTextUnitId = tmTextUnitId;
+  }
+
+  public ZonedDateTime getProcessingStartedAt() {
+    return processingStartedAt;
+  }
+
+  public void setProcessingStartedAt(ZonedDateTime processingStartedAt) {
+    this.processingStartedAt = processingStartedAt;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -436,7 +436,7 @@ public class AITranslateCronJob implements Job {
   @Override
   @Timed("AITranslateCronJob.execute")
   public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
-    logger.info("Executing AITranslateCronJob");
+    logger.debug("Executing AITranslateCronJob");
 
     aiTranslationService.resetExpiredProcessingStartedAtEntries(
         aiTranslationConfiguration.getTimeout());
@@ -451,7 +451,7 @@ public class AITranslateCronJob implements Job {
           tmTextUnitPendingMTRepository.findBatch(aiTranslationConfiguration.getBatchSize());
 
       if (pendingMTs.isEmpty()) {
-        logger.info("No pending MTs to process, finishing early.");
+        logger.debug("No pending MTs to process, finishing early.");
         return;
       }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -53,7 +53,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
 import org.springframework.scheduling.quartz.JobDetailFactoryBean;
 import org.springframework.stereotype.Component;
@@ -100,8 +99,6 @@ public class AITranslateCronJob implements Job {
   @Autowired TmTextUnitPendingMTRepository tmTextUnitPendingMTRepository;
 
   @Autowired TextUnitSearcher textUnitSearcher;
-
-  @Autowired JdbcTemplate jdbcTemplate;
 
   @Autowired(required = false)
   GlossaryCacheService glossaryCacheService;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -28,7 +28,6 @@ import com.box.l10n.mojito.service.tm.search.UsedFilter;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -431,7 +430,6 @@ public class AITranslateCronJob implements Job {
    */
   @Override
   @Timed("AITranslateCronJob.execute")
-  @Transactional
   public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
     logger.info("Executing AITranslateCronJob");
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJob.java
@@ -588,7 +588,9 @@ public class AITranslateCronJob implements Job {
                 aiTranslationConfiguration.getRateLimit().getMaxPollInterval().toMillis());
       }
       throw new AITranslateTimeoutException();
-    } catch (JedisException | InterruptedException e) {
+    } catch (InterruptedException e) {
+      throw new AITranslateTimeoutException();
+    } catch (JedisException e) {
       logger.error("Error checking rate limit for AI translation, proceeding with translation");
       meterRegistry
           .counter(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTimeoutException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTimeoutException.java
@@ -1,0 +1,7 @@
+package com.box.l10n.mojito.service.ai.translation;
+
+public class AITranslateTimeoutException extends RuntimeException {
+  public AITranslateTimeoutException() {
+    super();
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListener.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListener.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.ai.translation;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.quartz.JobExecutionContext;
 import org.quartz.Trigger;
 import org.quartz.listeners.TriggerListenerSupport;
@@ -26,12 +27,15 @@ public class AITranslateTriggerListener extends TriggerListenerSupport {
 
   private final int maxConcurrentJobs;
   private final JdbcTemplate jdbcTemplate;
+  private final MeterRegistry meterRegistry;
 
   public AITranslateTriggerListener(
       @Value("${l10n.ai.translation.job.maxConcurrentJobs:0}") int maxConcurrentJobs,
-      JdbcTemplate jdbcTemplate) {
+      JdbcTemplate jdbcTemplate,
+      MeterRegistry meterRegistry) {
     this.maxConcurrentJobs = maxConcurrentJobs;
     this.jdbcTemplate = jdbcTemplate;
+    this.meterRegistry = meterRegistry;
   }
 
   @Override
@@ -66,6 +70,8 @@ public class AITranslateTriggerListener extends TriggerListenerSupport {
           triggerName,
           currentlyRunningJobs,
           maxConcurrentJobs);
+
+      meterRegistry.counter("AITranslateTriggerListener.jobVetoed").increment();
     }
 
     return veto;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListener.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListener.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.ai.translation;
 
+import com.box.l10n.mojito.quartz.QuartzService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.quartz.JobExecutionContext;
 import org.quartz.Trigger;
@@ -7,7 +8,6 @@ import org.quartz.listeners.TriggerListenerSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
@@ -26,15 +26,15 @@ public class AITranslateTriggerListener extends TriggerListenerSupport {
       "SELECT COUNT(*) FROM QRTZ_FIRED_TRIGGERS WHERE TRIGGER_NAME = ? AND STATE = 'EXECUTING'";
 
   private final int maxConcurrentJobs;
-  private final JdbcTemplate jdbcTemplate;
+  private final QuartzService quartzService;
   private final MeterRegistry meterRegistry;
 
   public AITranslateTriggerListener(
       @Value("${l10n.ai.translation.job.maxConcurrentJobs:0}") int maxConcurrentJobs,
-      JdbcTemplate jdbcTemplate,
+      QuartzService quartzService,
       MeterRegistry meterRegistry) {
     this.maxConcurrentJobs = maxConcurrentJobs;
-    this.jdbcTemplate = jdbcTemplate;
+    this.quartzService = quartzService;
     this.meterRegistry = meterRegistry;
   }
 
@@ -61,8 +61,9 @@ public class AITranslateTriggerListener extends TriggerListenerSupport {
     if (maxConcurrentJobs <= 0) return false;
 
     final String triggerName = trigger.getKey().getName();
-    final int currentlyRunningJobs = getCurrentlyRunningJobsCount(triggerName);
-    final boolean veto = currentlyRunningJobs >= maxConcurrentJobs;
+    final int currentlyRunningJobs =
+        quartzService.getCurrentlyExecutingJobsCountForTrigger(triggerName);
+    final boolean veto = currentlyRunningJobs > maxConcurrentJobs;
 
     if (veto) {
       logger.warn(
@@ -75,16 +76,5 @@ public class AITranslateTriggerListener extends TriggerListenerSupport {
     }
 
     return veto;
-  }
-
-  /**
-   * Fetches the count of currently running jobs for the specified trigger.
-   *
-   * @param triggerName the name of the trigger
-   * @return the number of currently executing jobs for this trigger
-   */
-  private int getCurrentlyRunningJobsCount(String triggerName) {
-    Integer count = jdbcTemplate.queryForObject(EXECUTING_JOBS_QUERY, Integer.class, triggerName);
-    return count != null ? count : 0;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListener.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListener.java
@@ -1,0 +1,81 @@
+package com.box.l10n.mojito.service.ai.translation;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.Trigger;
+import org.quartz.listeners.TriggerListenerSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * A trigger listener for AI translation jobs that controls the maximum number of concurrent jobs by
+ * vetoing job execution when the limit is exceeded.
+ *
+ * @author mattwilshire
+ */
+@Component
+public class AITranslateTriggerListener extends TriggerListenerSupport {
+
+  private static final Logger logger = LoggerFactory.getLogger(AITranslateTriggerListener.class);
+
+  private static final String LISTENER_NAME = "AITranslateTriggerListener";
+  private static final String EXECUTING_JOBS_QUERY =
+      "SELECT COUNT(*) FROM QRTZ_FIRED_TRIGGERS WHERE TRIGGER_NAME = ? AND STATE = 'EXECUTING'";
+
+  private final int maxConcurrentJobs;
+  private final JdbcTemplate jdbcTemplate;
+
+  public AITranslateTriggerListener(
+      @Value("${l10n.ai.translation.job.maxConcurrentJobs:0}") int maxConcurrentJobs,
+      JdbcTemplate jdbcTemplate) {
+    this.maxConcurrentJobs = maxConcurrentJobs;
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public String getName() {
+    return LISTENER_NAME;
+  }
+
+  @Override
+  public void triggerFired(Trigger trigger, JobExecutionContext context) {
+    super.triggerFired(trigger, context);
+    logger.debug("Trigger fired: {}", trigger.getKey());
+  }
+
+  /**
+   * Determines whether to veto job execution based on the maximum concurrent jobs limit.
+   *
+   * @param trigger the trigger that was fired
+   * @param context the job execution context
+   * @return true if job execution should be vetoed, false otherwise
+   */
+  @Override
+  public boolean vetoJobExecution(Trigger trigger, JobExecutionContext context) {
+    if (maxConcurrentJobs <= 0) return false;
+
+    final String triggerName = trigger.getKey().getName();
+    final int currentlyRunningJobs = getCurrentlyRunningJobsCount(triggerName);
+
+    logger.info(
+        "Currently running jobs for trigger '{}': {} (max allowed: {})",
+        triggerName,
+        currentlyRunningJobs,
+        maxConcurrentJobs);
+
+    return currentlyRunningJobs > maxConcurrentJobs;
+  }
+
+  /**
+   * Fetches the count of currently running jobs for the specified trigger.
+   *
+   * @param triggerName the name of the trigger
+   * @return the number of currently executing jobs for this trigger
+   */
+  private int getCurrentlyRunningJobsCount(String triggerName) {
+    Integer count = jdbcTemplate.queryForObject(EXECUTING_JOBS_QUERY, Integer.class, triggerName);
+    return count != null ? count : 0;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListener.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListener.java
@@ -42,7 +42,7 @@ public class AITranslateTriggerListener extends TriggerListenerSupport {
   @Override
   public void triggerFired(Trigger trigger, JobExecutionContext context) {
     super.triggerFired(trigger, context);
-    logger.debug("Trigger fired: {}", trigger.getKey());
+    logger.debug("AITranslateTriggerListener: Trigger fired: {}", trigger.getKey());
   }
 
   /**
@@ -58,14 +58,17 @@ public class AITranslateTriggerListener extends TriggerListenerSupport {
 
     final String triggerName = trigger.getKey().getName();
     final int currentlyRunningJobs = getCurrentlyRunningJobsCount(triggerName);
+    final boolean veto = currentlyRunningJobs >= maxConcurrentJobs;
 
-    logger.info(
-        "Currently running jobs for trigger '{}': {} (max allowed: {})",
-        triggerName,
-        currentlyRunningJobs,
-        maxConcurrentJobs);
+    if (veto) {
+      logger.warn(
+          "Vetoing job execution for trigger '{}' as currently running jobs ({}) exceed max allowed ({})",
+          triggerName,
+          currentlyRunningJobs,
+          maxConcurrentJobs);
+    }
 
-    return currentlyRunningJobs > maxConcurrentJobs;
+    return veto;
   }
 
   /**

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerManager.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerManager.java
@@ -28,7 +28,6 @@ public class AITranslateTriggerManager {
 
   @PostConstruct
   void init() throws SchedulerException {
-    System.out.println("AITranslateTriggerManager initialized with maxConcurrentJobs > 0");
     schedulerManager
         .getScheduler(DEFAULT_SCHEDULER_NAME)
         .getListenerManager()

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerManager.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerManager.java
@@ -1,0 +1,39 @@
+package com.box.l10n.mojito.service.ai.translation;
+
+import static com.box.l10n.mojito.quartz.QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
+
+import com.box.l10n.mojito.quartz.QuartzSchedulerManager;
+import jakarta.annotation.PostConstruct;
+import org.quartz.SchedulerException;
+import org.quartz.TriggerKey;
+import org.quartz.impl.matchers.KeyMatcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+/**
+ * Attaches the {@link AITranslateTriggerListener} to the AITranslateCronJob trigger if the max
+ * concurrent jobs is set and greater than 0. This allows the listener to veto job execution if the
+ * number of currently running AI translation jobs exceed the limit.
+ *
+ * @author mattwilshire
+ */
+@Component
+@ConditionalOnExpression("${l10n.ai.translation.job.maxConcurrentJobs:0} > 0")
+public class AITranslateTriggerManager {
+
+  @Autowired QuartzSchedulerManager schedulerManager;
+
+  @Autowired AITranslateTriggerListener aiTranslateTriggerListener;
+
+  @PostConstruct
+  void init() throws SchedulerException {
+    System.out.println("AITranslateTriggerManager initialized with maxConcurrentJobs > 0");
+    schedulerManager
+        .getScheduler(DEFAULT_SCHEDULER_NAME)
+        .getListenerManager()
+        .addTriggerListener(
+            aiTranslateTriggerListener,
+            KeyMatcher.keyEquals(TriggerKey.triggerKey("triggerAiTranslateCronJob")));
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationConfiguration.java
@@ -75,6 +75,8 @@ public class AITranslationConfiguration {
     private Duration windowSize;
     private Duration minPollInterval;
     private Duration maxPollInterval;
+    private Duration minJitter = Duration.ofMillis(50);
+    private Duration maxJitter = Duration.ofMillis(200);
 
     public boolean isEnabled() {
       return enabled;
@@ -114,6 +116,22 @@ public class AITranslationConfiguration {
 
     public void setMaxPollInterval(Duration maxPollInterval) {
       this.maxPollInterval = maxPollInterval;
+    }
+
+    public Duration getMinJitter() {
+      return minJitter;
+    }
+
+    public void setMinJitter(Duration minJitter) {
+      this.minJitter = minJitter;
+    }
+
+    public Duration getMaxJitter() {
+      return maxJitter;
+    }
+
+    public void setMaxJitter(Duration maxJitter) {
+      this.maxJitter = maxJitter;
     }
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
@@ -260,7 +260,11 @@ public class AITranslationService {
   @Transactional
   public void resetExpiredProcessingStartedAtEntries(Duration expiryDuration) {
     String sql =
-        "UPDATE tm_text_unit_pending_mt SET processing_started_at = NULL WHERE processing_started_at < CURRENT_TIMESTAMP - ?";
+        """
+            UPDATE tm_text_unit_pending_mt
+            SET processing_started_at = NULL
+            WHERE processing_started_at < CURRENT_TIMESTAMP - INTERVAL ? SECOND
+        """;
     jdbcTemplate.update(sql, expiryDuration.toSeconds());
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
@@ -242,4 +242,36 @@ public class AITranslationService {
     tmTextUnitPendingMT.setCreatedDate(JSR310Migration.newDateTimeEmptyCtor());
     return tmTextUnitPendingMT;
   }
+
+  public void bulkUpdateProcessingStartedAt(List<TmTextUnitPendingMT> pendingMTs) {
+    if (pendingMTs.isEmpty()) return;
+
+    String placeholders = pendingMTs.stream().map(p -> "?").collect(Collectors.joining(","));
+    String sql =
+        "UPDATE tm_text_unit_pending_mt SET processing_started_at = CURRENT_TIMESTAMP WHERE tm_text_unit_id IN ("
+            + placeholders
+            + ");";
+
+    jdbcTemplate.update(
+        sql, pendingMTs.stream().map(TmTextUnitPendingMT::getTmTextUnitId).toArray());
+  }
+
+  public void resetExpiredProcessingStartedAtEntries(Duration expiryDuration) {
+    String sql =
+        "UPDATE tm_text_unit_pending_mt SET processing_started_at = NULL WHERE processing_started_at < CURRENT_TIMESTAMP - ?";
+    jdbcTemplate.update(sql, expiryDuration.toSeconds());
+  }
+
+  public void resetProcessingStartedAtForTextUnits(Queue<TmTextUnitPendingMT> pendingMTs) {
+    if (pendingMTs.isEmpty()) return;
+
+    String placeholders = pendingMTs.stream().map(p -> "?").collect(Collectors.joining(","));
+    String sql =
+        "UPDATE tm_text_unit_pending_mt SET processing_started_at = NULL WHERE tm_text_unit_id IN ("
+            + placeholders
+            + ");";
+
+    jdbcTemplate.update(
+        sql, pendingMTs.stream().map(TmTextUnitPendingMT::getTmTextUnitId).toArray());
+  }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationService.java
@@ -243,6 +243,7 @@ public class AITranslationService {
     return tmTextUnitPendingMT;
   }
 
+  @Transactional
   public void bulkUpdateProcessingStartedAt(List<TmTextUnitPendingMT> pendingMTs) {
     if (pendingMTs.isEmpty()) return;
 
@@ -256,12 +257,14 @@ public class AITranslationService {
         sql, pendingMTs.stream().map(TmTextUnitPendingMT::getTmTextUnitId).toArray());
   }
 
+  @Transactional
   public void resetExpiredProcessingStartedAtEntries(Duration expiryDuration) {
     String sql =
         "UPDATE tm_text_unit_pending_mt SET processing_started_at = NULL WHERE processing_started_at < CURRENT_TIMESTAMP - ?";
     jdbcTemplate.update(sql, expiryDuration.toSeconds());
   }
 
+  @Transactional
   public void resetProcessingStartedAtForTextUnits(Queue<TmTextUnitPendingMT> pendingMTs) {
     if (pendingMTs.isEmpty()) return;
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/TmTextUnitPendingMTRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/TmTextUnitPendingMTRepository.java
@@ -13,7 +13,8 @@ public interface TmTextUnitPendingMTRepository extends JpaRepository<TmTextUnitP
   TmTextUnitPendingMT findByTmTextUnitId(Long tmTextUnitId);
 
   @Query(
-      value = "SELECT * FROM tm_text_unit_pending_mt ORDER BY id LIMIT :batchSize",
+      value =
+          "SELECT * FROM tm_text_unit_pending_mt WHERE processing_started_at is NULL ORDER BY id LIMIT :batchSize",
       nativeQuery = true)
   List<TmTextUnitPendingMT> findBatch(@Param("batchSize") int batchSize);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ratelimiter/SlidingWindowRateLimiter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ratelimiter/SlidingWindowRateLimiter.java
@@ -13,10 +13,10 @@ public class SlidingWindowRateLimiter {
   private final RedisClient redisClient;
   private final String rateLimiterKey;
   private final int maxRequests;
-  private final int windowSizeInMillis;
+  private final long windowSizeInMillis;
 
   public SlidingWindowRateLimiter(
-      RedisClient redisClient, String rateLimiterKey, int maxRequests, int windowSizeInMillis) {
+      RedisClient redisClient, String rateLimiterKey, int maxRequests, long windowSizeInMillis) {
     this.redisClient = redisClient;
     this.rateLimiterKey = rateLimiterKey;
     this.maxRequests = maxRequests;

--- a/webapp/src/main/resources/db/migration/V81__Add_processing_started_at.sql
+++ b/webapp/src/main/resources/db/migration/V81__Add_processing_started_at.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tm_text_unit_pending_mt ADD COLUMN processing_started_at DATETIME NULL;
+
+ALTER TABLE tm_text_unit_pending_mt
+ADD INDEX I__TM_TEXT_UNIT_PENDING_MT__PROCESSING_STARTED_AT (processing_started_at);

--- a/webapp/src/main/resources/redis/scripts/sliding-window-rate-limiter.lua
+++ b/webapp/src/main/resources/redis/scripts/sliding-window-rate-limiter.lua
@@ -15,8 +15,12 @@ redis.call('ZREMRANGEBYSCORE', key, 0, now_ms - window_size_ms)
 local current_request_count = redis.call('ZCARD', key)
 
 if current_request_count < max_requests then
-    -- Add the current request, use the current time as the score and unique identifier
-    redis.call('ZADD', key, now_ms, now_ms)
+    -- Add the current request, use the current time as the score and a unique identifier as member
+    -- Member needs to be unique, although the script is atomic, multiple requests can have the
+    -- same timestamp (milliseconds) but differ in microseconds, without this you get a tricky to debug
+    -- race condition where multiple requests at the same millisecond are counted as one
+    local unique_id = now_ms .. ":" .. math.random(1000000, 9999999)
+    redis.call('ZADD', key, now_ms, unique_id)
     redis.call('EXPIRE', key, math.ceil(window_size_ms / 1000))
     return 1
 else

--- a/webapp/src/main/resources/redis/scripts/sliding-window-rate-limiter.lua
+++ b/webapp/src/main/resources/redis/scripts/sliding-window-rate-limiter.lua
@@ -19,7 +19,7 @@ if current_request_count < max_requests then
     -- Member needs to be unique, although the script is atomic, multiple requests can have the
     -- same timestamp (milliseconds) but differ in microseconds, without this you get a tricky to debug
     -- race condition where multiple requests at the same millisecond are counted as one
-    local unique_id = now_ms .. ":" .. math.random(1000000, 9999999)
+    local unique_id = now_ms .. ":" .. now[2] .. ":" .. math.random(1000000, 9999999)
     redis.call('ZADD', key, now_ms, unique_id)
     redis.call('EXPIRE', key, math.ceil(window_size_ms / 1000))
     return 1

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateCronJobTest.java
@@ -62,7 +62,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
-import org.springframework.jdbc.core.JdbcTemplate;
 import redis.clients.jedis.exceptions.JedisException;
 
 public class AITranslateCronJobTest {
@@ -97,8 +96,6 @@ public class AITranslateCronJobTest {
 
   @Mock GlossaryCacheService glossaryCacheService;
 
-  @Mock JdbcTemplate jdbcTemplate;
-
   AITranslateCronJob aiTranslateCronJob;
 
   TMTextUnit tmTextUnit;
@@ -125,7 +122,6 @@ public class AITranslateCronJobTest {
     aiTranslateCronJob.textUnitSearcher = textUnitSearcher;
     aiTranslateCronJob.glossaryCacheService = glossaryCacheService;
     aiTranslateCronJob.tmTextUnitVariantCommentService = tmTextUnitVariantCommentService;
-    aiTranslateCronJob.jdbcTemplate = jdbcTemplate;
     aITranslationConfiguration = new AITranslationConfiguration();
     aITranslationConfiguration.setEnabled(true);
     aITranslationConfiguration.setCron("0 0/10 * * * ?");

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListenerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListenerTest.java
@@ -1,0 +1,66 @@
+package com.box.l10n.mojito.service.ai.translation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.quartz.Trigger;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class AITranslateTriggerListenerTest {
+
+  @Mock JdbcTemplate jdbcTemplateMock;
+
+  @Mock Trigger triggerMock;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    when(triggerMock.getKey())
+        .thenReturn(org.quartz.TriggerKey.triggerKey("triggerAiTranslateCronJob"));
+  }
+
+  @Test
+  public void testVetoWhenUnderLimit() {
+    AITranslateTriggerListener listener = new AITranslateTriggerListener(3, jdbcTemplateMock);
+
+    when(jdbcTemplateMock.queryForObject(anyString(), eq(Integer.class), any())).thenReturn(1);
+
+    boolean veto =
+        listener.vetoJobExecution(triggerMock, mock(org.quartz.JobExecutionContext.class));
+
+    assertFalse(veto);
+  }
+
+  @Test
+  public void testVetoFalseWhenOverLimit() {
+    AITranslateTriggerListener listener = new AITranslateTriggerListener(3, jdbcTemplateMock);
+
+    when(jdbcTemplateMock.queryForObject(anyString(), eq(Integer.class), any())).thenReturn(4);
+
+    boolean veto =
+        listener.vetoJobExecution(triggerMock, mock(org.quartz.JobExecutionContext.class));
+
+    assertTrue(veto);
+  }
+
+  @Test
+  public void testVetoWhenZero() {
+    AITranslateTriggerListener listener = new AITranslateTriggerListener(0, jdbcTemplateMock);
+
+    when(jdbcTemplateMock.queryForObject(anyString(), eq(Integer.class), any())).thenReturn(10);
+
+    boolean veto =
+        listener.vetoJobExecution(triggerMock, mock(org.quartz.JobExecutionContext.class));
+
+    assertFalse(veto);
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListenerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListenerTest.java
@@ -6,8 +6,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -21,16 +24,22 @@ public class AITranslateTriggerListenerTest {
 
   @Mock Trigger triggerMock;
 
+  @Mock MeterRegistry meterRegistryMock;
+
   @Before
   public void setup() {
     MockitoAnnotations.openMocks(this);
     when(triggerMock.getKey())
         .thenReturn(org.quartz.TriggerKey.triggerKey("triggerAiTranslateCronJob"));
+
+    when(meterRegistryMock.counter(anyString()))
+        .thenReturn(mock(io.micrometer.core.instrument.Counter.class));
   }
 
   @Test
   public void testVetoWhenUnderLimit() {
-    AITranslateTriggerListener listener = new AITranslateTriggerListener(3, jdbcTemplateMock);
+    AITranslateTriggerListener listener =
+        new AITranslateTriggerListener(3, jdbcTemplateMock, meterRegistryMock);
 
     when(jdbcTemplateMock.queryForObject(anyString(), eq(Integer.class), any())).thenReturn(1);
 
@@ -38,11 +47,13 @@ public class AITranslateTriggerListenerTest {
         listener.vetoJobExecution(triggerMock, mock(org.quartz.JobExecutionContext.class));
 
     assertFalse(veto);
+    verify(meterRegistryMock, times(0)).counter("AITranslateTriggerListener.jobVetoed");
   }
 
   @Test
-  public void testVetoFalseWhenOverLimit() {
-    AITranslateTriggerListener listener = new AITranslateTriggerListener(3, jdbcTemplateMock);
+  public void testVetoWhenOverLimit() {
+    AITranslateTriggerListener listener =
+        new AITranslateTriggerListener(3, jdbcTemplateMock, meterRegistryMock);
 
     when(jdbcTemplateMock.queryForObject(anyString(), eq(Integer.class), any())).thenReturn(4);
 
@@ -50,11 +61,13 @@ public class AITranslateTriggerListenerTest {
         listener.vetoJobExecution(triggerMock, mock(org.quartz.JobExecutionContext.class));
 
     assertTrue(veto);
+    verify(meterRegistryMock, times(1)).counter("AITranslateTriggerListener.jobVetoed");
   }
 
   @Test
   public void testVetoWhenZero() {
-    AITranslateTriggerListener listener = new AITranslateTriggerListener(0, jdbcTemplateMock);
+    AITranslateTriggerListener listener =
+        new AITranslateTriggerListener(0, jdbcTemplateMock, meterRegistryMock);
 
     when(jdbcTemplateMock.queryForObject(anyString(), eq(Integer.class), any())).thenReturn(10);
 
@@ -62,5 +75,6 @@ public class AITranslateTriggerListenerTest {
         listener.vetoJobExecution(triggerMock, mock(org.quartz.JobExecutionContext.class));
 
     assertFalse(veto);
+    verify(meterRegistryMock, times(0)).counter("AITranslateTriggerListener.jobVetoed");
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListenerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslateTriggerListenerTest.java
@@ -2,25 +2,23 @@ package com.box.l10n.mojito.service.ai.translation;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.box.l10n.mojito.quartz.QuartzService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.quartz.Trigger;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 public class AITranslateTriggerListenerTest {
 
-  @Mock JdbcTemplate jdbcTemplateMock;
+  @Mock QuartzService quartzService;
 
   @Mock Trigger triggerMock;
 
@@ -39,9 +37,9 @@ public class AITranslateTriggerListenerTest {
   @Test
   public void testVetoWhenUnderLimit() {
     AITranslateTriggerListener listener =
-        new AITranslateTriggerListener(3, jdbcTemplateMock, meterRegistryMock);
+        new AITranslateTriggerListener(3, quartzService, meterRegistryMock);
 
-    when(jdbcTemplateMock.queryForObject(anyString(), eq(Integer.class), any())).thenReturn(1);
+    when(quartzService.getCurrentlyExecutingJobsCountForTrigger(anyString())).thenReturn(1);
 
     boolean veto =
         listener.vetoJobExecution(triggerMock, mock(org.quartz.JobExecutionContext.class));
@@ -53,9 +51,9 @@ public class AITranslateTriggerListenerTest {
   @Test
   public void testVetoWhenOverLimit() {
     AITranslateTriggerListener listener =
-        new AITranslateTriggerListener(3, jdbcTemplateMock, meterRegistryMock);
+        new AITranslateTriggerListener(3, quartzService, meterRegistryMock);
 
-    when(jdbcTemplateMock.queryForObject(anyString(), eq(Integer.class), any())).thenReturn(4);
+    when(quartzService.getCurrentlyExecutingJobsCountForTrigger(anyString())).thenReturn(4);
 
     boolean veto =
         listener.vetoJobExecution(triggerMock, mock(org.quartz.JobExecutionContext.class));
@@ -67,9 +65,9 @@ public class AITranslateTriggerListenerTest {
   @Test
   public void testVetoWhenZero() {
     AITranslateTriggerListener listener =
-        new AITranslateTriggerListener(0, jdbcTemplateMock, meterRegistryMock);
+        new AITranslateTriggerListener(0, quartzService, meterRegistryMock);
 
-    when(jdbcTemplateMock.queryForObject(anyString(), eq(Integer.class), any())).thenReturn(10);
+    when(quartzService.getCurrentlyExecutingJobsCountForTrigger(anyString())).thenReturn(10);
 
     boolean veto =
         listener.vetoJobExecution(triggerMock, mock(org.quartz.JobExecutionContext.class));


### PR DESCRIPTION
AITranslateCronJob retrieves all pending text units for AI translation and processes (translates) them in batches. When one batch runs slowly, the remaining batches are delayed. 

This PR makes the following changes to resolve this blocking:

- **Removed** `@DisallowConcurrentExecution` to allow AITranslateCronJob to run concurrently.
- **Added** `processing_started_at` column that stores the date of when a text unit started being processed by the AITranslate job. The job will pull out `batchSize` text units that don't have a `processing_started_at` date to ensure no two jobs work on the same text unit. (Row lock using date time)
- **Added** Rate limiter and configured by:
```
l10n.ai.translation.rateLimit.maxRequests=100
l10n.ai.translation.rateLimit.windowSize=1m
l10n.ai.translation.rateLimit.minPollInterval=1s
l10n.ai.translation.rateLimit.maxPollInterval=5s
```

- Translate requests wait for rate limit by checking if their request is allowed in Redis, if allowed the request proceeds, if not allowed then we back off by the configured poll intervals. **If Redis is down or the rate limiter is not configured the request is allowed.**
- **Added** `l10n.ai.translation.timeout` to configure how long a translate thread has to run before timing out. If a text unit times out it's `processing_started_at` field is reset to allow another job to pick it up where it left off.
- **Refactor**: The text unit variant is set straight away when the translation comes back from the LLM service.
- **Added** `AITranslateTriggerListener` that controls the maximum number of concurrent AITranslateCronJobs and can be configured by `l10n.ai.translation.job.maxConcurrentJobs=3`
- **Added** `AITranslateTriggerManager` which applies the `AITranslateTriggerListener` if `l10n.ai.translation.job.maxConcurrentJobs` is configured and > 0.
