### PR TITLE
I18N-2164 Implement label-aware i18n check skip handling and suppress skipped-check notifications

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
@@ -233,6 +233,13 @@ public class ExtractionCheckCommand extends Command {
   boolean areChecksSkipped = false;
 
   @Parameter(
+      names = {"--skip-i18n-checks-label-applied", "-sicl"},
+      arity = 1,
+      required = false,
+      description = "Github label name that is used to trigger skipping checks by label.")
+  boolean isSkipI18nChecksLabelApplied = false;
+
+  @Parameter(
       names = {"--checks-skipped-message", "-csm"},
       arity = 1,
       required = false,
@@ -620,6 +627,17 @@ public class ExtractionCheckCommand extends Command {
   }
 
   private void sendChecksSkippedNotifications() {
+    if (this.isSkipI18nChecksLabelApplied) {
+      consoleWriter
+          .fg(Ansi.Color.YELLOW)
+          .newLine()
+          .a(
+              String.format(
+                  "Checks skipped notifications suppressed because skip-i18n-checks label is applied."))
+          .println();
+      return;
+    }
+
     for (ExtractionCheckNotificationSender notificationSender :
         extractionCheckNotificationSenders) {
       try {

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommand.java
@@ -36,6 +36,8 @@ public class GithubPRInfoCommand extends Command {
 
   protected static final String SKIP_I18N_CHECKS_FLAG = "SKIP_I18N_CHECKS";
 
+  protected static final String SKIP_I18N_CHECKS_LABEL_FLAG = "MOJITO_SKIP_I18N_CHECKS_LABEL";
+
   protected static final String SKIP_MAX_STRINGS_BLOCK_FLAG = "MOJITO_SKIP_MAX_STRINGS_BLOCK";
 
   @Qualifier("ansiCodeEnabledFalse")
@@ -123,15 +125,22 @@ public class GithubPRInfoCommand extends Command {
           .println();
       List<GHIssueComment> prComments = github.getPRComments(repository, prNumber);
       boolean skipChecksViaComment = isSkipChecks(prComments);
-      boolean skipChecksViaLabel =
-          github.isLabelAppliedToPR(repository, prNumber, skipI18NChecksLabel);
-      if (skipChecksViaComment || skipChecksViaLabel) {
-        if (skipChecksViaComment) {
-          addReactionToSkipChecksComment(prComments);
-        }
+      if (skipChecksViaComment) {
+        addReactionToSkipChecksComment(prComments);
         consoleWriterAnsiCodeEnabledFalse.a("MOJITO_SKIP_I18N_CHECKS=true").println();
       } else {
         consoleWriterAnsiCodeEnabledFalse.a("MOJITO_SKIP_I18N_CHECKS=false").println();
+      }
+      boolean skipChecksViaLabel =
+          github.isLabelAppliedToPR(repository, prNumber, skipI18NChecksLabel);
+      if (skipChecksViaLabel) {
+        consoleWriterAnsiCodeEnabledFalse
+            .a(String.format("%s=true", SKIP_I18N_CHECKS_LABEL_FLAG))
+            .println();
+      } else {
+        consoleWriterAnsiCodeEnabledFalse
+            .a(String.format("%s=false", SKIP_I18N_CHECKS_LABEL_FLAG))
+            .println();
       }
 
       if (github.isLabelAppliedToPR(repository, prNumber, skipI18NPushLabel)) {

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest.java
@@ -791,6 +791,42 @@ public class ExtractionCheckCommandTest extends CLITestBase {
   }
 
   @Test
+  public void testChecksSkippedNotificationsSuppressedWhenSkipI18nChecksLabelApplied() {
+    ConsoleWriter consoleWriter = Mockito.mock(ConsoleWriter.class);
+    ExtractionCheckCommand extractionCheckCommand = Mockito.spy(new ExtractionCheckCommand());
+    extractionCheckCommand.consoleWriter = consoleWriter;
+    extractionCheckCommand.areChecksSkipped = true;
+    extractionCheckCommand.isSkipI18nChecksLabelApplied = true;
+    when(consoleWriter.fg(isA(Ansi.Color.class))).thenReturn(consoleWriter);
+    when(consoleWriter.newLine()).thenReturn(consoleWriter);
+    when(consoleWriter.a(isA(String.class))).thenReturn(consoleWriter);
+
+    extractionCheckCommand.execute();
+
+    verify(consoleWriter, times(1)).a("Checks disabled as --skip-checks is set to true.");
+    verify(consoleWriter, times(1))
+        .a("Checks skipped notifications suppressed because skip-i18n-checks label is applied.");
+  }
+
+  @Test
+  public void testChecksSkippedNotificationsNotSuppressedWhenSkipI18nChecksLabelNotApplied() {
+    ConsoleWriter consoleWriter = Mockito.mock(ConsoleWriter.class);
+    ExtractionCheckCommand extractionCheckCommand = Mockito.spy(new ExtractionCheckCommand());
+    extractionCheckCommand.consoleWriter = consoleWriter;
+    extractionCheckCommand.areChecksSkipped = true;
+    extractionCheckCommand.isSkipI18nChecksLabelApplied = false;
+    when(consoleWriter.fg(isA(Ansi.Color.class))).thenReturn(consoleWriter);
+    when(consoleWriter.newLine()).thenReturn(consoleWriter);
+    when(consoleWriter.a(isA(String.class))).thenReturn(consoleWriter);
+
+    extractionCheckCommand.execute();
+
+    verify(consoleWriter, times(1)).a("Checks disabled as --skip-checks is set to true.");
+    verify(consoleWriter, times(0))
+        .a("Checks skipped notifications suppressed because skip-i18n-checks label is applied.");
+  }
+
+  @Test
   public void testStatsAreReportedIfUrlTemplateSet() {
     ConsoleWriter consoleWriter = Mockito.mock(ConsoleWriter.class);
     RestTemplate restTemplateMock = Mockito.mock(RestTemplate.class);

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommandTest.java
@@ -69,6 +69,8 @@ public class GithubPRInfoCommandTest {
     verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
     verify(consoleWriterMock, times(1)).a("some");
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=false");
+    verify(this.consoleWriterMock, times(1))
+        .a(String.format("%s=false", GithubPRInfoCommand.SKIP_I18N_CHECKS_LABEL_FLAG));
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_PUSH=false");
     verify(this.consoleWriterMock, times(1))
         .a(String.format("%s=false", GithubPRInfoCommand.SKIP_MAX_STRINGS_BLOCK_FLAG));
@@ -85,6 +87,8 @@ public class GithubPRInfoCommandTest {
     verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
     verify(consoleWriterMock, times(1)).a("some");
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=true");
+    verify(this.consoleWriterMock, times(1))
+        .a(String.format("%s=false", GithubPRInfoCommand.SKIP_I18N_CHECKS_LABEL_FLAG));
     verify(ghIssueCommentMock, times(1)).createReaction(ReactionContent.PLUS_ONE);
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_PUSH=false");
     verify(this.consoleWriterMock, times(1))
@@ -102,6 +106,8 @@ public class GithubPRInfoCommandTest {
     verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
     verify(consoleWriterMock, times(1)).a("some");
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=false");
+    verify(this.consoleWriterMock, times(1))
+        .a(String.format("%s=false", GithubPRInfoCommand.SKIP_I18N_CHECKS_LABEL_FLAG));
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_PUSH=true");
     verify(this.consoleWriterMock, times(1))
         .a(String.format("%s=false", GithubPRInfoCommand.SKIP_MAX_STRINGS_BLOCK_FLAG));
@@ -126,6 +132,8 @@ public class GithubPRInfoCommandTest {
     verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
     verify(consoleWriterMock, times(1)).a("some");
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=false");
+    verify(this.consoleWriterMock, times(1))
+        .a(String.format("%s=false", GithubPRInfoCommand.SKIP_I18N_CHECKS_LABEL_FLAG));
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_PUSH=true");
     verify(this.consoleWriterMock, times(1))
         .a(String.format("%s=false", GithubPRInfoCommand.SKIP_MAX_STRINGS_BLOCK_FLAG));
@@ -155,6 +163,8 @@ public class GithubPRInfoCommandTest {
     verify(this.consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
     verify(this.consoleWriterMock, times(1)).a("some");
     verify(this.consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=false");
+    verify(this.consoleWriterMock, times(1))
+        .a(String.format("%s=false", GithubPRInfoCommand.SKIP_I18N_CHECKS_LABEL_FLAG));
     verify(this.consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_PUSH=false");
     verify(this.consoleWriterMock, times(1))
         .a(String.format("%s=true", GithubPRInfoCommand.SKIP_MAX_STRINGS_BLOCK_FLAG));
@@ -170,7 +180,9 @@ public class GithubPRInfoCommandTest {
     verify(consoleWriterMock, times(1)).a("some@email.com");
     verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
     verify(consoleWriterMock, times(1)).a("some");
-    verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=true");
+    verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=false");
+    verify(this.consoleWriterMock, times(1))
+        .a(String.format("%s=true", GithubPRInfoCommand.SKIP_I18N_CHECKS_LABEL_FLAG));
     verify(ghIssueCommentMock, times(0)).createReaction(ReactionContent.PLUS_ONE);
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_PUSH=false");
     verify(this.consoleWriterMock, times(1))
@@ -189,6 +201,8 @@ public class GithubPRInfoCommandTest {
     verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
     verify(consoleWriterMock, times(1)).a("some");
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=true");
+    verify(this.consoleWriterMock, times(1))
+        .a(String.format("%s=true", GithubPRInfoCommand.SKIP_I18N_CHECKS_LABEL_FLAG));
     verify(ghIssueCommentMock, times(1)).createReaction(ReactionContent.PLUS_ONE);
     verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_PUSH=false");
     verify(this.consoleWriterMock, times(1))


### PR DESCRIPTION
### Summary
This PR updates the i18n check skip flow to distinguish comment-based and label-based skip signals, and to suppress “checks skipped” notifications when the skip label is explicitly applied.

### What Changed
Added a new CLI/env signal for label-based skip state:

- MOJITO_SKIP_I18N_CHECKS_LABEL

Updated PR info export behavior to emit:

- MOJITO_SKIP_I18N_CHECKS based on skip comment presence
- MOJITO_SKIP_I18N_CHECKS_LABEL based on skip label presence

Added a new extraction-check CLI parameter:

- --skip-i18n-checks-label-applied (-sicl)
- Updated extraction-check skip flow so that when label-applied is true:
- checks-skipped notifications are suppressed
- a suppression message is logged

### Tests

- Extended GithubPRInfoCommandTest to validate MOJITO_SKIP_I18N_CHECKS_LABEL across normal, comment, label, push-label, and combined scenarios.
- Added new ExtractionCheckCommandTest unit tests to verify:

1. notifications are suppressed when [isSkipI18nChecksLabelApplied=true](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. notifications are not suppressed when [isSkipI18nChecksLabelApplied=false](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### Impact
Downstream automation can now reliably differentiate:

- comment-based skip (MOJITO_SKIP_I18N_CHECKS)
- label-based skip (MOJITO_SKIP_I18N_CHECKS_LABEL)
- Avoids redundant/undesired skipped-check notifications when the skip label is intentionally used.