### PR TITLE
[I18N-1560] Fix Quartz from getting into a blocked state if ScheduledJobListener throws

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobListener.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobListener.java
@@ -8,6 +8,9 @@ import org.quartz.JobExecutionException;
 import org.quartz.listeners.JobListenerSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 
 /**
  * Listener that listens for Quartz job events, this listener is attached to the 'scheduledJobs'
@@ -23,12 +26,29 @@ public class ScheduledJobListener extends JobListenerSupport {
 
   private final ScheduledJobRepository scheduledJobRepository;
   private final ScheduledJobStatusRepository scheduledJobStatusRepository;
+  private final RetryTemplate retryTemplate;
 
   public ScheduledJobListener(
       ScheduledJobRepository scheduledJobRepository,
-      ScheduledJobStatusRepository scheduledJobStatusRepository) {
+      ScheduledJobStatusRepository scheduledJobStatusRepository,
+      ScheduledJobListenerRetryConfiguration retryConfiguration) {
     this.scheduledJobRepository = scheduledJobRepository;
     this.scheduledJobStatusRepository = scheduledJobStatusRepository;
+    this.retryTemplate = buildRetryTemplate(retryConfiguration);
+  }
+
+  private static RetryTemplate buildRetryTemplate(
+      ScheduledJobListenerRetryConfiguration retryConfiguration) {
+    SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(retryConfiguration.getMaxAttempts());
+
+    ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+    backOffPolicy.setInitialInterval(retryConfiguration.getInitialInterval());
+    backOffPolicy.setMultiplier(retryConfiguration.getMultiplier());
+
+    RetryTemplate retryTemplate = new RetryTemplate();
+    retryTemplate.setRetryPolicy(retryPolicy);
+    retryTemplate.setBackOffPolicy(backOffPolicy);
+    return retryTemplate;
   }
 
   @Override
@@ -65,9 +85,28 @@ public class ScheduledJobListener extends JobListenerSupport {
         scheduledJob.getRepository().getName());
   }
 
-  /** The job finished execution, if an error occurred jobException will not be null */
+  /** The job finished execution, if an error occurred jobException will not be null. */
   @Override
   public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+    // This method must never throw an exception. If it does, Quartz will abort the remaining
+    // listener notifications - including the one that informs the DB that the job completed
+    // successfully. Skipping that notification will leave the job stuck in a BLOCKED state.
+    try {
+      retryTemplate.execute(
+          retryContext -> {
+            handleJobWasExecuted(context, jobException);
+            return null;
+          });
+    } catch (Exception e) {
+      logger.error(
+          "Failed to handle post execution for job {} after retries",
+          context.getJobDetail().getKey().getName(),
+          e);
+    }
+  }
+
+  private void handleJobWasExecuted(
+      JobExecutionContext context, JobExecutionException jobException) {
 
     Optional<ScheduledJob> optScheduledJob =
         scheduledJobRepository.findByUuid(context.getJobDetail().getKey().getName());

--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobListener.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobListener.java
@@ -85,7 +85,7 @@ public class ScheduledJobListener extends JobListenerSupport {
         scheduledJob.getRepository().getName());
   }
 
-  /** The job finished execution, if an error occurred jobException will not be null. */
+  /** The job finished execution, if an error occurred jobException will not be null */
   @Override
   public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
     // This method must never throw an exception. If it does, Quartz will abort the remaining

