### PR TITLE
[I18N-2076] Add string name pattern exclusion to AI translation filter

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationFilterConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationFilterConfiguration.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.service.ai.translation;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +25,8 @@ public class AITranslationFilterConfiguration {
     private boolean excludePlaceholders;
     private boolean excludeHtmlTags;
     private String excludePlaceholdersRegex = "\\{[^\\}]*\\}";
+    private boolean excludeStringNamePatterns;
+    private List<String> excludeStringNamePatternsRegex = new ArrayList<>();
 
     public boolean shouldExcludePlurals() {
       return excludePlurals;
@@ -54,6 +58,22 @@ public class AITranslationFilterConfiguration {
 
     public void setExcludePlaceholdersRegex(String excludePlaceholdersRegex) {
       this.excludePlaceholdersRegex = excludePlaceholdersRegex;
+    }
+
+    public boolean shouldExcludeStringNamePatterns() {
+      return excludeStringNamePatterns;
+    }
+
+    public void setExcludeStringNamePatterns(boolean excludeStringNamePatterns) {
+      this.excludeStringNamePatterns = excludeStringNamePatterns;
+    }
+
+    public List<String> getExcludeStringNamePatternsRegex() {
+      return excludeStringNamePatternsRegex;
+    }
+
+    public void setExcludeStringNamePatternsRegex(List<String> excludeStringNamePatternsRegex) {
+      this.excludeStringNamePatternsRegex = excludeStringNamePatternsRegex;
     }
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationTextUnitFilterService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/ai/translation/AITranslationTextUnitFilterService.java
@@ -4,10 +4,13 @@ import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnit;
 import com.google.common.collect.Maps;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import jakarta.annotation.PostConstruct;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +25,7 @@ public class AITranslationTextUnitFilterService {
   private static final Pattern HTML_TAG_PATTERN = Pattern.compile(HTML_TAG_REGEX);
 
   protected Map<String, Pattern> excludePlaceholdersPatternMap;
+  protected Map<String, List<Pattern>> excludeStringNamePatternsMap;
 
   @Autowired AITranslationFilterConfiguration aiTranslationFilterConfiguration;
 
@@ -75,6 +79,20 @@ public class AITranslationTextUnitFilterService {
       }
     }
 
+    if (repositoryConfig.shouldExcludeStringNamePatterns()) {
+      if (matchesExcludedStringNamePattern(repository.getName(), tmTextUnit)) {
+        logger.debug(
+            "Text unit with name: {}, matches excluded string name pattern, AI translation will be skipped",
+            tmTextUnit.getName());
+        meterRegistry
+            .counter(
+                "AITranslationTextUnitFilterService.excludedByStringNamePattern",
+                Tags.of("repository", repository.getName()))
+            .increment();
+        return false;
+      }
+    }
+
     return true;
   }
 
@@ -99,9 +117,22 @@ public class AITranslationTextUnitFilterService {
     return matcher.find();
   }
 
+  private boolean matchesExcludedStringNamePattern(String repositoryName, TMTextUnit tmTextUnit) {
+    List<Pattern> patterns = excludeStringNamePatternsMap.get(repositoryName);
+    if (patterns != null) {
+      for (Pattern pattern : patterns) {
+        if (pattern.matcher(tmTextUnit.getName()).find()) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   @PostConstruct
   public void init() {
     excludePlaceholdersPatternMap = Maps.newHashMap();
+    excludeStringNamePatternsMap = Maps.newHashMap();
     if (aiTranslationFilterConfiguration.getRepositoryConfig() != null) {
       for (Map.Entry<String, AITranslationFilterConfiguration.RepositoryConfig> entry :
           aiTranslationFilterConfiguration.getRepositoryConfig().entrySet()) {
@@ -109,6 +140,13 @@ public class AITranslationTextUnitFilterService {
         if (repositoryConfig.shouldExcludePlaceholders()) {
           excludePlaceholdersPatternMap.put(
               entry.getKey(), Pattern.compile(repositoryConfig.getExcludePlaceholdersRegex()));
+        }
+        if (repositoryConfig.shouldExcludeStringNamePatterns()) {
+          excludeStringNamePatternsMap.put(
+              entry.getKey(),
+              repositoryConfig.getExcludeStringNamePatternsRegex().stream()
+                  .map(Pattern::compile)
+                  .collect(Collectors.toList()));
         }
       }
     }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslationTextUnitFilterServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslationTextUnitFilterServiceTest.java
@@ -8,7 +8,6 @@ import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.PluralForm;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnit;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Collections;
 import java.util.List;
@@ -177,7 +176,8 @@ public class AITranslationTextUnitFilterServiceTest {
 
   private void setTestParameters(
       boolean excludePlurals, boolean excludePlaceholders, boolean excludeHtmlTags) {
-    setTestParameters(excludePlurals, excludePlaceholders, excludeHtmlTags, false, Collections.emptyList());
+    setTestParameters(
+        excludePlurals, excludePlaceholders, excludeHtmlTags, false, Collections.emptyList());
   }
 
   private void setTestParameters(

--- a/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslationTextUnitFilterServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/ai/translation/AITranslationTextUnitFilterServiceTest.java
@@ -8,8 +8,13 @@ import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.PluralForm;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnit;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -29,11 +34,13 @@ public class AITranslationTextUnitFilterServiceTest {
     when(testAsset.getRepository()).thenReturn(repository);
     when(repository.getName()).thenReturn("test");
     textUnitFilterService = new AITranslationTextUnitFilterService();
+    textUnitFilterService.meterRegistry = new SimpleMeterRegistry();
     AITranslationFilterConfiguration translationFilterConfiguration =
         new AITranslationFilterConfiguration();
-    setTestParameters(true, true, true);
+    setTestParameters(true, true, true, false, Collections.emptyList());
     textUnitFilterService.excludePlaceholdersPatternMap =
         Map.of("test", Pattern.compile("\\{[^\\}]*\\}"));
+    textUnitFilterService.excludeStringNamePatternsMap = Map.of();
   }
 
   @Test
@@ -128,8 +135,57 @@ public class AITranslationTextUnitFilterServiceTest {
     assertTrue(textUnitFilterService.isTranslatable(tmTextUnit, repository));
   }
 
+  @Test
+  public void testIsTranslatableWithExcludedStringNamePattern() {
+    setTestParameters(false, false, false, true, List.of(".*_legal_.*"));
+    TMTextUnit tmTextUnit = new TMTextUnit();
+    tmTextUnit.setName("tos_legal_disclaimer");
+    tmTextUnit.setContent("some content");
+    tmTextUnit.setAsset(testAsset);
+    assertFalse(textUnitFilterService.isTranslatable(tmTextUnit, repository));
+  }
+
+  @Test
+  public void testIsTranslatableWithNonMatchingStringNamePattern() {
+    setTestParameters(false, false, false, true, List.of(".*_legal_.*"));
+    TMTextUnit tmTextUnit = new TMTextUnit();
+    tmTextUnit.setName("homepage_title");
+    tmTextUnit.setContent("some content");
+    tmTextUnit.setAsset(testAsset);
+    assertTrue(textUnitFilterService.isTranslatable(tmTextUnit, repository));
+  }
+
+  @Test
+  public void testIsTranslatableWithMultipleStringNamePatterns() {
+    setTestParameters(false, false, false, true, List.of(".*_legal_.*", ".*_brand_.*"));
+    TMTextUnit tmTextUnit = new TMTextUnit();
+    tmTextUnit.setName("pinterest_brand_name");
+    tmTextUnit.setContent("some content");
+    tmTextUnit.setAsset(testAsset);
+    assertFalse(textUnitFilterService.isTranslatable(tmTextUnit, repository));
+  }
+
+  @Test
+  public void testIsTranslatableStringNamePatternsDisabled() {
+    setTestParameters(false, false, false, false, List.of(".*_legal_.*"));
+    TMTextUnit tmTextUnit = new TMTextUnit();
+    tmTextUnit.setName("tos_legal_disclaimer");
+    tmTextUnit.setContent("some content");
+    tmTextUnit.setAsset(testAsset);
+    assertTrue(textUnitFilterService.isTranslatable(tmTextUnit, repository));
+  }
+
   private void setTestParameters(
       boolean excludePlurals, boolean excludePlaceholders, boolean excludeHtmlTags) {
+    setTestParameters(excludePlurals, excludePlaceholders, excludeHtmlTags, false, Collections.emptyList());
+  }
+
+  private void setTestParameters(
+      boolean excludePlurals,
+      boolean excludePlaceholders,
+      boolean excludeHtmlTags,
+      boolean excludeStringNamePatterns,
+      List<String> excludeStringNamePatternsRegex) {
     AITranslationFilterConfiguration translationFilterConfiguration =
         new AITranslationFilterConfiguration();
     AITranslationFilterConfiguration.RepositoryConfig repositoryConfig =
@@ -138,10 +194,22 @@ public class AITranslationTextUnitFilterServiceTest {
     repositoryConfig.setExcludePlaceholders(excludePlaceholders);
     repositoryConfig.setExcludeHtmlTags(excludeHtmlTags);
     repositoryConfig.setExcludePlaceholdersRegex("\\{[^\\}]*\\}");
+    repositoryConfig.setExcludeStringNamePatterns(excludeStringNamePatterns);
+    repositoryConfig.setExcludeStringNamePatternsRegex(excludeStringNamePatternsRegex);
     translationFilterConfiguration.setRepositoryConfig(Map.of("test", repositoryConfig));
 
     textUnitFilterService.aiTranslationFilterConfiguration = translationFilterConfiguration;
     textUnitFilterService.excludePlaceholdersPatternMap =
         Map.of("test", Pattern.compile("\\{[^\\}]*\\}"));
+    if (excludeStringNamePatterns && !excludeStringNamePatternsRegex.isEmpty()) {
+      textUnitFilterService.excludeStringNamePatternsMap =
+          Map.of(
+              "test",
+              excludeStringNamePatternsRegex.stream()
+                  .map(Pattern::compile)
+                  .collect(Collectors.toList()));
+    } else {
+      textUnitFilterService.excludeStringNamePatternsMap = Map.of();
+    }
   }
 }


### PR DESCRIPTION
Add ability to exclude strings from AI translation based on their name/id matching configurable regex patterns. Patterns can be configured on a repository level