### PR TITLE
I18N-2153 Preserve localized LMS images when starting course translations in Intellum

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/EvolveCoursePicture.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/EvolveCoursePicture.java
@@ -1,0 +1,72 @@
+package com.box.l10n.mojito.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+    name = "evolve_course_picture",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "UK__EVOLVE_COURSE_PICTURE__COURSE_ID__LOCALE_BCP47_TAG",
+          columnNames = {"course_id", "locale_bcp47_tag"})
+    })
+public class EvolveCoursePicture extends BaseEntity {
+
+  @Column(name = "course_id", nullable = false)
+  private int courseId;
+
+  @Column(name = "locale_bcp47_tag", nullable = false, length = 20)
+  private String localeBcp47Tag;
+
+  @Column(name = "picture_url")
+  private String pictureUrl;
+
+  @Column(name = "hero_picture_url")
+  private String heroPictureUrl;
+
+  @Column(name = "hero_picture_mobile_url")
+  private String heroPictureMobileUrl;
+
+  public int getCourseId() {
+    return courseId;
+  }
+
+  public void setCourseId(int courseId) {
+    this.courseId = courseId;
+  }
+
+  public String getLocaleBcp47Tag() {
+    return localeBcp47Tag;
+  }
+
+  public void setLocaleBcp47Tag(String localeBcp47Tag) {
+    this.localeBcp47Tag = localeBcp47Tag;
+  }
+
+  public String getPictureUrl() {
+    return pictureUrl;
+  }
+
+  public void setPictureUrl(String pictureUrl) {
+    this.pictureUrl = pictureUrl;
+  }
+
+  public String getHeroPictureUrl() {
+    return heroPictureUrl;
+  }
+
+  public void setHeroPictureUrl(String heroPictureUrl) {
+    this.heroPictureUrl = heroPictureUrl;
+  }
+
+  public String getHeroPictureMobileUrl() {
+    return heroPictureMobileUrl;
+  }
+
+  public void setHeroPictureMobileUrl(String heroPictureMobileUrl) {
+    this.heroPictureMobileUrl = heroPictureMobileUrl;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/evolve/CoursesGetRequest.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/evolve/CoursesGetRequest.java
@@ -1,9 +1,15 @@
 package com.box.l10n.mojito.service.evolve;
 
 import java.time.ZonedDateTime;
+import java.util.Set;
 
-public record CoursesGetRequest(String locale, boolean active, ZonedDateTime updatedOnTo) {
+public record CoursesGetRequest(
+    Set<String> codes, String locale, boolean active, ZonedDateTime updatedOnTo) {
   public CoursesGetRequest(String locale, ZonedDateTime updatedOnTo) {
-    this(locale, true, updatedOnTo);
+    this(null, locale, true, updatedOnTo);
+  }
+
+  public CoursesGetRequest(Set<String> codes, ZonedDateTime updatedOnTo) {
+    this(codes, null, true, updatedOnTo);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/evolve/EvolveClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/evolve/EvolveClient.java
@@ -56,8 +56,8 @@ public class EvolveClient {
     return this.apiPath + endpointPath;
   }
 
-  private ListWithLastPage<CourseDTO> getCourses(String url) {
-    CoursesDTO coursesDTO = this.restTemplate.getForObject(url, CoursesDTO.class);
+  private ListWithLastPage<CourseDTO> getCourses(String uriTemplate) {
+    CoursesDTO coursesDTO = this.restTemplate.getForObject(uriTemplate, CoursesDTO.class);
     if (coursesDTO == null) {
       logger.error("Get Courses response is empty");
       throw new EvolveSyncException("Empty response");
@@ -70,18 +70,23 @@ public class EvolveClient {
 
   public Stream<CourseDTO> getCourses(CoursesGetRequest request) {
     UriComponentsBuilder builder =
-        UriComponentsBuilder.fromPath(this.getFullEndpointPath("courses"))
-            .queryParam("locale", request.locale())
+        UriComponentsBuilder.fromUriString(this.getFullEndpointPath("courses"))
             .queryParam("is_active", request.active());
+    if (request.codes() != null && !request.codes().isEmpty()) {
+      builder.queryParam("code[]", request.codes());
+    }
+    if (request.locale() != null) {
+      builder.queryParam("locale", request.locale());
+    }
     if (request.updatedOnTo() != null) {
       builder.queryParam("updated_on_to", request.updatedOnTo());
     }
     PageFetcherCurrentAndTotalPagesSplitIterator<CourseDTO> iterator =
         new PageFetcherCurrentAndTotalPagesSplitIterator<>(
             pageToFetch -> {
-              UriComponentsBuilder builderWithPage =
-                  builder.cloneBuilder().queryParam("page", pageToFetch);
-              return Mono.fromCallable(() -> this.getCourses(builderWithPage.toUriString()))
+              String uriTemplate =
+                  builder.cloneBuilder().queryParam("page", pageToFetch).build().toUriString();
+              return Mono.fromCallable(() -> this.getCourses(uriTemplate))
                   .retryWhen(
                       Retry.backoff(this.maxRetries, this.retryMinBackoff)
                           .maxBackoff(this.retryMaxBackoff))

--- a/webapp/src/main/java/com/box/l10n/mojito/service/evolve/EvolveCoursePictureRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/evolve/EvolveCoursePictureRepository.java
@@ -1,0 +1,17 @@
+package com.box.l10n.mojito.service.evolve;
+
+import com.box.l10n.mojito.entity.EvolveCoursePicture;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(exported = false)
+public interface EvolveCoursePictureRepository extends JpaRepository<EvolveCoursePicture, Long> {
+  List<EvolveCoursePicture> findByCourseId(int courseId);
+
+  Optional<EvolveCoursePicture> findByCourseIdAndLocaleBcp47Tag(
+      int courseId, String localeBcp47Tag);
+
+  void deleteByCourseId(int courseId);
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/evolve/EvolveCoursePictureService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/evolve/EvolveCoursePictureService.java
@@ -1,0 +1,73 @@
+package com.box.l10n.mojito.service.evolve;
+
+import com.box.l10n.mojito.entity.EvolveCoursePicture;
+import com.box.l10n.mojito.service.evolve.dto.CourseDTO;
+import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EvolveCoursePictureService {
+
+  private final EvolveCoursePictureRepository evolveCoursePictureRepository;
+
+  public EvolveCoursePictureService(EvolveCoursePictureRepository evolveCoursePictureRepository) {
+    this.evolveCoursePictureRepository = evolveCoursePictureRepository;
+  }
+
+  public Optional<EvolveCoursePicture> findByCourseIdAndLocaleBcp47Tag(
+      int courseId, String locale) {
+    return evolveCoursePictureRepository.findByCourseIdAndLocaleBcp47Tag(courseId, locale);
+  }
+
+  /**
+   * Creates or updates {@link EvolveCoursePicture} records for the given parent course, using the
+   * picture URLs from each localized course DTO. DTOs with no picture URLs are skipped. Existing
+   * records are matched by locale and updated in place; unmatched locales produce new records.
+   *
+   * @param parentCourseId the ID of the parent (source-language) course
+   * @param localizedCourseDTOs the localized course DTOs containing picture URL data
+   */
+  public void upsertLocalizedCoursePictureUrls(
+      int parentCourseId, List<CourseDTO> localizedCourseDTOs) {
+    List<EvolveCoursePicture> existingCoursePictures =
+        evolveCoursePictureRepository.findByCourseId(parentCourseId);
+    List<EvolveCoursePicture> evolveCoursePictures =
+        localizedCourseDTOs.stream()
+            .filter(
+                localizedCourseDTO ->
+                    !Strings.isNullOrEmpty(localizedCourseDTO.getPictureUrl())
+                        || !Strings.isNullOrEmpty(localizedCourseDTO.getHeroPictureUrl())
+                        || !Strings.isNullOrEmpty(localizedCourseDTO.getHeroPictureMobileUrl()))
+            .map(
+                localizedCourseDTO -> {
+                  EvolveCoursePicture evolveCoursePicture =
+                      existingCoursePictures.stream()
+                          .filter(
+                              existingCoursePicture ->
+                                  existingCoursePicture
+                                      .getLocaleBcp47Tag()
+                                      .equals(localizedCourseDTO.getLocale()))
+                          .findFirst()
+                          .orElseGet(EvolveCoursePicture::new);
+
+                  evolveCoursePicture.setCourseId(parentCourseId);
+                  evolveCoursePicture.setLocaleBcp47Tag(localizedCourseDTO.getLocale());
+                  evolveCoursePicture.setPictureUrl(localizedCourseDTO.getPictureUrl());
+                  evolveCoursePicture.setHeroPictureUrl(localizedCourseDTO.getHeroPictureUrl());
+                  evolveCoursePicture.setHeroPictureMobileUrl(
+                      localizedCourseDTO.getHeroPictureMobileUrl());
+                  return evolveCoursePicture;
+                })
+            .collect(Collectors.toList());
+    this.evolveCoursePictureRepository.saveAll(evolveCoursePictures);
+  }
+
+  @Transactional
+  public void deleteByCourseId(int courseId) {
+    evolveCoursePictureRepository.deleteByCourseId(courseId);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/evolve/EvolveService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/evolve/EvolveService.java
@@ -12,6 +12,7 @@ import com.box.l10n.mojito.entity.AssetContent;
 import com.box.l10n.mojito.entity.AssetExtractionByBranch;
 import com.box.l10n.mojito.entity.Branch;
 import com.box.l10n.mojito.entity.BranchStatistic;
+import com.box.l10n.mojito.entity.EvolveCoursePicture;
 import com.box.l10n.mojito.entity.Locale;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.RepositoryLocale;
@@ -40,6 +41,7 @@ import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -95,6 +97,8 @@ public class EvolveService {
 
   private final TranslationModeMapper translationModeMapper;
 
+  private final EvolveCoursePictureService evolveCoursePictureService;
+
   private final Duration retryMinBackoff;
 
   private final Duration retryMaxBackoff;
@@ -121,6 +125,7 @@ public class EvolveService {
       AssetExtractionByBranchRepository assetExtractionByBranchRepository,
       LocaleMappingHelper localeMappingHelper,
       TranslationModeMapper translationModeMapper,
+      EvolveCoursePictureService evolveCoursePictureService,
       @Autowired(required = false) ContentService contentService,
       EvolveSlackNotificationSender evolveSlackNotificationSender) {
     this.evolveConfigurationProperties = evolveConfigurationProperties;
@@ -137,6 +142,7 @@ public class EvolveService {
     this.assetExtractionByBranchRepository = assetExtractionByBranchRepository;
     this.localeMappingHelper = localeMappingHelper;
     this.translationModeMapper = translationModeMapper;
+    this.evolveCoursePictureService = evolveCoursePictureService;
     this.contentService = ofNullable(contentService);
     this.retryMinBackoff =
         Duration.ofSeconds(evolveConfigurationProperties.getRetryMinBackoffSecs());
@@ -195,8 +201,7 @@ public class EvolveService {
     sourceAsset.setRepositoryId(repositoryId);
     sourceAsset.setPath(this.getAssetPath(courseId));
     sourceAsset.setBranchCreatedByUsername(SYSTEM_USERNAME);
-    sourceAsset.setContent(
-        this.xliffUtils.removeAttribute(localizedAssetContent, "target-language"));
+    sourceAsset.setContent(this.xliffUtils.removeTargetLanguageAttribute(localizedAssetContent));
     ofNullable(this.evolveConfigurationProperties.getUsagesKeyRegexp())
         .ifPresent(
             usagesKeyRegexp ->
@@ -294,6 +299,34 @@ public class EvolveService {
         TEN_SECONDS);
   }
 
+  private String applyCoursePictureUrls(
+      int courseId,
+      String localizedContent,
+      Boolean refreshWithParentAssetsAndStructure,
+      String outputBcp47Tag)
+      throws XPathExpressionException,
+          ParserConfigurationException,
+          IOException,
+          SAXException,
+          TransformerException {
+    if (!this.xliffUtils.containsBinUnitElement(localizedContent)) {
+      return localizedContent;
+    }
+    if (refreshWithParentAssetsAndStructure == null || refreshWithParentAssetsAndStructure) {
+      return this.xliffUtils.removeBinUnitElements(localizedContent);
+    }
+    EvolveCoursePicture evolveCoursePicture =
+        this.evolveCoursePictureService
+            .findByCourseIdAndLocaleBcp47Tag(courseId, outputBcp47Tag)
+            .orElseGet(EvolveCoursePicture::new);
+    return this.xliffUtils.replaceTargetMediaTargetUrls(
+        courseId,
+        localizedContent,
+        evolveCoursePicture.getPictureUrl(),
+        evolveCoursePicture.getHeroPictureUrl(),
+        evolveCoursePicture.getHeroPictureMobileUrl());
+  }
+
   private void updateCourseTranslations(
       CourseDTO courseDTO,
       Asset asset,
@@ -301,17 +334,22 @@ public class EvolveService {
       Map<String, String> localeMappings,
       List<RepositoryLocale> targetRepositoryLocales) {
     String normalizedContent = NormalizationUtils.normalize(content);
+    Boolean refreshWithParentAssetsAndStructure =
+        this.translationModeMapper
+            .toRefreshWithParentAssetsAndStructure(courseDTO.getTranslationMode())
+            .orElse(null);
     targetRepositoryLocales.forEach(
         repositoryLocale -> {
           String localeBcp47Tag = repositoryLocale.getLocale().getBcp47Tag();
-          String generateLocalized;
+          String outputBcp47Tag = localeMappings.getOrDefault(localeBcp47Tag, localeBcp47Tag);
+          String localizedContent;
           try {
-            generateLocalized =
+            localizedContent =
                 tmService.generateLocalized(
                     asset,
                     normalizedContent,
                     repositoryLocale,
-                    localeMappings.getOrDefault(localeBcp47Tag, localeBcp47Tag),
+                    outputBcp47Tag,
                     null,
                     ImmutableList.of(),
                     Status.ACCEPTED,
@@ -320,25 +358,30 @@ public class EvolveService {
           } catch (UnsupportedAssetFilterTypeException e) {
             throw new EvolveSyncException(e.getMessage(), e);
           }
-          Boolean replaceLegacyEvolveLocaleContent =
-              this.translationModeMapper
-                  .mapTranslationModeToReplaceLegacyEvolveLocaleContent(
-                      courseDTO.getTranslationMode())
-                  .orElse(null);
+
+          String localizedContentWithUpdatedTargetUrls;
+          try {
+            localizedContentWithUpdatedTargetUrls =
+                this.applyCoursePictureUrls(
+                    courseDTO.getId(),
+                    localizedContent,
+                    refreshWithParentAssetsAndStructure,
+                    outputBcp47Tag);
+          } catch (XPathExpressionException
+              | ParserConfigurationException
+              | IOException
+              | SAXException
+              | TransformerException e) {
+            throw new EvolveSyncException(
+                "Error while updating picture and hero picture target URLs", e);
+          }
+
           Mono.fromRunnable(
-                  () -> {
-                    try {
+                  () ->
                       this.evolveClient.updateCourseTranslation(
                           courseDTO.getId(),
-                          replaceLegacyEvolveLocaleContent,
-                          this.xliffUtils.removeElement(generateLocalized, "bin-unit"));
-                    } catch (ParserConfigurationException
-                        | IOException
-                        | SAXException
-                        | TransformerException e) {
-                      throw new EvolveSyncException(e.getMessage(), e);
-                    }
-                  })
+                          refreshWithParentAssetsAndStructure,
+                          localizedContentWithUpdatedTargetUrls))
               .retryWhen(
                   Retry.backoff(
                           this.evolveConfigurationProperties.getMaxRetries(), this.retryMinBackoff)
@@ -397,6 +440,22 @@ public class EvolveService {
     this.sendSlackNotification(courseDTO.getId());
   }
 
+  private List<CourseDTO> getCourses(
+      String parentCourseCode, Set<String> localeBcp47Tags, ZonedDateTime startDateTime) {
+    Set<String> codes =
+        localeBcp47Tags.stream()
+            .map(localeBcp47Tag -> parentCourseCode + "-" + localeBcp47Tag)
+            .collect(Collectors.toSet());
+    CoursesGetRequest request = new CoursesGetRequest(codes, startDateTime);
+    return Mono.fromCallable(
+            () -> this.evolveClient.getCourses(request).collect(Collectors.toList()))
+        .retryWhen(
+            Retry.backoff(this.evolveConfigurationProperties.getMaxRetries(), this.retryMinBackoff)
+                .maxBackoff(this.retryMaxBackoff))
+        .doOnError(e -> log.error("Unable to fetch courses", e))
+        .block();
+  }
+
   private void syncReadyForTranslation(
       CourseDTO courseDTO,
       ZonedDateTime startDateTime,
@@ -411,6 +470,10 @@ public class EvolveService {
           InterruptedException,
           TransformerException,
           SAXException {
+    Set<String> localeBcp47Tags = new HashSet<>(additionalTargetLocaleBcp47Tags);
+    localeBcp47Tags.add(targetLocaleBcp47Tag);
+    List<CourseDTO> currentLocalizedCourseDTOs =
+        this.getCourses(courseDTO.getCode(), localeBcp47Tags, startDateTime);
     this.startCourseTranslations(
         courseDTO.getId(),
         courseDTO.getType(),
@@ -419,6 +482,8 @@ public class EvolveService {
         additionalTargetLocaleBcp47Tags);
     courseDTO.setTranslationStatus(IN_TRANSLATION);
     this.updateCourse(courseDTO, startDateTime);
+    this.evolveCoursePictureService.upsertLocalizedCoursePictureUrls(
+        courseDTO.getId(), currentLocalizedCourseDTOs);
   }
 
   private Optional<String> getContent(
@@ -464,6 +529,7 @@ public class EvolveService {
     }
     this.updateCourseTranslations(
         courseDTO, asset, content.get(), localeMappings, targetRepositoryLocales);
+    this.evolveCoursePictureService.deleteByCourseId(courseDTO.getId());
     if (branchStatistic != null
         && branchStatistic.getTotalCount() > 0
         && branchStatistic.getForTranslationCount() == 0) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/evolve/TranslationModeMapper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/evolve/TranslationModeMapper.java
@@ -15,8 +15,23 @@ public class TranslationModeMapper {
     this.evolveConfigurationProperties = evolveConfigurationProperties;
   }
 
-  public Optional<Boolean> mapTranslationModeToReplaceLegacyEvolveLocaleContent(
-      String translationMode) {
+  /**
+   * Maps an Evolve course translation mode string to the {@code
+   * refreshWithParentAssetsAndStructure} flag used when pushing translations back.
+   *
+   * <ul>
+   *   <li>{@code true} – when {@code translationMode} matches {@link
+   *       EvolveConfigurationProperties#getRefreshWithParentAssetsAndStructureText()}
+   *   <li>{@code false} – when it matches {@link
+   *       EvolveConfigurationProperties#getPreserveAssetsAndStructureText()}
+   *   <li>empty – when {@code translationMode} is {@code null} or matches neither value
+   * </ul>
+   *
+   * @param translationMode the raw translation mode string from the course DTO, may be {@code null}
+   * @return the mapped flag, or empty if the mode is unrecognised
+   * @throws EvolveSyncException if {@code translationMode} matches both configured values
+   */
+  public Optional<Boolean> toRefreshWithParentAssetsAndStructure(String translationMode) {
     if (translationMode == null) {
       return empty();
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/evolve/dto/CourseDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/evolve/dto/CourseDTO.java
@@ -6,6 +6,10 @@ public class CourseDTO {
 
   private int id;
 
+  private String code;
+
+  private String locale;
+
   @JsonProperty("custom_j")
   private TranslationStatusType translationStatus;
 
@@ -15,12 +19,33 @@ public class CourseDTO {
   @JsonProperty("type")
   private String type;
 
+  private PictureDTO picture;
+
+  @JsonProperty("hero_picture")
+  private PictureDTO heroPicture;
+
   public int getId() {
     return id;
   }
 
   public void setId(int id) {
     this.id = id;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getLocale() {
+    return locale;
+  }
+
+  public void setLocale(String locale) {
+    this.locale = locale;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
   }
 
   public TranslationStatusType getTranslationStatus() {
@@ -45,5 +70,42 @@ public class CourseDTO {
 
   public void setType(String type) {
     this.type = type;
+  }
+
+  public PictureDTO getPicture() {
+    return picture;
+  }
+
+  public void setPicture(PictureDTO picture) {
+    this.picture = picture;
+  }
+
+  public PictureDTO getHeroPicture() {
+    return heroPicture;
+  }
+
+  public void setHeroPicture(PictureDTO heroPicture) {
+    this.heroPicture = heroPicture;
+  }
+
+  public String getPictureUrl() {
+    if (picture != null) {
+      return picture.getTargetUrl();
+    }
+    return null;
+  }
+
+  public String getHeroPictureUrl() {
+    if (heroPicture != null) {
+      return heroPicture.getTargetUrl();
+    }
+    return null;
+  }
+
+  public String getHeroPictureMobileUrl() {
+    if (heroPicture != null) {
+      return heroPicture.getMobileTargetUrl();
+    }
+    return null;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/evolve/dto/PictureDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/evolve/dto/PictureDTO.java
@@ -1,0 +1,27 @@
+package com.box.l10n.mojito.service.evolve.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PictureDTO {
+  @JsonProperty("mobile_target_url")
+  private String mobileTargetUrl;
+
+  @JsonProperty("target_url")
+  private String targetUrl;
+
+  public String getMobileTargetUrl() {
+    return mobileTargetUrl;
+  }
+
+  public void setMobileTargetUrl(String mobileTargetUrl) {
+    this.mobileTargetUrl = mobileTargetUrl;
+  }
+
+  public String getTargetUrl() {
+    return targetUrl;
+  }
+
+  public void setTargetUrl(String targetUrl) {
+    this.targetUrl = targetUrl;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/xliff/XliffUtils.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/xliff/XliffUtils.java
@@ -1,8 +1,11 @@
 package com.box.l10n.mojito.xliff;
 
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.Objects;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -21,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.xml.SimpleNamespaceContext;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -36,6 +40,23 @@ public class XliffUtils {
 
   /** logger */
   static Logger logger = LoggerFactory.getLogger(XliffUtils.class);
+
+  private static final String BIN_UNIT_ELEMENT_NAME = "bin-unit";
+
+  private static final String BIN_TARGET_EXTERNAL_FILE_PATH = "bin-target/external-file";
+
+  private static final String BIN_UNIT_ID_ATTRIBUTE_NAME = "id";
+
+  private static final String EXTERNAL_FILE_HREF_ATTRIBUTE_NAME = "href";
+
+  private static final String PICTURE_TARGET_ID_FORMAT = "course[%d].picture.target_url";
+
+  private static final String HERO_PICTURE_TARGET_ID_FORMAT = "course[%d].hero_picture.target_url";
+
+  private static final String HERO_PICTURE_MOBILE_TARGET_ID_FORMAT =
+      "course[%d].hero_picture.mobile_target_url";
+
+  private static final String TARGET_LANGUAGE_ATTRIBUTE_NAME = "target-language";
 
   /**
    * Gets the target language of the XLIFF by looking at the first "file" element.
@@ -70,34 +91,59 @@ public class XliffUtils {
     return targetLanguage;
   }
 
-  public String removeAttribute(String xmlContent, String attributeName)
+  /**
+   * Creates a {@link DocumentBuilderFactory} hardened against XXE and DOCTYPE-based attacks.
+   *
+   * @return a securely configured factory
+   * @throws ParserConfigurationException if the parser does not support the required security
+   *     features
+   */
+  private DocumentBuilderFactory newSecureDocumentBuilderFactory()
+      throws ParserConfigurationException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    return factory;
+  }
+
+  /**
+   * Removes the {@code target-language} attribute from all elements in the given XML content.
+   *
+   * @param xmlContent the XML string to process
+   * @return the XML string with the {@code target-language} attribute removed
+   */
+  public String removeTargetLanguageAttribute(String xmlContent)
       throws ParserConfigurationException,
           IOException,
           SAXException,
           XPathExpressionException,
           TransformerException {
-    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-    dbFactory.setNamespaceAware(true); // Enable namespace awareness
+    DocumentBuilderFactory dbFactory = newSecureDocumentBuilderFactory();
     DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
     Document doc = dBuilder.parse(new InputSource(new StringReader(xmlContent)));
 
-    // Use XPath to find the element containing the attribute
     XPath xPath = XPathFactory.newInstance().newXPath();
     NodeList nodes =
         (NodeList)
             xPath
-                .compile(String.format("//*[@%s]", attributeName))
+                .compile(String.format("//*[@%s]", TARGET_LANGUAGE_ATTRIBUTE_NAME))
                 .evaluate(doc, XPathConstants.NODESET);
 
-    // Remove the attribute
     for (int i = 0; i < nodes.getLength(); i++) {
       Node node = nodes.item(i);
       if (node.getNodeType() == Node.ELEMENT_NODE) {
-        ((org.w3c.dom.Element) node).removeAttribute(attributeName);
+        ((org.w3c.dom.Element) node).removeAttribute(TARGET_LANGUAGE_ATTRIBUTE_NAME);
       }
     }
 
-    // Convert the modified Document back to a string
     TransformerFactory transformerFactory = TransformerFactory.newInstance();
     Transformer transformer = transformerFactory.newTransformer();
     transformer.setOutputProperty(OutputKeys.INDENT, "yes");
@@ -106,14 +152,33 @@ public class XliffUtils {
     return writer.toString();
   }
 
-  public String removeElement(String xmlContent, String elementName)
+  /**
+   * Returns {@code true} if the given XML content contains at least one {@code bin-unit} element.
+   *
+   * @param xmlContent the XML string to inspect
+   * @return {@code true} if a {@code bin-unit} element is present, {@code false} otherwise
+   */
+  public boolean containsBinUnitElement(String xmlContent)
+      throws ParserConfigurationException, IOException, SAXException {
+    DocumentBuilderFactory factory = newSecureDocumentBuilderFactory();
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    Document document = builder.parse(new InputSource(new StringReader(xmlContent)));
+    return document.getElementsByTagName(BIN_UNIT_ELEMENT_NAME).getLength() > 0;
+  }
+
+  /**
+   * Removes all {@code bin-unit} elements from the given XML content.
+   *
+   * @param xmlContent the XML string to process
+   * @return the XML string with all {@code bin-unit} elements removed
+   */
+  public String removeBinUnitElements(String xmlContent)
       throws ParserConfigurationException, IOException, SAXException, TransformerException {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilderFactory factory = newSecureDocumentBuilderFactory();
     factory.setNamespaceAware(true);
     DocumentBuilder builder = factory.newDocumentBuilder();
     Document document = builder.parse(new InputSource(new StringReader(xmlContent)));
-    document.getDocumentElement().normalize();
-    NodeList elements = document.getElementsByTagName(elementName);
+    NodeList elements = document.getElementsByTagName(BIN_UNIT_ELEMENT_NAME);
 
     while (elements.getLength() > 0) {
       Node element = elements.item(0);
@@ -129,5 +194,232 @@ public class XliffUtils {
     StringWriter writer = new StringWriter();
     transformer.transform(new DOMSource(document), new StreamResult(writer));
     return writer.toString();
+  }
+
+  /**
+   * Returns the first {@code bin-unit} element in the document whose {@code id} attribute equals
+   * {@code binUnitId}, or {@code null} if none matches.
+   *
+   * @param document the parsed DOM document to search
+   * @param binUnitId the expected value of the {@code id} attribute
+   * @return the matching {@code bin-unit} element, or {@code null}
+   */
+  private Element findBinUnitById(Document document, String binUnitId) {
+    NodeList elements = document.getElementsByTagName(BIN_UNIT_ELEMENT_NAME);
+
+    for (int i = 0; i < elements.getLength(); i++) {
+      Element element = (Element) elements.item(i);
+      if (element.hasAttribute(BIN_UNIT_ID_ATTRIBUTE_NAME)
+          && Objects.equals(binUnitId, element.getAttribute(BIN_UNIT_ID_ATTRIBUTE_NAME))) {
+        return element;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Converts a slash-separated element path into a namespace-agnostic relative XPath expression
+   * using {@code local-name()} predicates, so it works regardless of the namespace prefix in use.
+   *
+   * <p>For example, {@code "body/trans-unit"} becomes {@code
+   * "./*[local-name()='body']/*[local-name()='trans-unit']"}.
+   *
+   * @param elementPath slash-separated path of element names (e.g. {@code
+   *     "bin-target/external-file"})
+   * @return a relative XPath expression suitable for evaluation against a DOM {@link
+   *     org.w3c.dom.Element}
+   */
+  private String toLocalNamePath(String elementPath) {
+    StringBuilder xPathExpression = new StringBuilder(".");
+
+    for (String elementName : elementPath.split("/")) {
+      String trimmedElementName = elementName.trim();
+      if (!trimmedElementName.isEmpty()) {
+        xPathExpression.append("/*[local-name()='").append(trimmedElementName).append("']");
+      }
+    }
+
+    return xPathExpression.toString();
+  }
+
+  private Element getBinTargetExternalFileElement(Element element) throws XPathExpressionException {
+    XPath xPath = XPathFactory.newInstance().newXPath();
+    return (Element)
+        xPath.evaluate(
+            toLocalNamePath(BIN_TARGET_EXTERNAL_FILE_PATH), element, XPathConstants.NODE);
+  }
+
+  private boolean updateBinTargetHrefByBinUnitId(
+      Document document, String attributeValue, String nestedAttributeValue)
+      throws XPathExpressionException {
+    Element element = findBinUnitById(document, attributeValue);
+    if (element == null) {
+      logger.debug(
+          "No element found for name: {} with attribute: {} having value: {}",
+          BIN_UNIT_ELEMENT_NAME,
+          BIN_UNIT_ID_ATTRIBUTE_NAME,
+          attributeValue);
+      return false;
+    }
+
+    Element nestedElement = getBinTargetExternalFileElement(element);
+    if (nestedElement == null) {
+      logger.debug("No element found for path: {}", BIN_TARGET_EXTERNAL_FILE_PATH);
+      return false;
+    }
+
+    if (!nestedElement.hasAttribute(EXTERNAL_FILE_HREF_ATTRIBUTE_NAME)) {
+      logger.debug(
+          "No attribute: {} found on element for path: {}",
+          EXTERNAL_FILE_HREF_ATTRIBUTE_NAME,
+          BIN_TARGET_EXTERNAL_FILE_PATH);
+      return false;
+    }
+
+    nestedElement.setAttribute(EXTERNAL_FILE_HREF_ATTRIBUTE_NAME, nestedAttributeValue);
+    return true;
+  }
+
+  private boolean removeBinUnitElementById(Document document, String binUnitId) {
+    Element element = findBinUnitById(document, binUnitId);
+    if (element == null) {
+      return false;
+    }
+
+    element.getParentNode().removeChild(element);
+    return true;
+  }
+
+  private String toXml(Document document) throws TransformerException {
+    TransformerFactory transformerFactory = TransformerFactory.newInstance();
+    Transformer transformer = transformerFactory.newTransformer();
+    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+    transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+
+    StringWriter writer = new StringWriter();
+    transformer.transform(new DOMSource(document), new StreamResult(writer));
+    return writer.toString();
+  }
+
+  private Element ensureHeroPictureMobileBinUnitExists(Document document, int courseId) {
+    String heroPictureId = String.format(HERO_PICTURE_TARGET_ID_FORMAT, courseId);
+    String heroPictureMobileId = String.format(HERO_PICTURE_MOBILE_TARGET_ID_FORMAT, courseId);
+
+    Element existingMobile = findBinUnitById(document, heroPictureMobileId);
+    if (existingMobile != null) {
+      return existingMobile;
+    }
+
+    Element heroPictureBinUnit = findBinUnitById(document, heroPictureId);
+    if (heroPictureBinUnit == null) {
+      return null;
+    }
+
+    Element heroPictureMobileBinUnit = (Element) heroPictureBinUnit.cloneNode(true);
+    heroPictureMobileBinUnit.setAttribute(BIN_UNIT_ID_ATTRIBUTE_NAME, heroPictureMobileId);
+    heroPictureBinUnit
+        .getParentNode()
+        .insertBefore(heroPictureMobileBinUnit, heroPictureBinUnit.getNextSibling());
+
+    return heroPictureMobileBinUnit;
+  }
+
+  /**
+   * Updates the picture, hero picture, and hero picture mobile target URLs in the {@code bin-unit}
+   * elements of the given localized XLIFF content in a single DOM pass.
+   *
+   * <p>For each URL parameter:
+   *
+   * <ul>
+   *   <li>If non-null and non-empty, the matching {@code bin-unit}'s {@code
+   *       bin-target/external-file href} is updated.
+   *   <li>If null or empty, the matching {@code bin-unit} element is removed entirely.
+   * </ul>
+   *
+   * <p>For the mobile hero picture specifically, if no mobile {@code bin-unit} exists yet, one is
+   * created by cloning the hero picture {@code bin-unit}. If the hero {@code bin-unit} is also
+   * absent, the mobile URL is silently skipped.
+   *
+   * <p>Returns the original {@code localizedContent} string unchanged when no {@code bin-unit}
+   * elements were modified or removed.
+   *
+   * @param courseId the course ID used to locate the {@code bin-unit} elements by their id
+   * @param localizedContent the localized XLIFF content to update; must not be null or blank
+   * @param pictureTargetUrl the new picture target URL, or {@code null}/empty to remove the element
+   * @param heroPictureTargetUrl the new hero picture target URL, or {@code null}/empty to remove
+   * @param heroPictureMobileTargetUrl the new mobile hero picture target URL, or {@code null}/empty
+   *     to remove
+   * @return the updated XLIFF content, or the original string if nothing changed
+   * @throws IllegalArgumentException if {@code localizedContent} is null or blank
+   */
+  public String replaceTargetMediaTargetUrls(
+      int courseId,
+      String localizedContent,
+      String pictureTargetUrl,
+      String heroPictureTargetUrl,
+      String heroPictureMobileTargetUrl)
+      throws ParserConfigurationException,
+          IOException,
+          SAXException,
+          XPathExpressionException,
+          TransformerException {
+    validateLocalizedContent(localizedContent);
+
+    DocumentBuilderFactory factory = newSecureDocumentBuilderFactory();
+    factory.setNamespaceAware(true);
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    Document document = builder.parse(new InputSource(new StringReader(localizedContent)));
+
+    boolean changed = false;
+
+    if (!Strings.isNullOrEmpty(pictureTargetUrl)) {
+      changed |=
+          updateBinTargetHrefByBinUnitId(
+              document, String.format(PICTURE_TARGET_ID_FORMAT, courseId), pictureTargetUrl);
+    } else {
+      changed |=
+          removeBinUnitElementById(document, String.format(PICTURE_TARGET_ID_FORMAT, courseId));
+    }
+
+    if (!Strings.isNullOrEmpty(heroPictureTargetUrl)) {
+      changed |=
+          updateBinTargetHrefByBinUnitId(
+              document,
+              String.format(HERO_PICTURE_TARGET_ID_FORMAT, courseId),
+              heroPictureTargetUrl);
+    } else {
+      changed |=
+          removeBinUnitElementById(
+              document, String.format(HERO_PICTURE_TARGET_ID_FORMAT, courseId));
+    }
+
+    if (!Strings.isNullOrEmpty(heroPictureMobileTargetUrl)) {
+      Element mobileBinUnit = ensureHeroPictureMobileBinUnitExists(document, courseId);
+      if (mobileBinUnit != null) {
+        changed |=
+            updateBinTargetHrefByBinUnitId(
+                document,
+                String.format(HERO_PICTURE_MOBILE_TARGET_ID_FORMAT, courseId),
+                heroPictureMobileTargetUrl);
+      } else {
+        logger.debug(
+            "Hero picture bin-unit not found, cannot create mobile bin-unit for courseId: {}",
+            courseId);
+      }
+    } else {
+      changed |=
+          removeBinUnitElementById(
+              document, String.format(HERO_PICTURE_MOBILE_TARGET_ID_FORMAT, courseId));
+    }
+
+    return changed ? toXml(document) : localizedContent;
+  }
+
+  private void validateLocalizedContent(String localizedContent) {
+    if (localizedContent == null || localizedContent.trim().isEmpty()) {
+      throw new IllegalArgumentException("localizedContent must not be null or blank");
+    }
   }
 }

--- a/webapp/src/main/resources/db/migration/V86__Add_evolve_course_picture.sql
+++ b/webapp/src/main/resources/db/migration/V86__Add_evolve_course_picture.sql
@@ -1,0 +1,11 @@
+CREATE TABLE evolve_course_picture (
+    id            BIGINT       NOT NULL AUTO_INCREMENT,
+    course_id     INT          NOT NULL,
+    locale_bcp47_tag VARCHAR(20) NOT NULL,
+    picture_url   VARCHAR(2048),
+    hero_picture_url VARCHAR(2048),
+    hero_picture_mobile_url VARCHAR(2048),
+    PRIMARY KEY (id),
+    CONSTRAINT UK__EVOLVE_COURSE_PICTURE__COURSE_ID__LOCALE_BCP47_TAG
+        UNIQUE (course_id, locale_bcp47_tag)
+);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/evolve/EvolveClientTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/evolve/EvolveClientTest.java
@@ -37,7 +37,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {EvolveClientTest.class})
@@ -117,10 +116,10 @@ public class EvolveClientTest {
 
     assertEquals(urlCaptor.getAllValues().size(), 2);
     assertEquals(
-        this.apiPath + "courses?locale=en&is_active=true&page=1",
+        this.apiPath + "courses?is_active=true&locale=en&page=1",
         urlCaptor.getAllValues().getFirst());
     assertEquals(
-        this.apiPath + "courses?locale=en&is_active=true&page=2",
+        this.apiPath + "courses?is_active=true&locale=en&page=2",
         urlCaptor.getAllValues().getLast());
 
     for (CourseDTO courseDTO : courses) {
@@ -153,6 +152,90 @@ public class EvolveClientTest {
             this.retryMaxBackoffSecs);
   }
 
+  private void initDataWithSinglePage() {
+    CourseDTO courseDTO = new CourseDTO();
+    courseDTO.setId(1);
+    courseDTO.setTranslationStatus(READY_FOR_TRANSLATION);
+    courseDTO.setType("CourseEvolve");
+
+    CoursesDTO coursesDTO = new CoursesDTO();
+    coursesDTO.setCourses(ImmutableList.of(courseDTO));
+    PaginationDTO pagination = new PaginationDTO();
+    pagination.setCurrentPage(1);
+    pagination.setTotalPages(1);
+    coursesDTO.setPagination(pagination);
+    when(this.mockRestTemplate.getForObject(anyString(), any())).thenReturn(coursesDTO);
+    this.evolveClient =
+        new EvolveClient(
+            this.mockRestTemplate,
+            this.apiPath,
+            this.maxRetries,
+            this.retryMinBackoffSecs,
+            this.retryMaxBackoffSecs);
+  }
+
+  @Test
+  public void testGetCoursesWithSingleCode() {
+    this.initDataWithSinglePage();
+
+    CoursesGetRequest coursesGetRequest = new CoursesGetRequest(Sets.newHashSet("COURSE_A"), null);
+
+    List<CourseDTO> courses = this.evolveClient.getCourses(coursesGetRequest).toList();
+
+    verify(this.mockRestTemplate, times(1)).getForObject(urlCaptor.capture(), any());
+
+    assertEquals(1, courses.size());
+    assertEquals(
+        this.apiPath + "courses?is_active=true&code[]=COURSE_A&page=1", urlCaptor.getValue());
+  }
+
+  @Test
+  public void testGetCoursesWithMultipleCodes() {
+    this.initDataWithSinglePage();
+
+    CoursesGetRequest coursesGetRequest =
+        new CoursesGetRequest(Sets.newTreeSet(Sets.newHashSet("COURSE_A", "COURSE_B")), null);
+
+    this.evolveClient.getCourses(coursesGetRequest).count();
+
+    verify(this.mockRestTemplate, times(1)).getForObject(urlCaptor.capture(), any());
+
+    String capturedUrl = urlCaptor.getValue();
+    assertTrue(capturedUrl.startsWith(this.apiPath + "courses?is_active=true"));
+    assertTrue(capturedUrl.contains("code[]=COURSE_A"));
+    assertTrue(capturedUrl.contains("code[]=COURSE_B"));
+    assertTrue(capturedUrl.endsWith("&page=1"));
+  }
+
+  @Test
+  public void testGetCoursesWithNullCodesUsesLocaleInstead() {
+    this.initEmptyCoursesData();
+
+    CoursesGetRequest coursesGetRequest = new CoursesGetRequest((java.util.Set<String>) null, null);
+
+    this.evolveClient.getCourses(coursesGetRequest).count();
+
+    verify(this.mockRestTemplate, times(1)).getForObject(urlCaptor.capture(), any());
+
+    String capturedUrl = urlCaptor.getValue();
+    assertTrue(capturedUrl.startsWith(this.apiPath + "courses?is_active=true"));
+    assertTrue(!capturedUrl.contains("code%5B%5D"));
+  }
+
+  @Test
+  public void testGetCoursesWithEmptyCodesDoesNotAddCodeParam() {
+    this.initEmptyCoursesData();
+
+    CoursesGetRequest coursesGetRequest = new CoursesGetRequest(Sets.newHashSet(), null);
+
+    this.evolveClient.getCourses(coursesGetRequest).count();
+
+    verify(this.mockRestTemplate, times(1)).getForObject(urlCaptor.capture(), any());
+
+    String capturedUrl = urlCaptor.getValue();
+    assertTrue(!capturedUrl.contains("code%5B%5D"));
+  }
+
   @Test
   public void testGetCoursesWithUpdatedOnToDate() {
     this.initEmptyCoursesData();
@@ -168,8 +251,7 @@ public class EvolveClientTest {
     assertEquals(
         this.apiPath
             + String.format(
-                "courses?locale=en&is_active=true&updated_on_to=%s&page=1",
-                UriComponentsBuilder.fromPath(updatedOnTo.toString()).toUriString()),
+                "courses?is_active=true&locale=en&updated_on_to=%s&page=1", updatedOnTo),
         urlCaptor.getValue());
   }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/evolve/EvolveCoursePictureServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/evolve/EvolveCoursePictureServiceTest.java
@@ -1,0 +1,177 @@
+package com.box.l10n.mojito.service.evolve;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.box.l10n.mojito.entity.EvolveCoursePicture;
+import com.box.l10n.mojito.service.evolve.dto.CourseDTO;
+import com.box.l10n.mojito.service.evolve.dto.PictureDTO;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {EvolveCoursePictureServiceTest.class})
+public class EvolveCoursePictureServiceTest {
+
+  @Mock EvolveCoursePictureRepository evolveCoursePictureRepository;
+
+  EvolveCoursePictureService evolveCoursePictureService;
+
+  @Captor ArgumentCaptor<List<EvolveCoursePicture>> savedPicturesCaptor;
+
+  @Before
+  public void setUp() {
+    evolveCoursePictureService = new EvolveCoursePictureService(evolveCoursePictureRepository);
+  }
+
+  @Test
+  public void testFindByCourseIdAndLocaleBcp47TagReturnsPicture() {
+    EvolveCoursePicture picture = new EvolveCoursePicture();
+    picture.setCourseId(1);
+    picture.setLocaleBcp47Tag("fr");
+    when(evolveCoursePictureRepository.findByCourseIdAndLocaleBcp47Tag(1, "fr"))
+        .thenReturn(Optional.of(picture));
+
+    Optional<EvolveCoursePicture> result =
+        evolveCoursePictureService.findByCourseIdAndLocaleBcp47Tag(1, "fr");
+
+    assertTrue(result.isPresent());
+    assertEquals("fr", result.get().getLocaleBcp47Tag());
+    assertEquals(1, result.get().getCourseId());
+  }
+
+  @Test
+  public void testFindByCourseIdAndLocaleBcp47TagReturnsEmpty() {
+    when(evolveCoursePictureRepository.findByCourseIdAndLocaleBcp47Tag(99, "de"))
+        .thenReturn(Optional.empty());
+
+    Optional<EvolveCoursePicture> result =
+        evolveCoursePictureService.findByCourseIdAndLocaleBcp47Tag(99, "de");
+
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testUpsertCreatesNewPictureWhenNoneExist() {
+    when(evolveCoursePictureRepository.findByCourseId(10)).thenReturn(ImmutableList.of());
+
+    CourseDTO dto = new CourseDTO();
+    dto.setLocale("es");
+    PictureDTO picture = new PictureDTO();
+    picture.setTargetUrl("https://cdn.example.com/es.jpg");
+    dto.setPicture(picture);
+
+    evolveCoursePictureService.upsertLocalizedCoursePictureUrls(10, ImmutableList.of(dto));
+
+    verify(evolveCoursePictureRepository).saveAll(savedPicturesCaptor.capture());
+    List<EvolveCoursePicture> saved = savedPicturesCaptor.getValue();
+    assertEquals(1, saved.size());
+    assertEquals(10, saved.get(0).getCourseId());
+    assertEquals("es", saved.get(0).getLocaleBcp47Tag());
+    assertEquals("https://cdn.example.com/es.jpg", saved.get(0).getPictureUrl());
+  }
+
+  @Test
+  public void testUpsertUpdatesExistingPicture() {
+    EvolveCoursePicture existing = new EvolveCoursePicture();
+    existing.setCourseId(10);
+    existing.setLocaleBcp47Tag("es");
+    existing.setPictureUrl("https://cdn.example.com/old.jpg");
+    when(evolveCoursePictureRepository.findByCourseId(10)).thenReturn(ImmutableList.of(existing));
+
+    CourseDTO dto = new CourseDTO();
+    dto.setLocale("es");
+    PictureDTO picture = new PictureDTO();
+    picture.setTargetUrl("https://cdn.example.com/new.jpg");
+    dto.setPicture(picture);
+
+    evolveCoursePictureService.upsertLocalizedCoursePictureUrls(10, ImmutableList.of(dto));
+
+    verify(evolveCoursePictureRepository).saveAll(savedPicturesCaptor.capture());
+    List<EvolveCoursePicture> saved = savedPicturesCaptor.getValue();
+    assertEquals(1, saved.size());
+    assertEquals("https://cdn.example.com/new.jpg", saved.get(0).getPictureUrl());
+  }
+
+  @Test
+  public void testUpsertSkipsCourseDTOsWithNoPictureUrls() {
+    when(evolveCoursePictureRepository.findByCourseId(10)).thenReturn(ImmutableList.of());
+
+    CourseDTO dto = new CourseDTO();
+    dto.setLocale("es");
+
+    evolveCoursePictureService.upsertLocalizedCoursePictureUrls(10, ImmutableList.of(dto));
+
+    verify(evolveCoursePictureRepository).saveAll(savedPicturesCaptor.capture());
+    assertTrue(savedPicturesCaptor.getValue().isEmpty());
+  }
+
+  @Test
+  public void testUpsertIncludesCourseDTOWithHeroPictureUrl() {
+    when(evolveCoursePictureRepository.findByCourseId(5)).thenReturn(ImmutableList.of());
+
+    CourseDTO dto = new CourseDTO();
+    dto.setLocale("fr");
+    PictureDTO heroPicture = new PictureDTO();
+    heroPicture.setTargetUrl("https://cdn.example.com/hero.jpg");
+    dto.setHeroPicture(heroPicture);
+
+    evolveCoursePictureService.upsertLocalizedCoursePictureUrls(5, ImmutableList.of(dto));
+
+    verify(evolveCoursePictureRepository).saveAll(savedPicturesCaptor.capture());
+    List<EvolveCoursePicture> saved = savedPicturesCaptor.getValue();
+    assertEquals(1, saved.size());
+    assertEquals("https://cdn.example.com/hero.jpg", saved.get(0).getHeroPictureUrl());
+  }
+
+  @Test
+  public void testUpsertWithEmptyListSavesNothing() {
+    when(evolveCoursePictureRepository.findByCourseId(7)).thenReturn(ImmutableList.of());
+
+    evolveCoursePictureService.upsertLocalizedCoursePictureUrls(7, ImmutableList.of());
+
+    verify(evolveCoursePictureRepository).saveAll(savedPicturesCaptor.capture());
+    assertTrue(savedPicturesCaptor.getValue().isEmpty());
+  }
+
+  @Test
+  public void testUpsertHandlesMultipleLocales() {
+    when(evolveCoursePictureRepository.findByCourseId(3)).thenReturn(ImmutableList.of());
+
+    CourseDTO dtoEs = new CourseDTO();
+    dtoEs.setLocale("es");
+    PictureDTO picEs = new PictureDTO();
+    picEs.setTargetUrl("https://cdn.example.com/es.jpg");
+    dtoEs.setPicture(picEs);
+
+    CourseDTO dtoFr = new CourseDTO();
+    dtoFr.setLocale("fr");
+    PictureDTO picFr = new PictureDTO();
+    picFr.setTargetUrl("https://cdn.example.com/fr.jpg");
+    dtoFr.setPicture(picFr);
+
+    evolveCoursePictureService.upsertLocalizedCoursePictureUrls(3, ImmutableList.of(dtoEs, dtoFr));
+
+    verify(evolveCoursePictureRepository).saveAll(savedPicturesCaptor.capture());
+    List<EvolveCoursePicture> saved = savedPicturesCaptor.getValue();
+    assertEquals(2, saved.size());
+  }
+
+  @Test
+  public void testDeleteByCourseId() {
+    evolveCoursePictureService.deleteByCourseId(42);
+    verify(evolveCoursePictureRepository).deleteByCourseId(42);
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/evolve/EvolveServiceMockTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/evolve/EvolveServiceMockTest.java
@@ -1,0 +1,550 @@
+package com.box.l10n.mojito.service.evolve;
+
+import static com.box.l10n.mojito.service.evolve.dto.TranslationStatusType.IN_TRANSLATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.box.l10n.mojito.LocaleMappingHelper;
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.entity.AssetContent;
+import com.box.l10n.mojito.entity.AssetExtraction;
+import com.box.l10n.mojito.entity.AssetExtractionByBranch;
+import com.box.l10n.mojito.entity.Branch;
+import com.box.l10n.mojito.entity.BranchStatistic;
+import com.box.l10n.mojito.entity.EvolveCoursePicture;
+import com.box.l10n.mojito.entity.Locale;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.service.asset.AssetService;
+import com.box.l10n.mojito.service.assetExtraction.AssetExtractionByBranchRepository;
+import com.box.l10n.mojito.service.assetcontent.AssetContentRepository;
+import com.box.l10n.mojito.service.branch.BranchRepository;
+import com.box.l10n.mojito.service.branch.BranchService;
+import com.box.l10n.mojito.service.branch.BranchStatisticRepository;
+import com.box.l10n.mojito.service.evolve.dto.CourseDTO;
+import com.box.l10n.mojito.service.pollableTask.PollableTaskService;
+import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import com.box.l10n.mojito.service.tm.TMService;
+import com.box.l10n.mojito.xliff.XliffUtils;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Unit tests for {@link EvolveService}'s course picture URL handling, i.e. the private {@code
+ * applyCoursePictureUrls}.
+ *
+ * <p>That method is reached through the only public entry point of the service:
+ *
+ * <pre>
+ * sync() -&gt; syncInTranslation() -&gt; updateCourseTranslations() -&gt; applyCoursePictureUrls()
+ * </pre>
+ *
+ * <p>Its result is observable as the third argument of {@link
+ * EvolveClient#updateCourseTranslation(int, Boolean, String)}, so every test drives {@code sync}
+ * and asserts on that captured XLIFF content.
+ *
+ * <p>{@link XliffUtils} and {@link TranslationModeMapper} are intentionally real: the former is the
+ * XML transformation under test and the latter produces the flag that selects the branch. Only the
+ * outbound collaborators and the persistence layer are mocked.
+ *
+ * <p>NOTE: {@code sync} catches every per-course exception and only reports an aggregate {@code "N
+ * course(s) failed to sync"} at the end. A missing stub therefore surfaces as that opaque message
+ * rather than the underlying failure, so tests assert positively with {@code
+ * verify(evolveClientMock).updateCourseTranslation(...)} instead of relying on "no exception was
+ * thrown".
+ */
+public class EvolveServiceMockTest {
+
+  private static final long REPOSITORY_ID = 1L;
+
+  private static final int COURSE_ID = 1;
+
+  private static final String BRANCH_NAME = "evolve/course_1";
+
+  private static final String ASSET_PATH = "1.xliff";
+
+  private static final String CONTENT_MD5 = "contentMd5";
+
+  private static final String REFRESH_WITH_PARENT_ASSETS_AND_STRUCTURE =
+      "Refresh with parent assets and structure";
+
+  private static final String PRESERVE_ASSETS_AND_STRUCTURE = "Preserve assets and structure";
+
+  private static final String PICTURE_ID = "course[1].picture.target_url";
+
+  private static final String HERO_PICTURE_ID = "course[1].hero_picture.target_url";
+
+  private static final String HERO_PICTURE_MOBILE_ID = "course[1].hero_picture.mobile_target_url";
+
+  @Mock EvolveClient evolveClientMock;
+
+  @Mock EvolveCoursePictureService evolveCoursePictureServiceMock;
+
+  @Mock EvolveSlackNotificationSender evolveSlackNotificationSenderMock;
+
+  @Mock RepositoryRepository repositoryRepositoryMock;
+
+  @Mock AssetService assetServiceMock;
+
+  @Mock PollableTaskService pollableTaskServiceMock;
+
+  @Mock BranchRepository branchRepositoryMock;
+
+  @Mock BranchStatisticRepository branchStatisticRepositoryMock;
+
+  @Mock AssetContentRepository assetContentRepositoryMock;
+
+  @Mock AssetExtractionByBranchRepository assetExtractionByBranchRepositoryMock;
+
+  @Mock TMService tmServiceMock;
+
+  @Mock BranchService branchServiceMock;
+
+  @Captor ArgumentCaptor<Integer> courseIdCaptor;
+
+  @Captor ArgumentCaptor<Boolean> refreshWithParentAssetsAndStructureCaptor;
+
+  @Captor ArgumentCaptor<String> translatedCourseCaptor;
+
+  AutoCloseable mocks;
+
+  EvolveConfigurationProperties evolveConfigurationProperties;
+
+  EvolveService evolveService;
+
+  @BeforeEach
+  public void setUp() {
+    this.mocks = MockitoAnnotations.openMocks(this);
+
+    this.evolveConfigurationProperties = new EvolveConfigurationProperties();
+    this.evolveConfigurationProperties.setMaxRetries(0);
+    this.evolveConfigurationProperties.setRetryMinBackoffSecs(0);
+    this.evolveConfigurationProperties.setRetryMaxBackoffSecs(0);
+    this.evolveConfigurationProperties.setEvolveSyncMaxRetries(0);
+    this.evolveConfigurationProperties.setEvolveSyncRetryMinBackoffSecs(0);
+    this.evolveConfigurationProperties.setEvolveSyncRetryMaxBackoffSecs(0);
+    this.evolveConfigurationProperties.setRefreshWithParentAssetsAndStructureText(
+        REFRESH_WITH_PARENT_ASSETS_AND_STRUCTURE);
+    this.evolveConfigurationProperties.setPreserveAssetsAndStructureText(
+        PRESERVE_ASSETS_AND_STRUCTURE);
+
+    this.evolveService =
+        new EvolveService(
+            this.evolveConfigurationProperties,
+            this.repositoryRepositoryMock,
+            this.evolveClientMock,
+            this.assetServiceMock,
+            this.pollableTaskServiceMock,
+            new XliffUtils(),
+            this.branchRepositoryMock,
+            this.branchStatisticRepositoryMock,
+            this.assetContentRepositoryMock,
+            this.tmServiceMock,
+            this.branchServiceMock,
+            this.assetExtractionByBranchRepositoryMock,
+            new LocaleMappingHelper(),
+            new TranslationModeMapper(this.evolveConfigurationProperties),
+            this.evolveCoursePictureServiceMock,
+            null,
+            this.evolveSlackNotificationSenderMock);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    this.mocks.close();
+  }
+
+  private String getXliffContent(String fileName) throws IOException {
+    return Files.readString(
+        Path.of(Resources.getResource("com/box/l10n/mojito/service/evolve/" + fileName).getPath()));
+  }
+
+  private String getCourseWithPicturesXliffContent() throws IOException {
+    return this.getXliffContent("course_with_pictures.xliff");
+  }
+
+  private String getCourseWithoutPicturesXliffContent() throws IOException {
+    return this.getXliffContent("course_without_pictures.xliff");
+  }
+
+  private Locale createLocale(long id, String bcp47Tag) {
+    Locale locale = new Locale();
+    locale.setId(id);
+    locale.setBcp47Tag(bcp47Tag);
+    return locale;
+  }
+
+  private EvolveCoursePicture createCoursePicture(
+      String localeBcp47Tag,
+      String pictureUrl,
+      String heroPictureUrl,
+      String heroPictureMobileUrl) {
+    EvolveCoursePicture evolveCoursePicture = new EvolveCoursePicture();
+    evolveCoursePicture.setCourseId(COURSE_ID);
+    evolveCoursePicture.setLocaleBcp47Tag(localeBcp47Tag);
+    evolveCoursePicture.setPictureUrl(pictureUrl);
+    evolveCoursePicture.setHeroPictureUrl(heroPictureUrl);
+    evolveCoursePicture.setHeroPictureMobileUrl(heroPictureMobileUrl);
+    return evolveCoursePicture;
+  }
+
+  /**
+   * Stubs everything needed for {@code sync} to walk the IN_TRANSLATION path down to {@code
+   * applyCoursePictureUrls} and to call {@link EvolveClient#updateCourseTranslation(int, Boolean,
+   * String)} once per target locale.
+   *
+   * <p>The branch statistics deliberately report untranslated text units so {@code
+   * syncInTranslation} stops short of {@code syncTranslated}, which keeps branch deletion and
+   * pollable tasks out of the picture.
+   */
+  private void stubInTranslationSync(String translationMode, String... targetBcp47Tags) {
+    Locale sourceLocale = this.createLocale(1L, "en");
+    RepositoryLocale sourceRepositoryLocale = new RepositoryLocale();
+    sourceRepositoryLocale.setId(1L);
+    sourceRepositoryLocale.setLocale(sourceLocale);
+
+    Set<RepositoryLocale> repositoryLocales = new LinkedHashSet<>();
+    repositoryLocales.add(sourceRepositoryLocale);
+    for (int i = 0; i < targetBcp47Tags.length; i++) {
+      RepositoryLocale targetRepositoryLocale = new RepositoryLocale();
+      targetRepositoryLocale.setId(2L + i);
+      targetRepositoryLocale.setLocale(this.createLocale(2L + i, targetBcp47Tags[i]));
+      targetRepositoryLocale.setParentLocale(sourceRepositoryLocale);
+      repositoryLocales.add(targetRepositoryLocale);
+    }
+
+    Repository repository = new Repository();
+    repository.setId(REPOSITORY_ID);
+    repository.setRepositoryLocales(repositoryLocales);
+    when(this.repositoryRepositoryMock.findById(REPOSITORY_ID)).thenReturn(Optional.of(repository));
+
+    CourseDTO courseDTO = new CourseDTO();
+    courseDTO.setId(COURSE_ID);
+    courseDTO.setTranslationStatus(IN_TRANSLATION);
+    courseDTO.setTranslationMode(translationMode);
+    // Streams are single use, so a new one has to be created for every invocation.
+    when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
+        .thenAnswer(invocation -> Stream.of(courseDTO));
+
+    Branch branch = new Branch();
+    branch.setId(10L);
+    branch.setName(BRANCH_NAME);
+    branch.setRepository(repository);
+    when(this.branchRepositoryMock.findByNameAndRepository(BRANCH_NAME, repository))
+        .thenReturn(branch);
+
+    BranchStatistic branchStatistic = new BranchStatistic();
+    branchStatistic.setBranch(branch);
+    branchStatistic.setTotalCount(4L);
+    branchStatistic.setForTranslationCount(1L);
+    when(this.branchStatisticRepositoryMock.findByBranch(branch)).thenReturn(branchStatistic);
+
+    Asset asset = new Asset();
+    asset.setId(20L);
+    asset.setPath(ASSET_PATH);
+    asset.setRepository(repository);
+    when(this.assetServiceMock.findAll(REPOSITORY_ID, ASSET_PATH, false, false, branch.getId()))
+        .thenReturn(List.of(asset));
+
+    AssetExtraction assetExtraction = new AssetExtraction();
+    assetExtraction.setId(30L);
+    assetExtraction.setContentMd5(CONTENT_MD5);
+    AssetExtractionByBranch assetExtractionByBranch = new AssetExtractionByBranch();
+    assetExtractionByBranch.setAsset(asset);
+    assetExtractionByBranch.setBranch(branch);
+    assetExtractionByBranch.setAssetExtraction(assetExtraction);
+    when(this.assetExtractionByBranchRepositoryMock.findByAssetAndBranch(asset, branch))
+        .thenReturn(Optional.of(assetExtractionByBranch));
+
+    AssetContent assetContent = new AssetContent();
+    assetContent.setId(40L);
+    assetContent.setAsset(asset);
+    assetContent.setBranch(branch);
+    assetContent.setContentMd5(CONTENT_MD5);
+    assetContent.setContent("source content");
+    when(this.assetContentRepositoryMock.findByAssetRepositoryIdAndBranchName(
+            REPOSITORY_ID, BRANCH_NAME))
+        .thenReturn(List.of(assetContent));
+  }
+
+  /** Makes {@code tmService.generateLocalized} return {@code localizedContent} for every locale. */
+  private void stubGenerateLocalized(String localizedContent)
+      throws com.box.l10n.mojito.okapi.asset.UnsupportedAssetFilterTypeException {
+    // any() rather than anyString() for the null filterConfigIdOverride and pullRunName arguments,
+    // anyString() does not match null.
+    when(this.tmServiceMock.generateLocalized(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(localizedContent);
+  }
+
+  /** Makes {@code tmService.generateLocalized} return content keyed by the output BCP47 tag. */
+  private void stubGenerateLocalizedPerOutputBcp47Tag(Map<String, String> contentByOutputBcp47Tag)
+      throws com.box.l10n.mojito.okapi.asset.UnsupportedAssetFilterTypeException {
+    when(this.tmServiceMock.generateLocalized(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenAnswer(
+            invocation -> contentByOutputBcp47Tag.get(invocation.getArgument(3, String.class)));
+  }
+
+  private Document parse(String xmlContent) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    return factory.newDocumentBuilder().parse(new InputSource(new StringReader(xmlContent)));
+  }
+
+  /**
+   * Maps every {@code bin-unit} id in the given XLIFF to its {@code bin-target/external-file href},
+   * so assertions can be made on the document structure instead of on substrings.
+   */
+  private Map<String, String> getBinTargetHrefsById(String xmlContent) throws Exception {
+    Map<String, String> hrefsById = new HashMap<>();
+    NodeList binUnits = this.parse(xmlContent).getElementsByTagName("bin-unit");
+    for (int i = 0; i < binUnits.getLength(); i++) {
+      Element binUnit = (Element) binUnits.item(i);
+      String href = null;
+      NodeList binTargets = binUnit.getElementsByTagName("bin-target");
+      if (binTargets.getLength() > 0) {
+        NodeList externalFiles =
+            ((Element) binTargets.item(0)).getElementsByTagName("external-file");
+        if (externalFiles.getLength() > 0) {
+          href = ((Element) externalFiles.item(0)).getAttribute("href");
+        }
+      }
+      hrefsById.put(binUnit.getAttribute("id"), href);
+    }
+    return hrefsById;
+  }
+
+  private String syncAndCaptureTranslatedCourse() throws Exception {
+    this.evolveService.sync(REPOSITORY_ID, null);
+
+    verify(this.evolveClientMock)
+        .updateCourseTranslation(
+            this.courseIdCaptor.capture(),
+            this.refreshWithParentAssetsAndStructureCaptor.capture(),
+            this.translatedCourseCaptor.capture());
+    assertEquals(COURSE_ID, (int) this.courseIdCaptor.getValue());
+
+    return this.translatedCourseCaptor.getValue();
+  }
+
+  @Test
+  public void testContentWithoutBinUnitsIsUploadedUnchanged() throws Exception {
+    this.stubInTranslationSync(PRESERVE_ASSETS_AND_STRUCTURE, "es-ES");
+    String localizedContent = this.getCourseWithoutPicturesXliffContent();
+    this.stubGenerateLocalized(localizedContent);
+
+    String translatedCourse = this.syncAndCaptureTranslatedCourse();
+
+    assertEquals(localizedContent, translatedCourse);
+    assertFalse(this.refreshWithParentAssetsAndStructureCaptor.getValue());
+    // The picture URLs are never looked up: the method short circuits before that.
+    verify(this.evolveCoursePictureServiceMock, never())
+        .findByCourseIdAndLocaleBcp47Tag(anyInt(), anyString());
+  }
+
+  @Test
+  public void testNullTranslationModeRemovesAllBinUnits() throws Exception {
+    this.stubInTranslationSync(null, "es-ES");
+    this.stubGenerateLocalized(this.getCourseWithPicturesXliffContent());
+
+    String translatedCourse = this.syncAndCaptureTranslatedCourse();
+
+    assertTrue(this.getBinTargetHrefsById(translatedCourse).isEmpty());
+    assertNull(this.refreshWithParentAssetsAndStructureCaptor.getValue());
+    verify(this.evolveCoursePictureServiceMock, never())
+        .findByCourseIdAndLocaleBcp47Tag(anyInt(), anyString());
+  }
+
+  @Test
+  public void testRefreshWithParentAssetsAndStructureModeRemovesAllBinUnits() throws Exception {
+    this.stubInTranslationSync(REFRESH_WITH_PARENT_ASSETS_AND_STRUCTURE, "es-ES");
+    this.stubGenerateLocalized(this.getCourseWithPicturesXliffContent());
+
+    String translatedCourse = this.syncAndCaptureTranslatedCourse();
+
+    assertTrue(this.getBinTargetHrefsById(translatedCourse).isEmpty());
+    assertTrue(this.refreshWithParentAssetsAndStructureCaptor.getValue());
+    verify(this.evolveCoursePictureServiceMock, never())
+        .findByCourseIdAndLocaleBcp47Tag(anyInt(), anyString());
+  }
+
+  @Test
+  public void testUnmappedTranslationModeRemovesAllBinUnits() throws Exception {
+    this.stubInTranslationSync("some unmapped translation mode", "es-ES");
+    this.stubGenerateLocalized(this.getCourseWithPicturesXliffContent());
+
+    String translatedCourse = this.syncAndCaptureTranslatedCourse();
+
+    assertTrue(this.getBinTargetHrefsById(translatedCourse).isEmpty());
+    assertNull(this.refreshWithParentAssetsAndStructureCaptor.getValue());
+    verify(this.evolveCoursePictureServiceMock, never())
+        .findByCourseIdAndLocaleBcp47Tag(anyInt(), anyString());
+  }
+
+  @Test
+  public void testPreserveAssetsAndStructureModeAppliesAllPictureUrls() throws Exception {
+    this.stubInTranslationSync(PRESERVE_ASSETS_AND_STRUCTURE, "es-ES");
+    this.stubGenerateLocalized(this.getCourseWithPicturesXliffContent());
+    when(this.evolveCoursePictureServiceMock.findByCourseIdAndLocaleBcp47Tag(COURSE_ID, "es-ES"))
+        .thenReturn(
+            Optional.of(
+                this.createCoursePicture(
+                    "es-ES",
+                    "https://cdn.test.com/es/picture.png",
+                    "https://cdn.test.com/es/hero.png",
+                    "https://cdn.test.com/es/hero_mobile.png")));
+
+    String translatedCourse = this.syncAndCaptureTranslatedCourse();
+
+    Map<String, String> hrefsById = this.getBinTargetHrefsById(translatedCourse);
+    assertEquals(Set.of(PICTURE_ID, HERO_PICTURE_ID, HERO_PICTURE_MOBILE_ID), hrefsById.keySet());
+    assertEquals("https://cdn.test.com/es/picture.png", hrefsById.get(PICTURE_ID));
+    assertEquals("https://cdn.test.com/es/hero.png", hrefsById.get(HERO_PICTURE_ID));
+    // The fixture has no mobile bin-unit, it gets created by cloning the hero picture one.
+    assertEquals("https://cdn.test.com/es/hero_mobile.png", hrefsById.get(HERO_PICTURE_MOBILE_ID));
+    assertFalse(this.refreshWithParentAssetsAndStructureCaptor.getValue());
+  }
+
+  @Test
+  public void testPreserveAssetsAndStructureModeRemovesBinUnitsWithoutAUrl() throws Exception {
+    this.stubInTranslationSync(PRESERVE_ASSETS_AND_STRUCTURE, "es-ES");
+    this.stubGenerateLocalized(this.getCourseWithPicturesXliffContent());
+    when(this.evolveCoursePictureServiceMock.findByCourseIdAndLocaleBcp47Tag(COURSE_ID, "es-ES"))
+        .thenReturn(
+            Optional.of(
+                this.createCoursePicture(
+                    "es-ES", "https://cdn.test.com/es/picture.png", null, null)));
+
+    String translatedCourse = this.syncAndCaptureTranslatedCourse();
+
+    Map<String, String> hrefsById = this.getBinTargetHrefsById(translatedCourse);
+    assertEquals(Set.of(PICTURE_ID), hrefsById.keySet());
+    assertEquals("https://cdn.test.com/es/picture.png", hrefsById.get(PICTURE_ID));
+  }
+
+  @Test
+  public void testPreserveAssetsAndStructureModeTreatsAnEmptyUrlAsAbsent() throws Exception {
+    this.stubInTranslationSync(PRESERVE_ASSETS_AND_STRUCTURE, "es-ES");
+    this.stubGenerateLocalized(this.getCourseWithPicturesXliffContent());
+    when(this.evolveCoursePictureServiceMock.findByCourseIdAndLocaleBcp47Tag(COURSE_ID, "es-ES"))
+        .thenReturn(
+            Optional.of(
+                this.createCoursePicture("es-ES", "", "https://cdn.test.com/es/hero.png", null)));
+
+    String translatedCourse = this.syncAndCaptureTranslatedCourse();
+
+    Map<String, String> hrefsById = this.getBinTargetHrefsById(translatedCourse);
+    assertEquals(Set.of(HERO_PICTURE_ID), hrefsById.keySet());
+    assertEquals("https://cdn.test.com/es/hero.png", hrefsById.get(HERO_PICTURE_ID));
+  }
+
+  @Test
+  public void testPreserveAssetsAndStructureModeWithoutAStoredPictureRemovesAllBinUnits()
+      throws Exception {
+    this.stubInTranslationSync(PRESERVE_ASSETS_AND_STRUCTURE, "es-ES");
+    this.stubGenerateLocalized(this.getCourseWithPicturesXliffContent());
+    when(this.evolveCoursePictureServiceMock.findByCourseIdAndLocaleBcp47Tag(COURSE_ID, "es-ES"))
+        .thenReturn(Optional.empty());
+
+    String translatedCourse = this.syncAndCaptureTranslatedCourse();
+
+    assertTrue(this.getBinTargetHrefsById(translatedCourse).isEmpty());
+  }
+
+  @Test
+  public void testPreserveAssetsAndStructureModeLooksUpTheMappedOutputLocale() throws Exception {
+    this.stubInTranslationSync(PRESERVE_ASSETS_AND_STRUCTURE, "es-MX");
+    this.stubGenerateLocalized(this.getCourseWithPicturesXliffContent());
+    when(this.evolveCoursePictureServiceMock.findByCourseIdAndLocaleBcp47Tag(COURSE_ID, "es-419"))
+        .thenReturn(
+            Optional.of(
+                this.createCoursePicture(
+                    "es-419", "https://cdn.test.com/es-419/picture.png", null, null)));
+
+    this.evolveService.sync(REPOSITORY_ID, "es-MX:es-419");
+
+    verify(this.evolveClientMock)
+        .updateCourseTranslation(eq(COURSE_ID), eq(false), this.translatedCourseCaptor.capture());
+    // The lookup uses the mapped output tag, not the repository locale tag.
+    verify(this.evolveCoursePictureServiceMock)
+        .findByCourseIdAndLocaleBcp47Tag(COURSE_ID, "es-419");
+    verify(this.evolveCoursePictureServiceMock, never())
+        .findByCourseIdAndLocaleBcp47Tag(COURSE_ID, "es-MX");
+    assertEquals(
+        "https://cdn.test.com/es-419/picture.png",
+        this.getBinTargetHrefsById(this.translatedCourseCaptor.getValue()).get(PICTURE_ID));
+  }
+
+  @Test
+  public void testPreserveAssetsAndStructureModeAppliesPictureUrlsPerLocale() throws Exception {
+    this.stubInTranslationSync(PRESERVE_ASSETS_AND_STRUCTURE, "es-ES", "fr-FR");
+    String localizedContent = this.getCourseWithPicturesXliffContent();
+    this.stubGenerateLocalizedPerOutputBcp47Tag(
+        Map.of("es-ES", localizedContent, "fr-FR", localizedContent));
+    when(this.evolveCoursePictureServiceMock.findByCourseIdAndLocaleBcp47Tag(COURSE_ID, "es-ES"))
+        .thenReturn(
+            Optional.of(
+                this.createCoursePicture(
+                    "es-ES", "https://cdn.test.com/es/picture.png", null, null)));
+    when(this.evolveCoursePictureServiceMock.findByCourseIdAndLocaleBcp47Tag(COURSE_ID, "fr-FR"))
+        .thenReturn(
+            Optional.of(
+                this.createCoursePicture(
+                    "fr-FR", "https://cdn.test.com/fr/picture.png", null, null)));
+
+    this.evolveService.sync(REPOSITORY_ID, null);
+
+    verify(this.evolveClientMock, times(2))
+        .updateCourseTranslation(eq(COURSE_ID), eq(false), this.translatedCourseCaptor.capture());
+    List<String> translatedCourses = this.translatedCourseCaptor.getAllValues();
+    assertEquals(
+        List.of("https://cdn.test.com/es/picture.png", "https://cdn.test.com/fr/picture.png"),
+        List.of(
+            this.getBinTargetHrefsById(translatedCourses.get(0)).get(PICTURE_ID),
+            this.getBinTargetHrefsById(translatedCourses.get(1)).get(PICTURE_ID)));
+  }
+
+  @Test
+  public void testMalformedLocalizedContentFailsTheSyncWithoutUploading() throws Exception {
+    this.stubInTranslationSync(PRESERVE_ASSETS_AND_STRUCTURE, "es-ES");
+    this.stubGenerateLocalized("not xliff at all");
+
+    assertThrows(EvolveSyncException.class, () -> this.evolveService.sync(REPOSITORY_ID, null));
+
+    verify(this.evolveClientMock, never()).updateCourseTranslation(anyInt(), any(), anyString());
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/evolve/EvolveServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/evolve/EvolveServiceTest.java
@@ -116,6 +116,8 @@ public class EvolveServiceTest extends ServiceTestBase {
 
   @Autowired GitBlameService gitBlameService;
 
+  @Autowired EvolveCoursePictureService evolveCoursePictureService;
+
   @Rule public TestIdWatcher testIdWatcher = new TestIdWatcher();
 
   @Mock EvolveClient evolveClientMock;
@@ -131,6 +133,8 @@ public class EvolveServiceTest extends ServiceTestBase {
   @Captor ArgumentCaptor<Set<String>> additionalLocalesCaptor;
 
   @Captor ArgumentCaptor<TranslationStatusType> translationStatusTypeCaptor;
+
+  @Captor ArgumentCaptor<CoursesGetRequest> coursesGetRequestCaptor;
 
   EvolveService evolveService;
 
@@ -165,6 +169,7 @@ public class EvolveServiceTest extends ServiceTestBase {
             this.assetExtractionByBranchRepository,
             this.localeMappingHelper,
             new TranslationModeMapper(this.evolveConfigurationProperties),
+            this.evolveCoursePictureService,
             null,
             this.evolveSlackNotificationSenderMock);
   }
@@ -183,11 +188,61 @@ public class EvolveServiceTest extends ServiceTestBase {
     courseDTO1.setType("CourseCurriculum");
 
     when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
-        .thenReturn(Stream.of(courseDTO1));
+        .thenAnswer(invocation -> Stream.of(courseDTO1));
     when(this.evolveClientMock.startCourseTranslation(anyInt(), anyString(), anySet()))
         .thenReturn(this.getXliffContent());
 
     this.initEvolveService();
+  }
+
+  @Test
+  public void testSyncReadyForTranslationFetchesLocalizedCoursesAndUpsertsPictures()
+      throws RepositoryNameAlreadyUsedException, RepositoryLocaleCreationException, IOException {
+    Locale esLocale = this.localeService.findByBcp47Tag("es-ES");
+    RepositoryLocale esRepositoryLocale = new RepositoryLocale();
+    esRepositoryLocale.setLocale(esLocale);
+    Repository repository =
+        repositoryService.createRepository(
+            testIdWatcher.getEntityName("test"),
+            "",
+            this.localeService.getDefaultLocale(),
+            false,
+            Sets.newHashSet(),
+            Sets.newHashSet(esRepositoryLocale));
+
+    CourseDTO courseDTO = new CourseDTO();
+    courseDTO.setId(1);
+    courseDTO.setCode("COURSE_A");
+    courseDTO.setTranslationStatus(READY_FOR_TRANSLATION);
+    courseDTO.setType("CourseCurriculum");
+
+    CourseDTO localizedCourseDTO = new CourseDTO();
+    localizedCourseDTO.setId(2);
+    localizedCourseDTO.setLocale("es-ES");
+    com.box.l10n.mojito.service.evolve.dto.PictureDTO picture =
+        new com.box.l10n.mojito.service.evolve.dto.PictureDTO();
+    picture.setTargetUrl("https://cdn.example.com/es.jpg");
+    localizedCourseDTO.setPicture(picture);
+
+    when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
+        .thenAnswer(invocation -> Stream.of(courseDTO))
+        .thenAnswer(invocation -> Stream.of(localizedCourseDTO));
+    when(this.evolveClientMock.startCourseTranslation(anyInt(), anyString(), anySet()))
+        .thenReturn(this.getXliffContent());
+    this.initEvolveService();
+
+    this.evolveService.sync(repository.getId(), null);
+
+    verify(this.evolveClientMock, times(2)).getCourses(this.coursesGetRequestCaptor.capture());
+    CoursesGetRequest localizedCoursesRequest = this.coursesGetRequestCaptor.getAllValues().get(1);
+    assertEquals(Set.of("COURSE_A-es-ES"), localizedCoursesRequest.codes());
+    assertNull(localizedCoursesRequest.locale());
+
+    assertTrue(
+        this.evolveCoursePictureService
+            .findByCourseIdAndLocaleBcp47Tag(courseDTO.getId(), "es-ES")
+            .map(p -> "https://cdn.example.com/es.jpg".equals(p.getPictureUrl()))
+            .orElse(false));
   }
 
   @Test
@@ -243,7 +298,7 @@ public class EvolveServiceTest extends ServiceTestBase {
     courseDTO1.setTranslationStatus(IN_TRANSLATION);
 
     when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
-        .thenReturn(Stream.of(courseDTO1));
+        .thenAnswer(invocation -> Stream.of(courseDTO1));
 
     this.initEvolveService();
   }
@@ -587,7 +642,7 @@ public class EvolveServiceTest extends ServiceTestBase {
     courseDTO2.setTranslationStatus(IN_TRANSLATION);
 
     when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
-        .thenReturn(Stream.of(courseDTO1, courseDTO2));
+        .thenAnswer(invocation -> Stream.of(courseDTO1, courseDTO2));
     when(this.evolveClientMock.startCourseTranslation(anyInt(), anyString(), anySet()))
         .thenReturn(this.getXliffContent());
 
@@ -936,7 +991,7 @@ public class EvolveServiceTest extends ServiceTestBase {
     courseDTO2.setType("CourseCurriculum");
 
     when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
-        .thenReturn(Stream.of(courseDTO1, courseDTO2));
+        .thenAnswer(invocation -> Stream.of(courseDTO1, courseDTO2));
     when(this.evolveClientMock.startCourseTranslation(anyInt(), anyString(), anySet()))
         .thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(400)))
         .thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(400)))
@@ -981,7 +1036,7 @@ public class EvolveServiceTest extends ServiceTestBase {
     courseDTO2.setType("CourseCurriculum");
 
     when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
-        .thenReturn(Stream.of(courseDTO1, courseDTO2));
+        .thenAnswer(invocation -> Stream.of(courseDTO1, courseDTO2));
     when(this.evolveClientMock.startCourseTranslation(anyInt(), anyString(), anySet()))
         .thenReturn(this.getXliffContent());
     doThrow(new HttpClientErrorException(HttpStatusCode.valueOf(400)))
@@ -1023,7 +1078,7 @@ public class EvolveServiceTest extends ServiceTestBase {
     courseDTO1.setTranslationStatus(IN_TRANSLATION);
 
     when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
-        .thenReturn(Stream.of(courseDTO1));
+        .thenAnswer(invocation -> Stream.of(courseDTO1));
     doThrow(new HttpClientErrorException(HttpStatusCode.valueOf(400)))
         .when(this.evolveClientMock)
         .updateCourseTranslation(anyInt(), any(), anyString());
@@ -1114,7 +1169,7 @@ public class EvolveServiceTest extends ServiceTestBase {
     courseDTO1.setTranslationStatus(IN_TRANSLATION);
 
     when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
-        .thenReturn(Stream.of(courseDTO1));
+        .thenAnswer(invocation -> Stream.of(courseDTO1));
     doThrow(new HttpClientErrorException(HttpStatusCode.valueOf(400)))
         .when(this.evolveClientMock)
         .updateCourse(anyInt(), any(TranslationStatusType.class), any(ZonedDateTime.class));
@@ -1315,7 +1370,7 @@ public class EvolveServiceTest extends ServiceTestBase {
     courseDTO1.setType("CourseEvolve");
 
     when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
-        .thenReturn(Stream.of(courseDTO1));
+        .thenAnswer(invocation -> Stream.of(courseDTO1));
     when(this.evolveClientMock.startCourseTranslation(anyInt(), anyString(), anySet()))
         .thenThrow(
             new HttpClientErrorException(
@@ -1374,7 +1429,7 @@ public class EvolveServiceTest extends ServiceTestBase {
     courseDTO1.setType("CourseEvolve");
 
     when(this.evolveClientMock.getCourses(any(CoursesGetRequest.class)))
-        .thenReturn(Stream.of(courseDTO1));
+        .thenAnswer(invocation -> Stream.of(courseDTO1));
     when(this.evolveClientMock.startCourseTranslation(anyInt(), anyString(), anySet()))
         .thenThrow(
             new HttpClientErrorException(

--- a/webapp/src/test/java/com/box/l10n/mojito/service/evolve/TranslationModeMapperTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/evolve/TranslationModeMapperTest.java
@@ -24,8 +24,7 @@ class TranslationModeMapperTest {
         this.createMapper(
             "Refresh with parent assets and structure", "Preserve assets and structure");
 
-    assertEquals(
-        empty(), translationModeMapper.mapTranslationModeToReplaceLegacyEvolveLocaleContent(null));
+    assertEquals(empty(), translationModeMapper.toRefreshWithParentAssetsAndStructure(null));
   }
 
   @Test
@@ -34,8 +33,7 @@ class TranslationModeMapperTest {
         this.createMapper(
             "Refresh with parent assets and structure", "Preserve assets and structure");
 
-    assertEquals(
-        empty(), translationModeMapper.mapTranslationModeToReplaceLegacyEvolveLocaleContent(""));
+    assertEquals(empty(), translationModeMapper.toRefreshWithParentAssetsAndStructure(""));
   }
 
   @Test
@@ -46,7 +44,7 @@ class TranslationModeMapperTest {
 
     assertEquals(
         of(true),
-        translationModeMapper.mapTranslationModeToReplaceLegacyEvolveLocaleContent(
+        translationModeMapper.toRefreshWithParentAssetsAndStructure(
             "refresh WITH parent ASSETS and structure"));
   }
 
@@ -58,7 +56,7 @@ class TranslationModeMapperTest {
 
     assertEquals(
         of(false),
-        translationModeMapper.mapTranslationModeToReplaceLegacyEvolveLocaleContent(
+        translationModeMapper.toRefreshWithParentAssetsAndStructure(
             "preserve ASSETS and structure"));
   }
 
@@ -69,9 +67,7 @@ class TranslationModeMapperTest {
             "Refresh with parent assets and structure", "Preserve assets and structure");
 
     assertEquals(
-        empty(),
-        translationModeMapper.mapTranslationModeToReplaceLegacyEvolveLocaleContent(
-            "unmapped value"));
+        empty(), translationModeMapper.toRefreshWithParentAssetsAndStructure("unmapped value"));
   }
 
   @Test
@@ -80,8 +76,6 @@ class TranslationModeMapperTest {
 
     assertThrows(
         EvolveSyncException.class,
-        () ->
-            translationModeMapper.mapTranslationModeToReplaceLegacyEvolveLocaleContent(
-                "same value"));
+        () -> translationModeMapper.toRefreshWithParentAssetsAndStructure("same value"));
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/xliff/XliffUtilsTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/xliff/XliffUtilsTest.java
@@ -48,30 +48,392 @@ public class XliffUtilsTest {
           IOException,
           TransformerException,
           SAXException {
-    String xliffWithoutTargetLanguage = this.xliffUtils.removeAttribute(xliff, "target-language");
+    String xliffWithoutTargetLanguage = this.xliffUtils.removeTargetLanguageAttribute(xliff);
 
     assertEquals(null, this.xliffUtils.getTargetLanguage(xliffWithoutTargetLanguage));
   }
 
   @Test
-  public void testRemoveAttribute()
+  public void testRemoveTargetLanguageAttribute()
       throws XPathExpressionException,
           ParserConfigurationException,
           IOException,
           TransformerException,
           SAXException {
-    String newXliff = this.xliffUtils.removeAttribute(this.xliff, "target-language");
+    String newXliff = this.xliffUtils.removeTargetLanguageAttribute(this.xliff);
     assertFalse(newXliff.contains("target-language=\"fr-fr\""));
   }
 
+  String binUnit(String id, String sourceHref, String targetHref) {
+    return "<bin-unit id=\""
+        + id
+        + "\" mime-type=\"image/png\" restype=\"uri\">\n"
+        + "<bin-source>\n"
+        + "<external-file href=\""
+        + sourceHref
+        + "\"/>\n"
+        + "</bin-source>\n"
+        + "<bin-target>\n"
+        + "<external-file href=\""
+        + targetHref
+        + "\"/>\n"
+        + "</bin-target>\n"
+        + "<note>The course cover art</note>\n"
+        + "</bin-unit>\n";
+  }
+
+  String xliffWithBody(String bodyContent) {
+    return "<xliff version=\"1.2\" xmlns=\"urn:oasis:names:tc:xliff:document:1.2\">\n"
+        + "<file original=\"course[1]\" source-language=\"en\" target-language=\"fr-fr\" datatype=\"plaintext\">\n"
+        + "<body>\n"
+        + "<trans-unit id=\"course[25].name\">\n"
+        + "<source>Media Planner Practice Exam</source>\n"
+        + "<target/>\n"
+        + "</trans-unit>\n"
+        + bodyContent
+        + "</body>\n"
+        + "</file>\n"
+        + "</xliff>";
+  }
+
   @Test
-  public void testRemoveAttributeWithInvalidAttributeName()
+  public void testContainsBinUnitElement()
+      throws ParserConfigurationException, IOException, SAXException {
+    String xliffWithBinUnit =
+        this.xliffWithBody(
+            this.binUnit("course[25].picture.target_url", "https://cdn.test.com/source.png", ""));
+
+    assertTrue(this.xliffUtils.containsBinUnitElement(xliffWithBinUnit));
+  }
+
+  @Test
+  public void testContainsBinUnitElementWithMultipleBinUnits()
+      throws ParserConfigurationException, IOException, SAXException {
+    String xliffWithBinUnits =
+        this.xliffWithBody(
+            this.binUnit("course[25].picture.target_url", "https://cdn.test.com/picture.png", "")
+                + this.binUnit(
+                    "course[25].hero_picture.target_url", "https://cdn.test.com/hero.png", ""));
+
+    assertTrue(this.xliffUtils.containsBinUnitElement(xliffWithBinUnits));
+  }
+
+  @Test
+  public void testContainsBinUnitElementWhenMissing()
+      throws ParserConfigurationException, IOException, SAXException {
+    assertFalse(this.xliffUtils.containsBinUnitElement(this.xliff));
+  }
+
+  @Test
+  public void testContainsBinUnitElementWhenOnlyBinUnitChildElementsArePresent()
+      throws ParserConfigurationException, IOException, SAXException {
+    String xliffWithoutBinUnit =
+        this.xliffWithBody(
+            "<bin-source>\n"
+                + "<external-file href=\"https://cdn.test.com/source.png\"/>\n"
+                + "</bin-source>\n");
+
+    assertFalse(this.xliffUtils.containsBinUnitElement(xliffWithoutBinUnit));
+  }
+
+  @Test
+  public void testContainsBinUnitElementWhenElementNameOnlyContainsBinUnit()
+      throws ParserConfigurationException, IOException, SAXException {
+    String xliffWithoutBinUnit = this.xliffWithBody("<bin-unit-group id=\"course[25]\"/>\n");
+
+    assertFalse(this.xliffUtils.containsBinUnitElement(xliffWithoutBinUnit));
+  }
+
+  @Test(expected = SAXException.class)
+  public void testContainsBinUnitElementWithInvalidXml()
+      throws ParserConfigurationException, IOException, SAXException {
+    this.xliffUtils.containsBinUnitElement("<xliff><file><bin-unit></file></xliff>");
+  }
+
+  @Test(expected = SAXException.class)
+  public void testContainsBinUnitElementWithDoctypeIsRejected()
+      throws ParserConfigurationException, IOException, SAXException {
+    String xliffWithDoctype =
+        "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+            + this.xliffWithBody(this.binUnit("course[25].picture.target_url", "&xxe;", ""));
+
+    this.xliffUtils.containsBinUnitElement(xliffWithDoctype);
+  }
+
+  @Test(expected = SAXException.class)
+  public void testContainsBinUnitElementWithEmptyContent()
+      throws ParserConfigurationException, IOException, SAXException {
+    this.xliffUtils.containsBinUnitElement("");
+  }
+
+  @Test(expected = SAXException.class)
+  public void testRemoveTargetLanguageAttributeWithDoctypeIsRejected()
       throws XPathExpressionException,
           ParserConfigurationException,
           IOException,
           TransformerException,
           SAXException {
-    String newXliff = this.xliffUtils.removeAttribute(this.xliff, "invalid-target-language");
-    assertTrue(newXliff.contains("target-language=\"fr-fr\""));
+    String xliffWithDoctype =
+        "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>" + this.xliff;
+
+    this.xliffUtils.removeTargetLanguageAttribute(xliffWithDoctype);
+  }
+
+  @Test
+  public void testRemoveBinUnitElements()
+      throws ParserConfigurationException, IOException, SAXException, TransformerException {
+    String xliffWithBinUnits =
+        this.xliffWithBody(
+            this.binUnit("course[25].picture.target_url", "https://cdn.test.com/picture.png", "")
+                + this.binUnit(
+                    "course[25].hero_picture.target_url", "https://cdn.test.com/hero.png", ""));
+
+    String updatedXliff = this.xliffUtils.removeBinUnitElements(xliffWithBinUnits);
+
+    assertFalse(this.xliffUtils.containsBinUnitElement(updatedXliff));
+    assertTrue(updatedXliff.contains("<trans-unit id=\"course[25].name\">"));
+  }
+
+  @Test
+  public void testRemoveBinUnitElementsWithoutBinUnit()
+      throws ParserConfigurationException, IOException, SAXException, TransformerException {
+    String updatedXliff = this.xliffUtils.removeBinUnitElements(this.xliff);
+
+    assertFalse(this.xliffUtils.containsBinUnitElement(updatedXliff));
+    assertEquals("fr-fr", this.xliffUtils.getTargetLanguage(updatedXliff));
+  }
+
+  @Test(expected = SAXException.class)
+  public void testRemoveBinUnitElementsWithInvalidXml()
+      throws ParserConfigurationException, IOException, SAXException, TransformerException {
+    this.xliffUtils.removeBinUnitElements("<xliff><file><bin-unit></file></xliff>");
+  }
+
+  @Test(expected = SAXException.class)
+  public void testRemoveBinUnitElementsWithDoctypeIsRejected()
+      throws ParserConfigurationException, IOException, SAXException, TransformerException {
+    String xliffWithDoctype =
+        "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+            + this.xliffWithBody(this.binUnit("course[25].picture.target_url", "&xxe;", ""));
+
+    this.xliffUtils.removeBinUnitElements(xliffWithDoctype);
+  }
+
+  @Test(expected = SAXException.class)
+  public void testRemoveBinUnitElementsWithEmptyContent()
+      throws ParserConfigurationException, IOException, SAXException, TransformerException {
+    this.xliffUtils.removeBinUnitElements("");
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsUpdatesPictureUrl() throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit(
+                "course[25].picture.target_url",
+                "https://src.example.com/pic.png",
+                "https://old.example.com/pic.png"));
+
+    String result =
+        this.xliffUtils.replaceTargetMediaTargetUrls(
+            25, content, "https://new.example.com/pic.png", null, null);
+
+    assertTrue(result.contains("https://new.example.com/pic.png"));
+    assertFalse(result.contains("https://old.example.com/pic.png"));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsRemovesPictureBinUnitWhenUrlIsNull()
+      throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit("course[25].picture.target_url", "https://src.example.com/pic.png", ""));
+
+    String result = this.xliffUtils.replaceTargetMediaTargetUrls(25, content, null, null, null);
+
+    assertFalse(this.xliffUtils.containsBinUnitElement(result));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsRemovesPictureBinUnitWhenUrlIsEmpty()
+      throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit("course[25].picture.target_url", "https://src.example.com/pic.png", ""));
+
+    String result = this.xliffUtils.replaceTargetMediaTargetUrls(25, content, "", null, null);
+
+    assertFalse(this.xliffUtils.containsBinUnitElement(result));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsUpdatesHeroPictureUrl() throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit(
+                "course[25].hero_picture.target_url",
+                "https://src.example.com/hero.png",
+                "https://old.example.com/hero.png"));
+
+    String result =
+        this.xliffUtils.replaceTargetMediaTargetUrls(
+            25, content, null, "https://new.example.com/hero.png", null);
+
+    assertTrue(result.contains("https://new.example.com/hero.png"));
+    assertFalse(result.contains("https://old.example.com/hero.png"));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsRemovesHeroPictureBinUnitWhenUrlIsNull()
+      throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit(
+                "course[25].hero_picture.target_url", "https://src.example.com/hero.png", ""));
+
+    String result = this.xliffUtils.replaceTargetMediaTargetUrls(25, content, null, null, null);
+
+    assertFalse(this.xliffUtils.containsBinUnitElement(result));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsUpdatesMobileHeroPictureUrlWhenBinUnitExists()
+      throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit(
+                    "course[25].hero_picture.target_url", "https://src.example.com/hero.png", "")
+                + this.binUnit(
+                    "course[25].hero_picture.mobile_target_url",
+                    "https://src.example.com/mobile.png",
+                    "https://old.example.com/mobile.png"));
+
+    String result =
+        this.xliffUtils.replaceTargetMediaTargetUrls(
+            25, content, null, null, "https://new.example.com/mobile.png");
+
+    assertTrue(result.contains("https://new.example.com/mobile.png"));
+    assertFalse(result.contains("https://old.example.com/mobile.png"));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsCreatesMobileBinUnitFromHeroWhenMissing()
+      throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit(
+                "course[25].hero_picture.target_url",
+                "https://src.example.com/hero.png",
+                "https://hero.example.com/hero.png"));
+
+    String result =
+        this.xliffUtils.replaceTargetMediaTargetUrls(
+            25,
+            content,
+            null,
+            "https://hero.example.com/hero.png",
+            "https://new.example.com/mobile.png");
+
+    assertTrue(result.contains("course[25].hero_picture.mobile_target_url"));
+    assertTrue(result.contains("https://new.example.com/mobile.png"));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsMobileSkippedWhenNoHeroBinUnit() throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit(
+                "course[25].picture.target_url",
+                "https://src.example.com/pic.png",
+                "https://pic.example.com/pic.png"));
+
+    String result =
+        this.xliffUtils.replaceTargetMediaTargetUrls(
+            25,
+            content,
+            "https://pic.example.com/pic.png",
+            null,
+            "https://new.example.com/mobile.png");
+
+    assertFalse(result.contains("course[25].hero_picture.mobile_target_url"));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsRemovesMobileBinUnitWhenUrlIsNull() throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit(
+                    "course[25].hero_picture.target_url", "https://src.example.com/hero.png", "")
+                + this.binUnit(
+                    "course[25].hero_picture.mobile_target_url",
+                    "https://src.example.com/mobile.png",
+                    ""));
+
+    String result = this.xliffUtils.replaceTargetMediaTargetUrls(25, content, null, null, null);
+
+    assertFalse(result.contains("course[25].hero_picture.mobile_target_url"));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsAllThreeUrlsReplaced() throws Exception {
+    String content =
+        this.xliffWithBody(
+            this.binUnit(
+                    "course[25].picture.target_url",
+                    "https://src.example.com/pic.png",
+                    "https://old.example.com/pic.png")
+                + this.binUnit(
+                    "course[25].hero_picture.target_url",
+                    "https://src.example.com/hero.png",
+                    "https://old.example.com/hero.png")
+                + this.binUnit(
+                    "course[25].hero_picture.mobile_target_url",
+                    "https://src.example.com/mobile.png",
+                    "https://old.example.com/mobile.png"));
+
+    String result =
+        this.xliffUtils.replaceTargetMediaTargetUrls(
+            25,
+            content,
+            "https://new.example.com/pic.png",
+            "https://new.example.com/hero.png",
+            "https://new.example.com/mobile.png");
+
+    assertTrue(result.contains("https://new.example.com/pic.png"));
+    assertTrue(result.contains("https://new.example.com/hero.png"));
+    assertTrue(result.contains("https://new.example.com/mobile.png"));
+    assertFalse(result.contains("https://old.example.com/pic.png"));
+    assertFalse(result.contains("https://old.example.com/hero.png"));
+    assertFalse(result.contains("https://old.example.com/mobile.png"));
+  }
+
+  @Test
+  public void testReplaceTargetMediaTargetUrlsReturnsSameContentWhenNothingChanged()
+      throws Exception {
+    String content = this.xliff;
+
+    String result = this.xliffUtils.replaceTargetMediaTargetUrls(25, content, null, null, null);
+
+    assertEquals(content, result);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReplaceTargetMediaTargetUrlsThrowsOnNullContent() throws Exception {
+    this.xliffUtils.replaceTargetMediaTargetUrls(25, null, null, null, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReplaceTargetMediaTargetUrlsThrowsOnBlankContent() throws Exception {
+    this.xliffUtils.replaceTargetMediaTargetUrls(25, "   ", null, null, null);
+  }
+
+  @Test(expected = SAXException.class)
+  public void testReplaceTargetMediaTargetUrlsRejectsDoctype() throws Exception {
+    String xliffWithDoctype =
+        "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+            + this.xliffWithBody(this.binUnit("course[25].picture.target_url", "&xxe;", ""));
+
+    this.xliffUtils.replaceTargetMediaTargetUrls(
+        25, xliffWithDoctype, "https://new.example.com/pic.png", null, null);
   }
 }

--- a/webapp/src/test/resources/com/box/l10n/mojito/service/evolve/course_with_pictures.xliff
+++ b/webapp/src/test/resources/com/box/l10n/mojito/service/evolve/course_with_pictures.xliff
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file additional-languages="fr" code="evolve-course-en" course-type="CourseEvolve" datatype="plaintext" evolve-draft-id="123abc" evolve-locale-id="" original="course[1]" rtl="false" source-language="en">
+        <body>
+            <trans-unit datatype="plaintext" id="course[1].name">
+                <source>Media Planner Practice Exam</source>
+                <target/>
+                <note>The name of the course</note>
+            </trans-unit>
+            <bin-unit id="course[1].picture.target_url" mime-type="image/png" restype="uri">
+                <bin-source>
+                    <external-file href="https://cdn.test.com/uploads/picture/original/picture.png"/>
+                </bin-source>
+                <bin-target>
+                    <external-file href=""/>
+                </bin-target>
+                <note>The course cover art</note>
+            </bin-unit>
+            <bin-unit id="course[1].hero_picture.target_url" mime-type="image/png" restype="uri">
+                <bin-source>
+                    <external-file href="https://cdn.test.com/uploads/hero_picture/original/hero.png"/>
+                </bin-source>
+                <bin-target>
+                    <external-file href=""/>
+                </bin-target>
+                <note>The course hero art</note>
+            </bin-unit>
+            <trans-unit evolve-path="_videos.gifPlayButtonAriaLabel" evolve-ref-id="67901d791b22e91f45a711c9" evolve-translation-type="String" evolve-type="course" id="335">
+                <source>start animation</source>
+                <target/>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/webapp/src/test/resources/com/box/l10n/mojito/service/evolve/course_without_pictures.xliff
+++ b/webapp/src/test/resources/com/box/l10n/mojito/service/evolve/course_without_pictures.xliff
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file additional-languages="fr" code="evolve-course-en" course-type="CourseEvolve" datatype="plaintext" evolve-draft-id="123abc" evolve-locale-id="" original="course[1]" rtl="false" source-language="en">
+        <body>
+            <trans-unit datatype="plaintext" id="course[1].name">
+                <source>Media Planner Practice Exam</source>
+                <target/>
+                <note>The name of the course</note>
+            </trans-unit>
+            <trans-unit evolve-path="_videos.gifPlayButtonAriaLabel" evolve-ref-id="67901d791b22e91f45a711c9" evolve-translation-type="String" evolve-type="course" id="335">
+                <source>start animation</source>
+                <target/>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
## Summary

  ### Problem (Why)

  When Mojito started translations for an Evolve course, the localized courses' LMS images were
  replaced by the parent course's images.

  `startCourseTranslations` asks Evolve to create/refresh the localized copies of a parent course.
  That copy step carries the parent's artwork down onto any localized course that already exists,
  clobbering images the localized course had before. Nothing downstream restored them:
  `EvolveService.updateCourseTranslations()` unconditionally stripped every `bin-unit` element from
  the localized XLIFF before the `PUT` to `course_translations/{courseId}`, so the upload carried no
  target media and the parent's images stayed in place permanently.

  Inheriting the parent's images is the intended behavior when the course's translation mode asks for
  a refresh from the parent (`refreshWithParentAssetsAndStructure = true`). It is wrong when the mode
  asks to preserve the localized assets and structure.

  ### Solution (What + How)

  Snapshot each localized course's image URLs *before* asking Evolve to start translations, then write
  them back into the `bin-target` hrefs of the XLIFF we upload — but only for courses whose translation
  mode preserves assets.

  **1. Capture (`syncReadyForTranslation`)** — fetch the already-existing localized courses and read
  their picture URLs *before* `startCourseTranslations` runs, since that call is what destroys them:

  - `CoursesGetRequest` gained a `codes` component and `EvolveClient.getCourses()` now emits a
    repeated `code[]` query param, so we can look up localized siblings by code
    (`<parentCourseCode>-<localeBcp47Tag>`) in one paginated request instead of per-locale calls.
    `locale` is only appended when present, and the builder moved from `fromPath` to `fromUriString`
    so the page-fetch closure works on a URI template rather than a re-encoded string.
  - `CourseDTO` picks up `code`, `locale`, `picture`, and `hero_picture` (new `PictureDTO` with
    `target_url` / `mobile_target_url`).
  - `EvolveCoursePictureService.upsertLocalizedCoursePictureUrls()` stores the three URLs per
    `(course_id, locale_bcp47_tag)` in the new `evolve_course_picture` table (migration `V86`,
    unique constraint on the pair). Courses with no image URLs at all are skipped.

  **2. Restore (`updateCourseTranslations` → new `applyCoursePictureUrls`)** — per target locale, the
  localized XLIFF takes one of three paths:

  | Condition | Behavior |
  | --- | --- |
  | No `bin-unit` elements | Upload unchanged |
  | `refreshWithParentAssetsAndStructure` is `true` or unset | Strip all `bin-unit` elements (previous behavior — current images are wanted here) |
  | `refreshWithParentAssetsAndStructure` is `false` | Rewrite `bin-target/external-file href` from the snapshot, restoring the pre-start images |

  `XliffUtils.replaceTargetMediaTargetUrls()` does the rewrite in a single DOM pass: a stored URL
  updates the matching `bin-unit`'s href; a missing URL removes that `bin-unit` entirely (so we never
  send an empty href, which is what let the current image win in the first place). Because the
  exported XLIFF has no mobile hero `bin-unit`, one is synthesized by cloning the hero `bin-unit` and
  re-`id`ing it to `course[N].hero_picture.mobile_target_url`. If nothing changed, the original string
  is returned untouched.

  **3. Cleanup** — `EvolveCoursePictureService.deleteByCourseId()` runs once translations are pushed,
  so the snapshot table doesn't accumulate stale rows.

  ### Diagram

  ```mermaid
  sequenceDiagram
      participant Sync as EvolveService
      participant Evolve as Evolve API
      participant Pics as EvolveCoursePictureService
      participant TM as TmService
      participant Xliff as XliffUtils

      Note over Sync,Pics: 1. Capture — must precede start, which overwrites the images
      Sync->>Evolve: GET courses?code[]=parent-fr&code[]=parent-ja
      Evolve-->>Sync: localized CourseDTOs with picture URLs
      Sync->>Evolve: POST start course translations
      Note right of Evolve: localized images replaced by parent's
      Sync->>Pics: upsertLocalizedCoursePictureUrls(courseId, dtos)

      Note over Sync,Xliff: 2. Restore — per target locale, on upload
      Sync->>TM: generateLocalized(asset, locale)
      TM-->>Sync: localized XLIFF
      Sync->>Pics: findByCourseIdAndLocaleBcp47Tag(courseId, locale)
      Pics-->>Sync: stored picture URLs
      Sync->>Xliff: replaceTargetMediaTargetUrls(...)
      Xliff-->>Sync: XLIFF with localized bin-target hrefs
      Sync->>Evolve: PUT course_translations/{courseId}

      Note over Sync,Pics: 3. Cleanup
      Sync->>Pics: deleteByCourseId(courseId)
  ```
