### PR TITLE
I18N-1387 Support skipping i18n checks via GitHub PR label

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommand.java
@@ -67,6 +67,13 @@ public class GithubPRInfoCommand extends Command {
   String owner;
 
   @Parameter(
+      names = {"--skip-i18n-checks-label"},
+      arity = 1,
+      required = false,
+      description = "Github label name that is used to trigger skipping i18n checks")
+  String skipI18NChecksLabel = "skip-i18n-checks";
+
+  @Parameter(
       names = {"--skip-i18n-push-label"},
       arity = 1,
       required = false,
@@ -115,8 +122,13 @@ public class GithubPRInfoCommand extends Command {
           .a(getUsernameForAuthorEmail(authorEmail))
           .println();
       List<GHIssueComment> prComments = github.getPRComments(repository, prNumber);
-      if (isSkipChecks(prComments)) {
-        addReactionToSkipChecksComment(prComments);
+      boolean skipChecksViaComment = isSkipChecks(prComments);
+      boolean skipChecksViaLabel =
+          github.isLabelAppliedToPR(repository, prNumber, skipI18NChecksLabel);
+      if (skipChecksViaComment || skipChecksViaLabel) {
+        if (skipChecksViaComment) {
+          addReactionToSkipChecksComment(prComments);
+        }
         consoleWriterAnsiCodeEnabledFalse.a("MOJITO_SKIP_I18N_CHECKS=true").println();
       } else {
         consoleWriterAnsiCodeEnabledFalse.a("MOJITO_SKIP_I18N_CHECKS=false").println();

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithub.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithub.java
@@ -207,7 +207,7 @@ public class ExtractionCheckNotificationSenderGithub extends ExtractionCheckNoti
               githubRepo,
               commitSha,
               GHCommitState.SUCCESS,
-              "Checks disabled as SKIP_I18N_CHECKS was applied in comments.",
+              "Checks disabled because a SKIP_I18N_CHECKS comment or label was found.",
               "I18N String Checks",
               commitStatusTargetUrl);
     }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommandTest.java
@@ -159,4 +159,39 @@ public class GithubPRInfoCommandTest {
     verify(this.consoleWriterMock, times(1))
         .a(String.format("%s=true", GithubPRInfoCommand.SKIP_MAX_STRINGS_BLOCK_FLAG));
   }
+
+  @Test
+  public void testExecuteWithChecksSkippedViaLabel() throws IOException {
+    when(githubMock.isLabelAppliedToPR("testRepo", 1, "skip-i18n-checks")).thenReturn(true);
+    githubPRInfoCommand.execute();
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_BASE_COMMIT=");
+    verify(consoleWriterMock, times(1)).a("baseSha");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_EMAIL=");
+    verify(consoleWriterMock, times(1)).a("some@email.com");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
+    verify(consoleWriterMock, times(1)).a("some");
+    verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=true");
+    verify(ghIssueCommentMock, times(0)).createReaction(ReactionContent.PLUS_ONE);
+    verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_PUSH=false");
+    verify(this.consoleWriterMock, times(1))
+        .a(String.format("%s=false", GithubPRInfoCommand.SKIP_MAX_STRINGS_BLOCK_FLAG));
+  }
+
+  @Test
+  public void testExecuteWithChecksSkippedViaBothCommentAndLabel() throws IOException {
+    when(ghIssueCommentMock.getBody()).thenReturn("SKIP_I18N_CHECKS");
+    when(githubMock.isLabelAppliedToPR("testRepo", 1, "skip-i18n-checks")).thenReturn(true);
+    githubPRInfoCommand.execute();
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_BASE_COMMIT=");
+    verify(consoleWriterMock, times(1)).a("baseSha");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_EMAIL=");
+    verify(consoleWriterMock, times(1)).a("some@email.com");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
+    verify(consoleWriterMock, times(1)).a("some");
+    verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=true");
+    verify(ghIssueCommentMock, times(1)).createReaction(ReactionContent.PLUS_ONE);
+    verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_PUSH=false");
+    verify(this.consoleWriterMock, times(1))
+        .a(String.format("%s=false", GithubPRInfoCommand.SKIP_MAX_STRINGS_BLOCK_FLAG));
+  }
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithubTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithubTest.java
@@ -251,7 +251,7 @@ public class ExtractionCheckNotificationSenderGithubTest {
             "testRepo",
             "123456789",
             GHCommitState.SUCCESS,
-            "Checks disabled as SKIP_I18N_CHECKS was applied in comments.",
+            "Checks disabled because a SKIP_I18N_CHECKS comment or label was found.",
             "I18N String Checks",
             "https://somewebaddress.com/");
   }


### PR DESCRIPTION
**Summary**
Adds support for skipping i18n checks using a GitHub PR label in addition to the existing comment-based mechanism. PRs can now be labeled with skip-i18n-checks to bypass i18n validation checks without requiring a comment.

**Changes**
- Added --skip-i18n-checks-label parameter to GithubPRInfoCommand (defaults to skip-i18n-checks)
- Modified check logic to support both label-based and comment-based skip mechanisms
- Only adds reaction to comment when checks are skipped via comment (not via label)
- Updated commit status message to reflect both skip methods
- Added comprehensive test coverage for label-only and combined label+comment scenarios

**Test Plan**
- Unit tests added for label-based skip functionality
- Tests verify correct behavior when both label and comment are present
- Tests confirm reaction is only added to comments, not when label is used