### PR TITLE
Update .dockerignore to ignore frontend-v2 node ande node_modules directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 webapp/src/main/frontend/node_modules
 webapp/src/main/frontend/node
+webapp/src/main/frontend-v2/node_modules
+webapp/src/main/frontend-v2/node


### PR DESCRIPTION
Ignore the `node` and `node_modules` directories in `frontend-v2` to prevent ARM-specific Node binaries/packages from being included in the Docker image when built on mac.