### PR TITLE
Add minimum release age property for pnpm used by frontend-v2

### DIFF
--- a/webapp/src/main/frontend-v2/pnpm-workspace.yaml
+++ b/webapp/src/main/frontend-v2/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320


### PR DESCRIPTION
# Summary
https://pnpm.io/settings#minimumreleaseage

"`minimumReleaseAge` defines the minimum number of minutes that must pass after a version is published before pnpm will install it. This applies to all dependencies, **including transitive ones.**"

This property ensures any new packages we install for `frontend-v2` must be over `3` days old.