### PR TITLE
[I18N-2029] Migrate deprecated ReplayProcessor to new Sinks implementation (reactor.core)

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
@@ -51,12 +51,17 @@ public class RepositoryStatisticsUpdatedReactor {
         .subscribe(
             repositoryIds -> {
               for (Long repositoryId : Sets.newHashSet(repositoryIds)) {
-                meterRegistry
-                    .counter(
-                        "repositoryStatisticsUpdatedReactor.scheduleRepoStatsJob",
-                        Tags.of("repositoryId", String.valueOf(repositoryId)))
-                    .increment();
-                repositoryStatisticsJobScheduler.schedule(repositoryId);
+                try {
+                  meterRegistry
+                      .counter(
+                          "repositoryStatisticsUpdatedReactor.scheduleRepoStatsJob",
+                          Tags.of("repositoryId", String.valueOf(repositoryId)))
+                      .increment();
+                  repositoryStatisticsJobScheduler.schedule(repositoryId);
+                } catch (Exception e) {
+                  logger.error(
+                      "Failed to schedule repo stats job for repositoryId={}", repositoryId, e);
+                }
               }
             });
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
@@ -30,7 +30,7 @@ public class RepositoryStatisticsUpdatedReactor {
 
   @Autowired MeterRegistry meterRegistry;
 
-  @Value("${l10n.repositoryStatisticsUpdatedReactor.bufferDuration:PT10S}")
+  @Value("${l10n.repositoryStatisticsUpdatedReactor.bufferDuration:PT1S}")
   Duration bufferDuration;
 
   @Autowired
@@ -56,7 +56,6 @@ public class RepositoryStatisticsUpdatedReactor {
                         "repositoryStatisticsUpdatedReactor.scheduleRepoStatsJob",
                         Tags.of("repositoryId", String.valueOf(repositoryId)))
                     .increment();
-                logger.info("Running replay processor for repo id {}", repositoryId);
                 repositoryStatisticsJobScheduler.schedule(repositoryId);
               }
             });

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
@@ -45,7 +45,7 @@ public class RepositoryStatisticsUpdatedReactor {
   }
 
   void createProcessor() {
-    sink = Sinks.many().multicast().onBackpressureBuffer();
+    sink = Sinks.many().unicast().onBackpressureBuffer();
     sink.asFlux()
         .buffer(bufferDuration)
         .subscribe(
@@ -59,6 +59,11 @@ public class RepositoryStatisticsUpdatedReactor {
                       .increment();
                   repositoryStatisticsJobScheduler.schedule(repositoryId);
                 } catch (Exception e) {
+                  meterRegistry
+                      .counter(
+                          "repositoryStatisticsUpdatedReactor.scheduleRepoStatsJobException",
+                          Tags.of("repositoryId", String.valueOf(repositoryId)))
+                      .increment();
                   logger.error(
                       "Failed to schedule repo stats job for repositoryId={}", repositoryId, e);
                 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.ReplayProcessor;
+import reactor.core.publisher.Sinks;
 
 /**
  * This class aggregates events that requires repository statistics re-computation and saves at most
@@ -26,11 +26,11 @@ public class RepositoryStatisticsUpdatedReactor {
 
   RepositoryStatisticsJobScheduler repositoryStatisticsJobScheduler;
 
-  ReplayProcessor<Long> replayProcessor;
+  Sinks.Many<Long> sink;
 
   @Autowired MeterRegistry meterRegistry;
 
-  @Value("${l10n.repositoryStatisticsUpdatedReactor.bufferDuration:PT1S}")
+  @Value("${l10n.repositoryStatisticsUpdatedReactor.bufferDuration:PT10S}")
   Duration bufferDuration;
 
   @Autowired
@@ -45,8 +45,8 @@ public class RepositoryStatisticsUpdatedReactor {
   }
 
   void createProcessor() {
-    replayProcessor = ReplayProcessor.create();
-    replayProcessor
+    sink = Sinks.many().multicast().onBackpressureBuffer();
+    sink.asFlux()
         .buffer(bufferDuration)
         .subscribe(
             repositoryIds -> {
@@ -56,6 +56,7 @@ public class RepositoryStatisticsUpdatedReactor {
                         "repositoryStatisticsUpdatedReactor.scheduleRepoStatsJob",
                         Tags.of("repositoryId", String.valueOf(repositoryId)))
                     .increment();
+                logger.info("Running replay processor for repo id {}", repositoryId);
                 repositoryStatisticsJobScheduler.schedule(repositoryId);
               }
             });
@@ -67,6 +68,6 @@ public class RepositoryStatisticsUpdatedReactor {
    * @param repositoryId
    */
   public synchronized void generateEvent(Long repositoryId) {
-    replayProcessor.onNext(repositoryId);
+    sink.emitNext(repositoryId, Sinks.EmitFailureHandler.FAIL_FAST);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/statistics/RepositoryStatisticsUpdatedReactor.java
@@ -51,22 +51,12 @@ public class RepositoryStatisticsUpdatedReactor {
         .subscribe(
             repositoryIds -> {
               for (Long repositoryId : Sets.newHashSet(repositoryIds)) {
-                try {
-                  meterRegistry
-                      .counter(
-                          "repositoryStatisticsUpdatedReactor.scheduleRepoStatsJob",
-                          Tags.of("repositoryId", String.valueOf(repositoryId)))
-                      .increment();
-                  repositoryStatisticsJobScheduler.schedule(repositoryId);
-                } catch (Exception e) {
-                  meterRegistry
-                      .counter(
-                          "repositoryStatisticsUpdatedReactor.scheduleRepoStatsJobException",
-                          Tags.of("repositoryId", String.valueOf(repositoryId)))
-                      .increment();
-                  logger.error(
-                      "Failed to schedule repo stats job for repositoryId={}", repositoryId, e);
-                }
+                meterRegistry
+                    .counter(
+                        "repositoryStatisticsUpdatedReactor.scheduleRepoStatsJob",
+                        Tags.of("repositoryId", String.valueOf(repositoryId)))
+                    .increment();
+                repositoryStatisticsJobScheduler.schedule(repositoryId);
               }
             });
   }


### PR DESCRIPTION
## Summary
`ReplayProcessor` is deprecated and will be removed in `reactor.core` v3.5.
https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ReplayProcessor.html

We use `ReplayProcessor` to coalesce repository stats update events over a configurable buffer duration (default is 1s) in `RepositoryStatisticsUpdatedReactor`.

This PR replaces the `ReplayProcessor` with the suggested `Sinks` implementation closely representing the existing handling logic.

## Changes
`Sinks.many().unicast().onBackpressureBuffer();`

- `.many()` -> Accept many values, list of Longs.
- `.unicast()` -> Only allow one subscriber - we only have one subscriber consuming the events, deduplicating and firing them.
- `.onBackpressureBuffer()` -> Buffer events when the producer emits faster than the subscriber can consume - isn't much of an issue here, consumer fires asynchronous Pollable task jobs to calculate repo stats which is quick from the consumers perspective.

`sink.emitNext(repositoryId, Sinks.EmitFailureHandler.FAIL_FAST);` -> Emit the event to the Sink, failed emits should fail fast aligning closely with the previous `replayProcessor.onNext` logic.

## Tests
Test in `RepositoryStatisticsUpdatedReactorTest` doesn't need updating as logic works the same after migration.