### PR TITLE
Fix sticky text unit ids in Search params after navigating from the branch page

### DIFF
--- a/webapp/src/main/frontend/js/stores/workbench/SearchParamsStore.js
+++ b/webapp/src/main/frontend/js/stores/workbench/SearchParamsStore.js
@@ -125,6 +125,7 @@ class SearchParamsStore {
             case SearchConstants.REPOSITORIES_CHANGED:
 
                 this.setFirstPageAsCurrent();
+                this.clearTmTextUnitIds();
                 this.repoIds = paramData.repoIds;
                 this.filterBcp47TagsForSelectedRepositories();
                 break;
@@ -132,12 +133,14 @@ class SearchParamsStore {
             case SearchConstants.LOCALES_CHANGED:
 
                 this.setFirstPageAsCurrent();
+                this.clearTmTextUnitIds();
                 this.bcp47Tags = paramData.bcp47Tags;
                 break;
 
             case SearchConstants.SEARCHTEXT_CHANGED:
 
                 this.setFirstPageAsCurrent();
+                this.clearTmTextUnitIds();
                 this.searchText = paramData.data.searchText;
                 this.searchAttribute = paramData.data.searchAttribute;
                 this.searchType = paramData.data.searchType;
@@ -146,6 +149,7 @@ class SearchParamsStore {
             case SearchConstants.SEARCHFILTER_CHANGED:
 
                 this.setFirstPageAsCurrent();
+                this.clearTmTextUnitIds();
                 this[paramData.searchFilterParam] = paramData.searchFilterParamValue;
                 break;
 
@@ -358,6 +362,11 @@ class SearchParamsStore {
 
     updatePageOffset() {
         this.pageOffset = (this.currentPageNumber - 1) * this.pageSize;
+    }
+
+    clearTmTextUnitIds() {
+        this.tmTextUnitIds = [];
+        this.branchId = null;
     }
 
     setFirstPageAsCurrent() {


### PR DESCRIPTION
 ## Problem

  When clicking a string ID from the branch page, the user is navigated to the workbench with a `tmTextUnitIds` filter set. Any subsequent search actions (changing repos, locales, text, or filters) continued to include that filter in API requests, effectively limiting results to just that one text unit.

## Solution

  Added `clearTmTextUnitIds` method to SearchParamsStore that empties `tmTextUnitIds` and sets `branchId` to null.

This is called on cases where the search changes text units to be displayed (notice it's called after setFirstPageAsCurrent): `REPOSITORIES_CHANGED`, `LOCALES_CHANGED`, `SEARCHTEXT_CHANGED`, and `SEARCHFILTER_CHANGED`.

## Test plan
Tested locally, works as intended.