--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobListenerRetryConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobListenerRetryConfiguration.java
@@ -1,0 +1,36 @@
+package com.box.l10n.mojito.service.scheduledjob;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "l10n.scheduledjobs.listener.retry")
+public class ScheduledJobListenerRetryConfiguration {
+  private int maxAttempts = 5;
+  private long initialInterval = 10000;
+  private double multiplier = 2;
+
+  public int getMaxAttempts() {
+    return maxAttempts;
+  }
+
+  public void setMaxAttempts(int maxAttempts) {
+    this.maxAttempts = maxAttempts;
+  }
+
+  public long getInitialInterval() {
+    return initialInterval;
+  }
+
+  public void setInitialInterval(long initialInterval) {
+    this.initialInterval = initialInterval;
+  }
+
+  public double getMultiplier() {
+    return multiplier;
+  }
+
+  public void setMultiplier(double multiplier) {
+    this.multiplier = multiplier;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManager.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManager.java
@@ -36,8 +36,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 /**
- * Component for scheduling jobs inside the scheduled jobs table. Currently, jobs are pulled from
- * the application.properties and pushed to the scheduled_job table.
+ * Component for scheduling jobs inside the scheduled jobs table.
  *
  * @author mattwilshire
  */
@@ -52,6 +51,7 @@ public class ScheduledJobManager {
   private final ScheduledJobStatusRepository scheduledJobStatusRepository;
   private final ScheduledJobTypeRepository scheduledJobTypeRepository;
   private final RepositoryRepository repositoryRepository;
+  private final ScheduledJobListenerRetryConfiguration scheduledJobListenerRetryConfiguration;
 
   /* Quartz scheduler dedicated to scheduled jobs using in memory data source.
    * The value is also set using equals as this is not managed by Spring Boot in the tests. */
@@ -72,13 +72,15 @@ public class ScheduledJobManager {
       ScheduledJobRepository scheduledJobRepository,
       ScheduledJobStatusRepository scheduledJobStatusRepository,
       ScheduledJobTypeRepository scheduledJobTypeRepository,
-      RepositoryRepository repositoryRepository) {
+      RepositoryRepository repositoryRepository,
+      ScheduledJobListenerRetryConfiguration scheduledJobListenerRetryConfiguration) {
     this.thirdPartySyncJobsConfig = thirdPartySyncJobConfig;
     this.schedulerManager = schedulerManager;
     this.scheduledJobRepository = scheduledJobRepository;
     this.scheduledJobStatusRepository = scheduledJobStatusRepository;
     this.scheduledJobTypeRepository = scheduledJobTypeRepository;
     this.repositoryRepository = repositoryRepository;
+    this.scheduledJobListenerRetryConfiguration = scheduledJobListenerRetryConfiguration;
   }
 
   @PostConstruct
@@ -88,7 +90,10 @@ public class ScheduledJobManager {
     getScheduler()
         .getListenerManager()
         .addJobListener(
-            new ScheduledJobListener(scheduledJobRepository, scheduledJobStatusRepository));
+            new ScheduledJobListener(
+                scheduledJobRepository,
+                scheduledJobStatusRepository,
+                scheduledJobListenerRetryConfiguration));
     // Add Trigger Listener
     getScheduler()
         .getListenerManager()

--- a/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/scheduledjob/ScheduledJobManagerTest.java
@@ -108,7 +108,8 @@ public class ScheduledJobManagerTest extends ServiceTestBase {
                 scheduledJobRepository,
                 scheduledJobStatusRepository,
                 scheduledJobTypeRepository,
-                repositoryRepository));
+                repositoryRepository,
+                new ScheduledJobListenerRetryConfiguration()));
 
     Mockito.doReturn(NoOpScheduledJobTest.class).when(scheduledJobManager).loadJobClass(any());
 


### PR DESCRIPTION
## Summary
Quartz aborts all remaining listener notifications for a job the moment one listener throws. 

`ScheduledJobListener.jobWasExecuted` persists the job's completion status (success/failure) back to the database - if it
throws (e.g. a transient DB error), that notification is dropped and the job's row is left stuck in `IN_PROGRESS` / `BLOCKED` state forever, even though it actually finished. It then **never gets picked up again by the scheduler**.

## Solution
The solution here is to ensure nothing in the `jobWasExecuted` method throws which stops Quartz from sending the "job has finished" notification to the db. This PR ensures any exceptions are captured in the listener and does retries with exponential backoff.

## Concern
Another concern was if the db is actually down for something like maintenance (e.g version upgrade) even if we don't throw in the `jobWasExecuted`, wouldn't Quartz not be able to send the notification to the db saying the "job has finished" also causing the equivalent issue with the job being forever in a BLOCKED state?

**The answer to this is** Quartz will **retry every 15 seconds** by default to report the job status back to the db **infinitely**, more info here under the `org.quartz.scheduler.dbFailureRetryInterval` property: https://www.quartz-scheduler.org/documentation/quartz-2.2.2/configuration/ConfigMain.html

## Testing
All of this was tested locally by stopping the local MySQL instance during job execution to simulate the blocked state. The retries take place and Quartz successfully unblocks itself when the db comes back up.