### PR TITLE
I18N-2192 Return posted review comments

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
@@ -912,15 +912,8 @@ public class ExtractionCheckCommand extends Command {
                     .println();
               });
 
-    } catch (GithubException e) {
-      logger.error("Error adding inline review comments: " + e.getMessage(), e);
-      consoleWriter
-          .fg(Ansi.Color.RED)
-          .newLine()
-          .a("Error adding inline review comments: " + e.getMessage())
-          .println();
-    } catch (ExtractionCheckNotificationSenderException e) {
-      logger.error("Error adding inline review comments: " + e.getMessage(), e);
+    } catch (GithubException | ExtractionCheckNotificationSenderException e) {
+      logger.error("Error adding inline review comments: {}", e.getMessage(), e);
       consoleWriter
           .fg(Ansi.Color.RED)
           .newLine()

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithub.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithub.java
@@ -92,8 +92,8 @@ public class ExtractionCheckNotificationSenderGithub extends ExtractionCheckNoti
    * method will only post comments if all required data is available.
    *
    * @param failures the check failures to create review comments for
-   * @return the review comments that were generated (and posted), or an empty list if none were
-   *     generated or required data was missing
+   * @return the review comments that were posted to the pull request, or an empty list if none were
+   *     generated, they were all already present on the pull request, or required data was missing
    */
   public List<GithubClient.ReviewComment> addInlineReviewComments(
       List<CliCheckResult> failures,
@@ -118,12 +118,12 @@ public class ExtractionCheckNotificationSenderGithub extends ExtractionCheckNoti
               prefixToRemoveFromFileUris);
 
       if (!reviewComments.isEmpty()) {
-        githubClients
+        return githubClients
             .getClient(githubOwner)
             .addReviewCommentsToPR(githubRepo, prNumber, reviewComments, commitSha);
       }
 
-      return reviewComments;
+      return List.of();
     } catch (Exception e) {
       throw new ExtractionCheckNotificationSenderException(
           "Failed to add inline review comments to PR", e);

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithubTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithubTest.java
@@ -4,6 +4,7 @@ import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNot
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -17,6 +18,7 @@ import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
 import com.box.l10n.mojito.cli.command.utils.GithubReviewCommentService;
 import com.box.l10n.mojito.github.GithubClient;
 import com.box.l10n.mojito.github.GithubClients;
+import com.box.l10n.mojito.github.GithubException;
 import com.box.l10n.mojito.thirdpartynotification.github.GithubIcon;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -469,7 +471,7 @@ public class ExtractionCheckNotificationSenderGithubTest {
   }
 
   @Test
-  public void testAddInlineReviewCommentsPostsAndReturnsGeneratedComments() {
+  public void testAddInlineReviewCommentsPostsGeneratedCommentsAndReturnsThePostedOnes() {
     setup(true);
     List<CliCheckResult> failures = new ArrayList<>();
     List<AssetExtractionDiff> assetExtractionDiffs = List.of(new AssetExtractionDiff());
@@ -480,6 +482,8 @@ public class ExtractionCheckNotificationSenderGithubTest {
     when(githubReviewCommentServiceMock.generateReviewComments(
             failures, assetExtractionDiffs, githubModifiedLines, "testRepo", "prefix/"))
         .thenReturn(generatedComments);
+    when(githubClientMock.addReviewCommentsToPR(eq("testRepo"), eq(100), any(), eq("123456789")))
+        .thenReturn(generatedComments);
 
     List<GithubClient.ReviewComment> result =
         extractionCheckNotificationSenderGithub.addInlineReviewComments(
@@ -488,10 +492,62 @@ public class ExtractionCheckNotificationSenderGithubTest {
     Assert.assertEquals(generatedComments, result);
     verify(githubClientMock, times(1))
         .addReviewCommentsToPR(
-            org.mockito.ArgumentMatchers.eq("testRepo"),
-            org.mockito.ArgumentMatchers.eq(100),
-            reviewCommentsCaptor.capture(),
-            org.mockito.ArgumentMatchers.eq("123456789"));
+            eq("testRepo"), eq(100), reviewCommentsCaptor.capture(), eq("123456789"));
+    Assert.assertEquals(generatedComments, reviewCommentsCaptor.getValue());
+  }
+
+  @Test
+  public void testAddInlineReviewCommentsReturnsOnlyTheCommentsThatWereNotSkippedAsDuplicates() {
+    setup(true);
+    List<CliCheckResult> failures = new ArrayList<>();
+    List<AssetExtractionDiff> assetExtractionDiffs = List.of(new AssetExtractionDiff());
+    Map<String, Set<Integer>> githubModifiedLines = Map.of("file.py", Set.of(10, 20));
+    GithubClient.ReviewComment alreadyPosted =
+        new GithubClient.ReviewComment("Already on the PR", "file.py", 10);
+    GithubClient.ReviewComment newComment =
+        new GithubClient.ReviewComment("New finding", "file.py", 20);
+    List<GithubClient.ReviewComment> generatedComments = List.of(alreadyPosted, newComment);
+
+    when(githubReviewCommentServiceMock.generateReviewComments(
+            failures, assetExtractionDiffs, githubModifiedLines, "testRepo", ""))
+        .thenReturn(generatedComments);
+    when(githubClientMock.addReviewCommentsToPR(anyString(), anyInt(), any(), anyString()))
+        .thenReturn(List.of(newComment));
+
+    List<GithubClient.ReviewComment> result =
+        extractionCheckNotificationSenderGithub.addInlineReviewComments(
+            failures, assetExtractionDiffs, githubModifiedLines, "");
+
+    Assert.assertEquals(List.of(newComment), result);
+    verify(githubClientMock, times(1))
+        .addReviewCommentsToPR(
+            eq("testRepo"), eq(100), reviewCommentsCaptor.capture(), eq("123456789"));
+    Assert.assertEquals(generatedComments, reviewCommentsCaptor.getValue());
+  }
+
+  @Test
+  public void testAddInlineReviewCommentsReturnsEmptyListWhenAllCommentsAreAlreadyOnThePR() {
+    setup(true);
+    List<CliCheckResult> failures = new ArrayList<>();
+    List<AssetExtractionDiff> assetExtractionDiffs = List.of(new AssetExtractionDiff());
+    Map<String, Set<Integer>> githubModifiedLines = Map.of("file.py", Set.of(10));
+    List<GithubClient.ReviewComment> generatedComments =
+        List.of(new GithubClient.ReviewComment("Already on the PR", "file.py", 10));
+
+    when(githubReviewCommentServiceMock.generateReviewComments(
+            failures, assetExtractionDiffs, githubModifiedLines, "testRepo", ""))
+        .thenReturn(generatedComments);
+    when(githubClientMock.addReviewCommentsToPR(anyString(), anyInt(), any(), anyString()))
+        .thenReturn(List.of());
+
+    List<GithubClient.ReviewComment> result =
+        extractionCheckNotificationSenderGithub.addInlineReviewComments(
+            failures, assetExtractionDiffs, githubModifiedLines, "");
+
+    Assert.assertTrue(result.isEmpty());
+    verify(githubClientMock, times(1))
+        .addReviewCommentsToPR(
+            eq("testRepo"), eq(100), reviewCommentsCaptor.capture(), eq("123456789"));
     Assert.assertEquals(generatedComments, reviewCommentsCaptor.getValue());
   }
 
@@ -525,6 +581,23 @@ public class ExtractionCheckNotificationSenderGithubTest {
     when(githubReviewCommentServiceMock.generateReviewComments(
             any(), any(), any(), anyString(), any()))
         .thenThrow(new RuntimeException("Something went wrong"));
+
+    extractionCheckNotificationSenderGithub.addInlineReviewComments(
+        failures, assetExtractionDiffs, githubModifiedLines, "");
+  }
+
+  @Test(expected = ExtractionCheckNotificationSenderException.class)
+  public void testAddInlineReviewCommentsThrowsWhenPostingToTheClientFails() {
+    setup(true);
+    List<CliCheckResult> failures = new ArrayList<>();
+    List<AssetExtractionDiff> assetExtractionDiffs = List.of(new AssetExtractionDiff());
+    Map<String, Set<Integer>> githubModifiedLines = Map.of("file.py", Set.of(10));
+
+    when(githubReviewCommentServiceMock.generateReviewComments(
+            any(), any(), any(), anyString(), any()))
+        .thenReturn(List.of(new GithubClient.ReviewComment("Some comment body", "file.py", 10)));
+    when(githubClientMock.addReviewCommentsToPR(anyString(), anyInt(), any(), anyString()))
+        .thenThrow(new GithubException("Error adding review comments to PR"));
 
     extractionCheckNotificationSenderGithub.addInlineReviewComments(
         failures, assetExtractionDiffs, githubModifiedLines, "");

--- a/common/src/main/java/com/box/l10n/mojito/github/GithubClient.java
+++ b/common/src/main/java/com/box/l10n/mojito/github/GithubClient.java
@@ -664,18 +664,20 @@ public class GithubClient {
    * @param prNumber The pull request number
    * @param reviewComments List of review comments to post
    * @param commitSha The commit SHA to attach the review to
+   * @return the review comments that were actually posted, ie. the provided comments minus the
+   *     skipped duplicates, in the original order. Empty if there was nothing to post.
    */
-  public void addReviewCommentsToPR(
+  public List<ReviewComment> addReviewCommentsToPR(
       String repository, int prNumber, List<ReviewComment> reviewComments, String commitSha) {
     String repoFullPath = getRepositoryPath(repository);
 
     if (reviewComments == null || reviewComments.isEmpty()) {
       logger.debug(
           "No review comments to post for PR {} in repository '{}'", prNumber, repoFullPath);
-      return;
+      return List.of();
     }
 
-    Mono.fromRunnable(
+    return Mono.fromCallable(
             () -> {
               try {
                 GHPullRequest pullRequest =
@@ -693,7 +695,7 @@ public class GithubClient {
                       reviewComments.size(),
                       prNumber,
                       repoFullPath);
-                  return;
+                  return List.<ReviewComment>of();
                 }
 
                 // Create a review with comments. The event must be set: leaving it blank creates
@@ -719,6 +721,8 @@ public class GithubClient {
                     commentsToPost.size(),
                     prNumber,
                     repoFullPath);
+
+                return List.copyOf(commentsToPost);
 
               } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
                 String message =

--- a/common/src/test/java/com/box/l10n/mojito/github/GithubClientTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/github/GithubClientTest.java
@@ -360,16 +360,20 @@ public class GithubClientTest {
 
   @Test
   public void testAddReviewCommentsToPRWithNullComments() throws IOException {
-    githubClient.addReviewCommentsToPR("testRepo", 1, null, "commitSha");
+    List<GithubClient.ReviewComment> postedComments =
+        githubClient.addReviewCommentsToPR("testRepo", 1, null, "commitSha");
 
+    assertTrue(postedComments.isEmpty());
     verify(gitHubMock, never()).getRepository(anyString());
     verify(ghPullRequestMock, never()).createReview();
   }
 
   @Test
   public void testAddReviewCommentsToPRWithEmptyComments() throws IOException {
-    githubClient.addReviewCommentsToPR("testRepo", 1, List.of(), "commitSha");
+    List<GithubClient.ReviewComment> postedComments =
+        githubClient.addReviewCommentsToPR("testRepo", 1, List.of(), "commitSha");
 
+    assertTrue(postedComments.isEmpty());
     verify(gitHubMock, never()).getRepository(anyString());
     verify(ghPullRequestMock, never()).createReview();
   }
@@ -537,6 +541,55 @@ public class GithubClientTest {
     verify(ghPullRequestMock, never()).createReview();
     verify(ghPullRequestReviewBuilderMock, never()).create();
     verify(counterMock, times(1)).increment(2);
+  }
+
+  @Test
+  public void testAddReviewCommentsToPRReturnsThePostedComments() throws IOException {
+    stubReviewBuilder();
+    GithubClient.ReviewComment comment1 =
+        new GithubClient.ReviewComment("Comment 1", "src/main/strings.xml", 10);
+    GithubClient.ReviewComment comment2 =
+        new GithubClient.ReviewComment("Comment 2", "src/main/other.xml", 20);
+
+    List<GithubClient.ReviewComment> postedComments =
+        githubClient.addReviewCommentsToPR("testRepo", 1, List.of(comment1, comment2), "commitSha");
+
+    assertEquals(List.of(comment1, comment2), postedComments);
+  }
+
+  @Test
+  public void testAddReviewCommentsToPRReturnsOnlyTheCommentsThatWereNotSkipped()
+      throws IOException {
+    stubReviewBuilder();
+    stubExistingReviewComments(
+        List.of(stubExistingReviewComment("Placeholder issue", "src/main/strings.xml", 42, 42)));
+    GithubClient.ReviewComment alreadyPosted =
+        new GithubClient.ReviewComment("Placeholder issue", "src/main/strings.xml", 42);
+    GithubClient.ReviewComment newComment =
+        new GithubClient.ReviewComment("Another issue", "src/main/strings.xml", 42);
+
+    List<GithubClient.ReviewComment> postedComments =
+        githubClient.addReviewCommentsToPR(
+            "testRepo", 1, List.of(alreadyPosted, newComment), "commitSha");
+
+    assertEquals(List.of(newComment), postedComments);
+  }
+
+  @Test
+  public void testAddReviewCommentsToPRReturnsNoCommentsWhenAllCommentsAlreadyExist()
+      throws IOException {
+    stubReviewBuilder();
+    stubExistingReviewComments(
+        List.of(stubExistingReviewComment("Comment 1", "src/main/strings.xml", 10, 10)));
+
+    List<GithubClient.ReviewComment> postedComments =
+        githubClient.addReviewCommentsToPR(
+            "testRepo",
+            1,
+            List.of(new GithubClient.ReviewComment("Comment 1", "src/main/strings.xml", 10)),
+            "commitSha");
+
+    assertTrue(postedComments.isEmpty());
   }
 
   private void stubExistingReviewComments(List<GHPullRequestReviewComment> existingComments)


### PR DESCRIPTION
## Summary

Follow-up to #495 (inline GitHub PR review comments for source string check failures).

The count reported by `extraction-check` was wrong on re-runs. `GithubClient.addReviewCommentsToPR` skips comments that are already present on the PR (same body, file and line) so that re-running the checks doesn't duplicate them, but it returned `void`, so `ExtractionCheckNotificationSenderGithub.addInlineReviewComments` returned the *generated* comments instead. A re-run on an unchanged PR posted nothing and still printed `N inline review comments added`.

This threads the real result back to the caller: `addReviewCommentsToPR` now returns the comments it actually posted, and the sender returns that list instead of the generated one.

## Changes

- `GithubClient.addReviewCommentsToPR` returns `List<ReviewComment>` — the provided comments minus the duplicates that were skipped, in the original order. `Mono.fromRunnable` becomes `Mono.fromCallable`; the empty/null input and all-duplicates paths return `List.of()`.
- `ExtractionCheckNotificationSenderGithub.addInlineReviewComments` returns the client's result, so the console message in `ExtractionCheckCommand` reflects what was posted rather than what was generated. Javadoc updated on both methods.
- 
## Behaviour

No change to what gets posted on GitHub — only to what the caller is told was posted. The review is still submitted as a `COMMENT` event, and duplicate sup`Mojito.GitHubClient.DuplicatedReviewCommentsSkipped` metric are unchanged.