### PR TITLE
Show Branch String ID Filter in Workbench

### DIFF
--- a/webapp/src/main/frontend/js/components/branches/BranchesPage.jsx
+++ b/webapp/src/main/frontend/js/components/branches/BranchesPage.jsx
@@ -203,7 +203,7 @@ class BranchesPage extends React.Component {
                             this.props.router.push("/workbench", null, null);
                         }}
 
-                        onTextUnitNameClick={(branchStatistic, tmTextUnitId) => {
+                        onTextUnitNameClick={(branchStatistic, tmTextUnitId, stringId) => {
 
                             let repoIds = [branchStatistic.branch.repository.id];
 
@@ -211,6 +211,9 @@ class BranchesPage extends React.Component {
                                 "changedParam": SearchConstants.UPDATE_ALL,
                                 "repoIds": repoIds,
                                 "tmTextUnitIds": [tmTextUnitId],
+                                "searchText": stringId,
+                                "searchAttribute": SearchParamsStore.SEARCH_ATTRIBUTES.STRING_ID,
+                                "searchType": SearchParamsStore.SEARCH_TYPES.EXACT,
                                 "bcp47Tags": RepositoryStore.getAllBcp47TagsForRepositoryIds(repoIds, true),
                                 "status": SearchParamsStore.STATUS.ALL,
                             }

--- a/webapp/src/main/frontend/js/components/branches/BranchesSearchResults.jsx
+++ b/webapp/src/main/frontend/js/components/branches/BranchesSearchResults.jsx
@@ -435,7 +435,9 @@ class BranchesSearchResults extends React.Component {
                                             this.props.onTextUnitNameClick(
                                                 branchStatistic,
                                                 branchTextUnitStatistic
-                                                    .tmTextUnit.id
+                                                    .tmTextUnit.id,
+                                                branchTextUnitStatistic
+                                                    .tmTextUnit.name
                                             );
                                         }}
                                     >

--- a/webapp/src/main/frontend/js/components/workbench/SearchText.jsx
+++ b/webapp/src/main/frontend/js/components/workbench/SearchText.jsx
@@ -63,7 +63,7 @@ let SearchText = createReactClass({
      * @return {string}
      */
     getInitialSearchAttribute() {
-        return this.props.searchAttribute ? this.props.searchAttribute : SearchParamsStore.SEARCH_ATTRIBUTES.TARGET;
+        return this.props.searchAttribute ? this.props.searchAttribute : SearchParamsStore.getState().searchAttribute;
     },
 
     /**
@@ -72,7 +72,9 @@ let SearchText = createReactClass({
      * @return {string}
      */
     getInitialSearchText() {
-        return this.props.searchText ? this.props.searchText : null;
+        return typeof this.props.searchText !== "undefined"
+            ? this.props.searchText
+            : SearchParamsStore.getState().searchText;
     },
 
     /**
@@ -81,7 +83,7 @@ let SearchText = createReactClass({
      * @return {string}
      */
     getInitialSearchType() {
-        return this.props.searchType ? this.props.searchType : SearchParamsStore.SEARCH_TYPES.CONTAINS;
+        return this.props.searchType ? this.props.searchType : SearchParamsStore.getState().searchType;
     },
 
     onSearchAttributeSelected(searchAttribute) {


### PR DESCRIPTION
## Summary

### Problem (Why)

Navigating from a Branches text-unit link correctly scopes Workbench results through the internal `tmTextUnitId`, but the Workbench search controls continue to show their default state. Users therefore cannot see which string ID produced the result.

### Solution (What + How)

- Pass the displayed string ID alongside the internal text-unit ID when navigating from Branches.
- Populate Workbench's visible `Id` search with the clicked string ID using exact matching while retaining the internal ID for unique result scoping.
- Initialize the Workbench search controls from `SearchParamsStore` so navigation state is visible on first render.

## JIRA Ticket
https://pinterest.atlassian.net/browse/I18N-2127

## Test Plan

- `npm test -- --runInBand` (34 tests passed)
- `npm run build`
- Manually expanded `workbench-filter-repro` in the Demo repository, clicked `from.branch1`, and confirmed Workbench displayed `Id` with `from.branch1` while retaining the expected locale-specific results.

Made with [Cursor](https://cursor.com)